### PR TITLE
test coverage

### DIFF
--- a/json5/parse_test.mbt
+++ b/json5/parse_test.mbt
@@ -202,6 +202,19 @@ test "parses leading zeroes" {
   )?
 }
 
+test "pattern" {
+  let json_data = 
+    #| [0,1,2,{"a":3,"b":4},[5,6,7],8,9] 
+    #|  
+  let json = test_parse(json_data)?
+  match json {
+    Array ([_,_,_, Object({"a": data})]) => @assertion.assert_eq(data, Some(Number(3.0)))?
+      // inspect(data,)?
+    _ => panic()
+  }  
+  
+}
+
 test "parses integers" {
   let json = test_parse("[1,23,456,7890]")?
   @assertion.assert_eq(


### PR DESCRIPTION
moon test crashed
```
git/x$RUST_BACKTRACE=full moon test
thread 'main' panicked at src/main.rs:159:57:
called `Option::unwrap()` on a `None` value
stack backtrace:
   0:        0x102987d58 - __mh_execute_header
   1:        0x102954188 - __mh_execute_header
   2:        0x102988da8 - __mh_execute_header
   3:        0x102988ad0 - __mh_execute_header
   4:        0x1029894a4 - __mh_execute_header
   5:        0x102988f9c - __mh_execute_header
   6:        0x102988f2c - __mh_execute_header
   7:        0x102988f20 - __mh_execute_header
   8:        0x103be4720 - __mh_execute_header
   9:        0x103be4848 - __mh_execute_header
  10:        0x103be4a28 - __mh_execute_header
  11:        0x10290cacc - __mh_execute_header
  12:        0x10295ce28 - __mh_execute_header
  13:        0x10290dd34 - __mh_execute_header
Error when running /Users/hongbozhang/git/x/target/wasm-gc/debug/test/json5/json5.underscore_test.wasm: Failed to run the test
Total tests: 173, passed: 173, failed: 0.
```