### PR TITLE
refactor: better impl for sm3 bytes api; code cleanup

### DIFF
--- a/crypto/crypto.mbti
+++ b/crypto/crypto.mbti
@@ -17,7 +17,7 @@ fn sm3(Bytes) -> Bytes
 
 fn sm3_from_iter(Iter[Byte]) -> Bytes
 
-fn uints_to_hex_string(Array[UInt]) -> String
+fn uints_to_hex_string(FixedArray[UInt]) -> String
 
 // Types and methods
 type MD5Context

--- a/crypto/crypto.mbti
+++ b/crypto/crypto.mbti
@@ -17,7 +17,7 @@ fn sm3(Bytes) -> Bytes
 
 fn sm3_from_iter(Iter[Byte]) -> Bytes
 
-fn uints_to_hex_string(FixedArray[UInt]) -> String
+fn uints_to_hex_string(Iter[UInt]) -> String
 
 // Types and methods
 type MD5Context

--- a/crypto/md5.mbt
+++ b/crypto/md5.mbt
@@ -127,148 +127,90 @@ fn md5_update(ctx : MD5Context, data : Bytes) -> Unit {
 }
 
 fn md5_transform(state : FixedArray[UInt], input : FixedArray[UInt]) -> Unit {
-  let a = Ref::new(state[0])
-  let b = Ref::new(state[1])
-  let c = Ref::new(state[2])
-  let d = Ref::new(state[3])
-  fn t_f(
-    state_a : Ref[UInt],
-    state_b : Ref[UInt],
-    state_c : Ref[UInt],
-    state_d : Ref[UInt],
-    k : Int,
-    s : Int, // calculate w/ floor(2^32 * |sin(i + 1)|) for i in 0..63
-    ac : UInt
-  ) -> Unit {
-    state_a.val = state_b.val + urotate_left(
-        state_a.val + f(state_b.val, state_c.val, state_d.val) + input[k] + ac,
-        s,
-      )
-  }
+  let mut a = state[0]
+  let mut b = state[1]
+  let mut c = state[2]
+  let mut d = state[3]
 
-  fn t_g(
-    state_a : Ref[UInt],
-    state_b : Ref[UInt],
-    state_c : Ref[UInt],
-    state_d : Ref[UInt],
-    k : Int,
-    s : Int, // calculate w/ floor(2^32 * |sin(i + 1)|) for i in 0..63
-    ac : UInt
-  ) -> Unit {
-    state_a.val = state_b.val + urotate_left(
-        state_a.val + g(state_b.val, state_c.val, state_d.val) + input[k] + ac,
-        s,
-      )
-  }
-
-  fn t_h(
-    state_a : Ref[UInt],
-    state_b : Ref[UInt],
-    state_c : Ref[UInt],
-    state_d : Ref[UInt],
-    k : Int,
-    s : Int, // calculate w/ floor(2^32 * |sin(i + 1)|) for i in 0..63
-    ac : UInt
-  ) -> Unit {
-    state_a.val = state_b.val + urotate_left(
-        state_a.val + h(state_b.val, state_c.val, state_d.val) + input[k] + ac,
-        s,
-      )
-  }
-
-  fn t_i(
-    state_a : Ref[UInt],
-    state_b : Ref[UInt],
-    state_c : Ref[UInt],
-    state_d : Ref[UInt],
-    k : Int,
-    s : Int, // calculate w/ floor(2^32 * |sin(i + 1)|) for i in 0..63
-    ac : UInt
-  ) -> Unit {
-    state_a.val = state_b.val + urotate_left(
-        state_a.val + i(state_b.val, state_c.val, state_d.val) + input[k] + ac,
-        s,
-      )
-  }
   // Round 1
   // s[ 0..15] := { 7, 12, 17, 22,  7, 12, 17, 22,  7, 12, 17, 22,  7, 12, 17, 22 }
-  t_f(a, b, c, d, 0, 7, 0xd76aa478)
-  t_f(d, a, b, c, 1, 12, 0xe8c7b756)
-  t_f(c, d, a, b, 2, 17, 0x242070db)
-  t_f(b, c, d, a, 3, 22, 0xc1bdceee)
-  t_f(a, b, c, d, 4, 7, 0xf57c0faf)
-  t_f(d, a, b, c, 5, 12, 0x4787c62a)
-  t_f(c, d, a, b, 6, 17, 0xa8304613)
-  t_f(b, c, d, a, 7, 22, 0xfd469501)
-  t_f(a, b, c, d, 8, 7, 0x698098d8)
-  t_f(d, a, b, c, 9, 12, 0x8b44f7af)
-  t_f(c, d, a, b, 10, 17, 0xffff5bb1)
-  t_f(b, c, d, a, 11, 22, 0x895cd7be)
-  t_f(a, b, c, d, 12, 7, 0x6b901122)
-  t_f(d, a, b, c, 13, 12, 0xfd987193)
-  t_f(c, d, a, b, 14, 17, 0xa679438e)
-  t_f(b, c, d, a, 15, 22, 0x49b40821)
+  a = b + rotate_left_u(a + f(b, c, d) + input[0] + 0xd76aa478, 7)
+  d = a + rotate_left_u(d + f(a, b, c) + input[1] + 0xe8c7b756, 12)
+  c = d + rotate_left_u(c + f(d, a, b) + input[2] + 0x242070db, 17)
+  b = c + rotate_left_u(b + f(c, d, a) + input[3] + 0xc1bdceee, 22)
+  a = b + rotate_left_u(a + f(b, c, d) + input[4] + 0xf57c0faf, 7)
+  d = a + rotate_left_u(d + f(a, b, c) + input[5] + 0x4787c62a, 12)
+  c = d + rotate_left_u(c + f(d, a, b) + input[6] + 0xa8304613, 17)
+  b = c + rotate_left_u(b + f(c, d, a) + input[7] + 0xfd469501, 22)
+  a = b + rotate_left_u(a + f(b, c, d) + input[8] + 0x698098d8, 7)
+  d = a + rotate_left_u(d + f(a, b, c) + input[9] + 0x8b44f7af, 12)
+  c = d + rotate_left_u(c + f(d, a, b) + input[10] + 0xffff5bb1, 17)
+  b = c + rotate_left_u(b + f(c, d, a) + input[11] + 0x895cd7be, 22)
+  a = b + rotate_left_u(a + f(b, c, d) + input[12] + 0x6b901122, 7)
+  d = a + rotate_left_u(d + f(a, b, c) + input[13] + 0xfd987193, 12)
+  c = d + rotate_left_u(c + f(d, a, b) + input[14] + 0xa679438e, 17)
+  b = c + rotate_left_u(b + f(c, d, a) + input[15] + 0x49b40821, 22)
 
   // Round 2
   // s[16..31] := { 5,  9, 14, 20,  5,  9, 14, 20,  5,  9, 14, 20,  5,  9, 14, 20 }
-  t_g(a, b, c, d, 1, 5, 0xf61e2562)
-  t_g(d, a, b, c, 6, 9, 0xc040b340)
-  t_g(c, d, a, b, 11, 14, 0x265e5a51)
-  t_g(b, c, d, a, 0, 20, 0xe9b6c7aa)
-  t_g(a, b, c, d, 5, 5, 0xd62f105d)
-  t_g(d, a, b, c, 10, 9, 0x02441453)
-  t_g(c, d, a, b, 15, 14, 0xd8a1e681)
-  t_g(b, c, d, a, 4, 20, 0xe7d3fbc8)
-  t_g(a, b, c, d, 9, 5, 0x21e1cde6)
-  t_g(d, a, b, c, 14, 9, 0xc33707d6)
-  t_g(c, d, a, b, 3, 14, 0xf4d50d87)
-  t_g(b, c, d, a, 8, 20, 0x455a14ed)
-  t_g(a, b, c, d, 13, 5, 0xa9e3e905)
-  t_g(d, a, b, c, 2, 9, 0xfcefa3f8)
-  t_g(c, d, a, b, 7, 14, 0x676f02d9)
-  t_g(b, c, d, a, 12, 20, 0x8d2a4c8a)
+  a = b + rotate_left_u(a + g(b, c, d) + input[1] + 0xf61e2562, 5)
+  d = a + rotate_left_u(d + g(a, b, c) + input[6] + 0xc040b340, 9)
+  c = d + rotate_left_u(c + g(d, a, b) + input[11] + 0x265e5a51, 14)
+  b = c + rotate_left_u(b + g(c, d, a) + input[0] + 0xe9b6c7aa, 20)
+  a = b + rotate_left_u(a + g(b, c, d) + input[5] + 0xd62f105d, 5)
+  d = a + rotate_left_u(d + g(a, b, c) + input[10] + 0x02441453, 9)
+  c = d + rotate_left_u(c + g(d, a, b) + input[15] + 0xd8a1e681, 14)
+  b = c + rotate_left_u(b + g(c, d, a) + input[4] + 0xe7d3fbc8, 20)
+  a = b + rotate_left_u(a + g(b, c, d) + input[9] + 0x21e1cde6, 5)
+  d = a + rotate_left_u(d + g(a, b, c) + input[14] + 0xc33707d6, 9)
+  c = d + rotate_left_u(c + g(d, a, b) + input[3] + 0xf4d50d87, 14)
+  b = c + rotate_left_u(b + g(c, d, a) + input[8] + 0x455a14ed, 20)
+  a = b + rotate_left_u(a + g(b, c, d) + input[13] + 0xa9e3e905, 5)
+  d = a + rotate_left_u(d + g(a, b, c) + input[2] + 0xfcefa3f8, 9)
+  c = d + rotate_left_u(c + g(d, a, b) + input[7] + 0x676f02d9, 14)
+  b = c + rotate_left_u(b + g(c, d, a) + input[12] + 0x8d2a4c8a, 20)
 
   // Round 3
   // s[32..47] := { 4, 11, 16, 23,  4, 11, 16, 23,  4, 11, 16, 23,  4, 11, 16, 23 }
-  t_h(a, b, c, d, 5, 4, 0xfffa3942)
-  t_h(d, a, b, c, 8, 11, 0x8771f681)
-  t_h(c, d, a, b, 11, 16, 0x6d9d6122)
-  t_h(b, c, d, a, 14, 23, 0xfde5380c)
-  t_h(a, b, c, d, 1, 4, 0xa4beea44)
-  t_h(d, a, b, c, 4, 11, 0x4bdecfa9)
-  t_h(c, d, a, b, 7, 16, 0xf6bb4b60)
-  t_h(b, c, d, a, 10, 23, 0xbebfbc70)
-  t_h(a, b, c, d, 13, 4, 0x289b7ec6)
-  t_h(d, a, b, c, 0, 11, 0xeaa127fa)
-  t_h(c, d, a, b, 3, 16, 0xd4ef3085)
-  t_h(b, c, d, a, 6, 23, 0x04881d05)
-  t_h(a, b, c, d, 9, 4, 0xd9d4d039)
-  t_h(d, a, b, c, 12, 11, 0xe6db99e5)
-  t_h(c, d, a, b, 15, 16, 0x1fa27cf8)
-  t_h(b, c, d, a, 2, 23, 0xc4ac5665)
+  a = b + rotate_left_u(a + h(b, c, d) + input[5] + 0xfffa3942, 4)
+  d = a + rotate_left_u(d + h(a, b, c) + input[8] + 0x8771f681, 11)
+  c = d + rotate_left_u(c + h(d, a, b) + input[11] + 0x6d9d6122, 16)
+  b = c + rotate_left_u(b + h(c, d, a) + input[14] + 0xfde5380c, 23)
+  a = b + rotate_left_u(a + h(b, c, d) + input[1] + 0xa4beea44, 4)
+  d = a + rotate_left_u(d + h(a, b, c) + input[4] + 0x4bdecfa9, 11)
+  c = d + rotate_left_u(c + h(d, a, b) + input[7] + 0xf6bb4b60, 16)
+  b = c + rotate_left_u(b + h(c, d, a) + input[10] + 0xbebfbc70, 23)
+  a = b + rotate_left_u(a + h(b, c, d) + input[13] + 0x289b7ec6, 4)
+  d = a + rotate_left_u(d + h(a, b, c) + input[0] + 0xeaa127fa, 11)
+  c = d + rotate_left_u(c + h(d, a, b) + input[3] + 0xd4ef3085, 16)
+  b = c + rotate_left_u(b + h(c, d, a) + input[6] + 0x04881d05, 23)
+  a = b + rotate_left_u(a + h(b, c, d) + input[9] + 0xd9d4d039, 4)
+  d = a + rotate_left_u(d + h(a, b, c) + input[12] + 0xe6db99e5, 11)
+  c = d + rotate_left_u(c + h(d, a, b) + input[15] + 0x1fa27cf8, 16)
+  b = c + rotate_left_u(b + h(c, d, a) + input[2] + 0xc4ac5665, 23)
 
   // Round 4
   // s[48..63] := { 6, 10, 15, 21,  6, 10, 15, 21,  6, 10, 15, 21,  6, 10, 15, 21 }
-  t_i(a, b, c, d, 0, 6, 0xf4292244)
-  t_i(d, a, b, c, 7, 10, 0x432aff97)
-  t_i(c, d, a, b, 14, 15, 0xab9423a7)
-  t_i(b, c, d, a, 5, 21, 0xfc93a039)
-  t_i(a, b, c, d, 12, 6, 0x655b59c3)
-  t_i(d, a, b, c, 3, 10, 0x8f0ccc92)
-  t_i(c, d, a, b, 10, 15, 0xffeff47d)
-  t_i(b, c, d, a, 1, 21, 0x85845dd1)
-  t_i(a, b, c, d, 8, 6, 0x6fa87e4f)
-  t_i(d, a, b, c, 15, 10, 0xfe2ce6e0)
-  t_i(c, d, a, b, 6, 15, 0xa3014314)
-  t_i(b, c, d, a, 13, 21, 0x4e0811a1)
-  t_i(a, b, c, d, 4, 6, 0xf7537e82)
-  t_i(d, a, b, c, 11, 10, 0xbd3af235)
-  t_i(c, d, a, b, 2, 15, 0x2ad7d2bb)
-  t_i(b, c, d, a, 9, 21, 0xeb86d391)
-  state[0] += a.val
-  state[1] += b.val
-  state[2] += c.val
-  state[3] += d.val
+  a = b + rotate_left_u(a + i(b, c, d) + input[0] + 0xf4292244, 6)
+  d = a + rotate_left_u(d + i(a, b, c) + input[7] + 0x432aff97, 10)
+  c = d + rotate_left_u(c + i(d, a, b) + input[14] + 0xab9423a7, 15)
+  b = c + rotate_left_u(b + i(c, d, a) + input[5] + 0xfc93a039, 21)
+  a = b + rotate_left_u(a + i(b, c, d) + input[12] + 0x655b59c3, 6)
+  d = a + rotate_left_u(d + i(a, b, c) + input[3] + 0x8f0ccc92, 10)
+  c = d + rotate_left_u(c + i(d, a, b) + input[10] + 0xffeff47d, 15)
+  b = c + rotate_left_u(b + i(c, d, a) + input[1] + 0x85845dd1, 21)
+  a = b + rotate_left_u(a + i(b, c, d) + input[8] + 0x6fa87e4f, 6)
+  d = a + rotate_left_u(d + i(a, b, c) + input[15] + 0xfe2ce6e0, 10)
+  c = d + rotate_left_u(c + i(d, a, b) + input[6] + 0xa3014314, 15)
+  b = c + rotate_left_u(b + i(c, d, a) + input[13] + 0x4e0811a1, 21)
+  a = b + rotate_left_u(a + i(b, c, d) + input[4] + 0xf7537e82, 6)
+  d = a + rotate_left_u(d + i(a, b, c) + input[11] + 0xbd3af235, 10)
+  c = d + rotate_left_u(c + i(d, a, b) + input[2] + 0x2ad7d2bb, 15)
+  b = c + rotate_left_u(b + i(c, d, a) + input[9] + 0xeb86d391, 21)
+  state[0] += a
+  state[1] += b
+  state[2] += c
+  state[3] += d
 }
 
 /// Compute the MD5 digest of some `data` based on [RFC1321](https://www.ietf.org/rfc/rfc1321.txt).

--- a/crypto/md5.mbt
+++ b/crypto/md5.mbt
@@ -131,8 +131,7 @@ fn md5_transform(state : FixedArray[UInt], input : FixedArray[UInt]) -> Unit {
   let b = Ref::new(state[1])
   let c = Ref::new(state[2])
   let d = Ref::new(state[3])
-  fn t(
-    op : (UInt, UInt, UInt) -> UInt,
+  fn t_f(
     state_a : Ref[UInt],
     state_b : Ref[UInt],
     state_c : Ref[UInt],
@@ -142,86 +141,130 @@ fn md5_transform(state : FixedArray[UInt], input : FixedArray[UInt]) -> Unit {
     ac : UInt
   ) -> Unit {
     state_a.val = state_b.val + urotate_left(
-        state_a.val + op(state_b.val, state_c.val, state_d.val) + input[k] + ac,
+        state_a.val + f(state_b.val, state_c.val, state_d.val) + input[k] + ac,
         s,
       )
   }
 
+  fn t_g(
+    state_a : Ref[UInt],
+    state_b : Ref[UInt],
+    state_c : Ref[UInt],
+    state_d : Ref[UInt],
+    k : Int,
+    s : Int, // calculate w/ floor(2^32 * |sin(i + 1)|) for i in 0..63
+    ac : UInt
+  ) -> Unit {
+    state_a.val = state_b.val + urotate_left(
+        state_a.val + g(state_b.val, state_c.val, state_d.val) + input[k] + ac,
+        s,
+      )
+  }
+
+  fn t_h(
+    state_a : Ref[UInt],
+    state_b : Ref[UInt],
+    state_c : Ref[UInt],
+    state_d : Ref[UInt],
+    k : Int,
+    s : Int, // calculate w/ floor(2^32 * |sin(i + 1)|) for i in 0..63
+    ac : UInt
+  ) -> Unit {
+    state_a.val = state_b.val + urotate_left(
+        state_a.val + h(state_b.val, state_c.val, state_d.val) + input[k] + ac,
+        s,
+      )
+  }
+
+  fn t_i(
+    state_a : Ref[UInt],
+    state_b : Ref[UInt],
+    state_c : Ref[UInt],
+    state_d : Ref[UInt],
+    k : Int,
+    s : Int, // calculate w/ floor(2^32 * |sin(i + 1)|) for i in 0..63
+    ac : UInt
+  ) -> Unit {
+    state_a.val = state_b.val + urotate_left(
+        state_a.val + i(state_b.val, state_c.val, state_d.val) + input[k] + ac,
+        s,
+      )
+  }
   // Round 1
   // s[ 0..15] := { 7, 12, 17, 22,  7, 12, 17, 22,  7, 12, 17, 22,  7, 12, 17, 22 }
-  t(f, a, b, c, d, 0, 7, 0xd76aa478)
-  t(f, d, a, b, c, 1, 12, 0xe8c7b756)
-  t(f, c, d, a, b, 2, 17, 0x242070db)
-  t(f, b, c, d, a, 3, 22, 0xc1bdceee)
-  t(f, a, b, c, d, 4, 7, 0xf57c0faf)
-  t(f, d, a, b, c, 5, 12, 0x4787c62a)
-  t(f, c, d, a, b, 6, 17, 0xa8304613)
-  t(f, b, c, d, a, 7, 22, 0xfd469501)
-  t(f, a, b, c, d, 8, 7, 0x698098d8)
-  t(f, d, a, b, c, 9, 12, 0x8b44f7af)
-  t(f, c, d, a, b, 10, 17, 0xffff5bb1)
-  t(f, b, c, d, a, 11, 22, 0x895cd7be)
-  t(f, a, b, c, d, 12, 7, 0x6b901122)
-  t(f, d, a, b, c, 13, 12, 0xfd987193)
-  t(f, c, d, a, b, 14, 17, 0xa679438e)
-  t(f, b, c, d, a, 15, 22, 0x49b40821)
+  t_f(a, b, c, d, 0, 7, 0xd76aa478)
+  t_f(d, a, b, c, 1, 12, 0xe8c7b756)
+  t_f(c, d, a, b, 2, 17, 0x242070db)
+  t_f(b, c, d, a, 3, 22, 0xc1bdceee)
+  t_f(a, b, c, d, 4, 7, 0xf57c0faf)
+  t_f(d, a, b, c, 5, 12, 0x4787c62a)
+  t_f(c, d, a, b, 6, 17, 0xa8304613)
+  t_f(b, c, d, a, 7, 22, 0xfd469501)
+  t_f(a, b, c, d, 8, 7, 0x698098d8)
+  t_f(d, a, b, c, 9, 12, 0x8b44f7af)
+  t_f(c, d, a, b, 10, 17, 0xffff5bb1)
+  t_f(b, c, d, a, 11, 22, 0x895cd7be)
+  t_f(a, b, c, d, 12, 7, 0x6b901122)
+  t_f(d, a, b, c, 13, 12, 0xfd987193)
+  t_f(c, d, a, b, 14, 17, 0xa679438e)
+  t_f(b, c, d, a, 15, 22, 0x49b40821)
 
   // Round 2
   // s[16..31] := { 5,  9, 14, 20,  5,  9, 14, 20,  5,  9, 14, 20,  5,  9, 14, 20 }
-  t(g, a, b, c, d, 1, 5, 0xf61e2562)
-  t(g, d, a, b, c, 6, 9, 0xc040b340)
-  t(g, c, d, a, b, 11, 14, 0x265e5a51)
-  t(g, b, c, d, a, 0, 20, 0xe9b6c7aa)
-  t(g, a, b, c, d, 5, 5, 0xd62f105d)
-  t(g, d, a, b, c, 10, 9, 0x02441453)
-  t(g, c, d, a, b, 15, 14, 0xd8a1e681)
-  t(g, b, c, d, a, 4, 20, 0xe7d3fbc8)
-  t(g, a, b, c, d, 9, 5, 0x21e1cde6)
-  t(g, d, a, b, c, 14, 9, 0xc33707d6)
-  t(g, c, d, a, b, 3, 14, 0xf4d50d87)
-  t(g, b, c, d, a, 8, 20, 0x455a14ed)
-  t(g, a, b, c, d, 13, 5, 0xa9e3e905)
-  t(g, d, a, b, c, 2, 9, 0xfcefa3f8)
-  t(g, c, d, a, b, 7, 14, 0x676f02d9)
-  t(g, b, c, d, a, 12, 20, 0x8d2a4c8a)
+  t_g(a, b, c, d, 1, 5, 0xf61e2562)
+  t_g(d, a, b, c, 6, 9, 0xc040b340)
+  t_g(c, d, a, b, 11, 14, 0x265e5a51)
+  t_g(b, c, d, a, 0, 20, 0xe9b6c7aa)
+  t_g(a, b, c, d, 5, 5, 0xd62f105d)
+  t_g(d, a, b, c, 10, 9, 0x02441453)
+  t_g(c, d, a, b, 15, 14, 0xd8a1e681)
+  t_g(b, c, d, a, 4, 20, 0xe7d3fbc8)
+  t_g(a, b, c, d, 9, 5, 0x21e1cde6)
+  t_g(d, a, b, c, 14, 9, 0xc33707d6)
+  t_g(c, d, a, b, 3, 14, 0xf4d50d87)
+  t_g(b, c, d, a, 8, 20, 0x455a14ed)
+  t_g(a, b, c, d, 13, 5, 0xa9e3e905)
+  t_g(d, a, b, c, 2, 9, 0xfcefa3f8)
+  t_g(c, d, a, b, 7, 14, 0x676f02d9)
+  t_g(b, c, d, a, 12, 20, 0x8d2a4c8a)
 
   // Round 3
   // s[32..47] := { 4, 11, 16, 23,  4, 11, 16, 23,  4, 11, 16, 23,  4, 11, 16, 23 }
-  t(h, a, b, c, d, 5, 4, 0xfffa3942)
-  t(h, d, a, b, c, 8, 11, 0x8771f681)
-  t(h, c, d, a, b, 11, 16, 0x6d9d6122)
-  t(h, b, c, d, a, 14, 23, 0xfde5380c)
-  t(h, a, b, c, d, 1, 4, 0xa4beea44)
-  t(h, d, a, b, c, 4, 11, 0x4bdecfa9)
-  t(h, c, d, a, b, 7, 16, 0xf6bb4b60)
-  t(h, b, c, d, a, 10, 23, 0xbebfbc70)
-  t(h, a, b, c, d, 13, 4, 0x289b7ec6)
-  t(h, d, a, b, c, 0, 11, 0xeaa127fa)
-  t(h, c, d, a, b, 3, 16, 0xd4ef3085)
-  t(h, b, c, d, a, 6, 23, 0x04881d05)
-  t(h, a, b, c, d, 9, 4, 0xd9d4d039)
-  t(h, d, a, b, c, 12, 11, 0xe6db99e5)
-  t(h, c, d, a, b, 15, 16, 0x1fa27cf8)
-  t(h, b, c, d, a, 2, 23, 0xc4ac5665)
+  t_h(a, b, c, d, 5, 4, 0xfffa3942)
+  t_h(d, a, b, c, 8, 11, 0x8771f681)
+  t_h(c, d, a, b, 11, 16, 0x6d9d6122)
+  t_h(b, c, d, a, 14, 23, 0xfde5380c)
+  t_h(a, b, c, d, 1, 4, 0xa4beea44)
+  t_h(d, a, b, c, 4, 11, 0x4bdecfa9)
+  t_h(c, d, a, b, 7, 16, 0xf6bb4b60)
+  t_h(b, c, d, a, 10, 23, 0xbebfbc70)
+  t_h(a, b, c, d, 13, 4, 0x289b7ec6)
+  t_h(d, a, b, c, 0, 11, 0xeaa127fa)
+  t_h(c, d, a, b, 3, 16, 0xd4ef3085)
+  t_h(b, c, d, a, 6, 23, 0x04881d05)
+  t_h(a, b, c, d, 9, 4, 0xd9d4d039)
+  t_h(d, a, b, c, 12, 11, 0xe6db99e5)
+  t_h(c, d, a, b, 15, 16, 0x1fa27cf8)
+  t_h(b, c, d, a, 2, 23, 0xc4ac5665)
 
   // Round 4
   // s[48..63] := { 6, 10, 15, 21,  6, 10, 15, 21,  6, 10, 15, 21,  6, 10, 15, 21 }
-  t(i, a, b, c, d, 0, 6, 0xf4292244)
-  t(i, d, a, b, c, 7, 10, 0x432aff97)
-  t(i, c, d, a, b, 14, 15, 0xab9423a7)
-  t(i, b, c, d, a, 5, 21, 0xfc93a039)
-  t(i, a, b, c, d, 12, 6, 0x655b59c3)
-  t(i, d, a, b, c, 3, 10, 0x8f0ccc92)
-  t(i, c, d, a, b, 10, 15, 0xffeff47d)
-  t(i, b, c, d, a, 1, 21, 0x85845dd1)
-  t(i, a, b, c, d, 8, 6, 0x6fa87e4f)
-  t(i, d, a, b, c, 15, 10, 0xfe2ce6e0)
-  t(i, c, d, a, b, 6, 15, 0xa3014314)
-  t(i, b, c, d, a, 13, 21, 0x4e0811a1)
-  t(i, a, b, c, d, 4, 6, 0xf7537e82)
-  t(i, d, a, b, c, 11, 10, 0xbd3af235)
-  t(i, c, d, a, b, 2, 15, 0x2ad7d2bb)
-  t(i, b, c, d, a, 9, 21, 0xeb86d391)
+  t_i(a, b, c, d, 0, 6, 0xf4292244)
+  t_i(d, a, b, c, 7, 10, 0x432aff97)
+  t_i(c, d, a, b, 14, 15, 0xab9423a7)
+  t_i(b, c, d, a, 5, 21, 0xfc93a039)
+  t_i(a, b, c, d, 12, 6, 0x655b59c3)
+  t_i(d, a, b, c, 3, 10, 0x8f0ccc92)
+  t_i(c, d, a, b, 10, 15, 0xffeff47d)
+  t_i(b, c, d, a, 1, 21, 0x85845dd1)
+  t_i(a, b, c, d, 8, 6, 0x6fa87e4f)
+  t_i(d, a, b, c, 15, 10, 0xfe2ce6e0)
+  t_i(c, d, a, b, 6, 15, 0xa3014314)
+  t_i(b, c, d, a, 13, 21, 0x4e0811a1)
+  t_i(a, b, c, d, 4, 6, 0xf7537e82)
+  t_i(d, a, b, c, 11, 10, 0xbd3af235)
+  t_i(c, d, a, b, 2, 15, 0x2ad7d2bb)
+  t_i(b, c, d, a, 9, 21, 0xeb86d391)
   state[0] += a.val
   state[1] += b.val
   state[2] += c.val

--- a/crypto/sm3.mbt
+++ b/crypto/sm3.mbt
@@ -234,7 +234,7 @@ fn sm3_compute(
 
 /// Compute the SM3 digest from given SM3Context
 pub fn finalize(self : SM3Context) -> Bytes {
-  arr_u32_to_u8be(self.sm3_compute())
+  arr_u32_to_u8be(self.sm3_compute().iter())
 }
 
 /// Compute the SM3 digest in `UInt[]` of some `data`
@@ -252,11 +252,11 @@ fn sm3_u32(data : Bytes) -> FixedArray[UInt] {
 
 /// Compute the SM3 digest in `Bytes` of some `data`. Note that SM3 is big-endian.
 pub fn sm3(data : Bytes) -> Bytes {
-  arr_u32_to_u8be(sm3_u32(data))
+  arr_u32_to_u8be(sm3_u32(data).iter())
 }
 
 pub fn sm3_from_iter(data : Iter[Byte]) -> Bytes {
-  arr_u32_to_u8be(sm3_u32_from_iter(data))
+  arr_u32_to_u8be(sm3_u32_from_iter(data).iter())
 }
 
 test {
@@ -264,7 +264,7 @@ test {
     uints_to_hex_string(
       sm3_u32(
         b"\x61\x62\x63", // abc in utf-8
-      ),
+      ).iter(),
     ),
     content="66c7f0f462eeedd9d1f2d46bdc10e4e24167c4875cf2f7a2297da02b8f4ba8e0",
   )
@@ -273,13 +273,13 @@ test {
       sm3_u32(
         // abcd * 16 in utf-8
         b"\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64",
-      ),
+      ).iter(),
     ),
     content="debe9ff92275b8a138604889c18e5a4d6fdb70e5387e5765293dcba39c0c5732",
   )
   @test.eq!(
     bytes_to_hex_string(sm3(b"\x61\x62\x63")),
-    uints_to_hex_string(sm3_u32(b"\x61\x62\x63")),
+    uints_to_hex_string(sm3_u32(b"\x61\x62\x63").iter()),
   )
   let hash1 = "66c7f0f462eeedd9d1f2d46bdc10e4e24167c4875cf2f7a2297da02b8f4ba8e0"
   let ctx = SM3Context::new()

--- a/crypto/sm3.mbt
+++ b/crypto/sm3.mbt
@@ -105,7 +105,11 @@ fn pad(self : SM3Context) -> Bytes {
   return self.buf
 }
 
-fn transform(self : SM3Context, data : Bytes, ~offset : Int = 0) -> Array[UInt] {
+fn transform(
+  self : SM3Context,
+  data : Bytes,
+  ~offset : Int = 0
+) -> FixedArray[UInt] {
   let w_0 = FixedArray::make(68, 0U)
   let w_1 = FixedArray::make(64, 0U)
   let mut a = self.reg[0]
@@ -171,14 +175,14 @@ fn transform(self : SM3Context, data : Bytes, ~offset : Int = 0) -> Array[UInt] 
   f = f ^ f1
   g = g ^ g1
   h = h ^ h1
-  let t_arr : Array[UInt] = [a, b, c, d, e, f, g, h]
+  let t_arr : FixedArray[UInt] = [a, b, c, d, e, f, g, h]
   for index = 0; index < 8; index = index + 1 {
     self.reg[index] = t_arr[index]
   }
   return t_arr
 }
 
-fn sm3_update(self : SM3Context, data : Iter[Byte]) -> Unit {
+pub fn update_from_iter(self : SM3Context, data : Iter[Byte]) -> Unit {
   data.each(
     fn(b) {
       self.buf[self.buf_index] = b
@@ -195,18 +199,30 @@ fn sm3_update(self : SM3Context, data : Iter[Byte]) -> Unit {
 
 /// update the state of given context from new `data` 
 pub fn update(self : SM3Context, data : Bytes) -> Unit {
-  self.sm3_update(bytes_to_iter(data))
-}
+  let mut offset = 0
+  while offset < data.length() {
+    let min_len = if 64 - self.buf_index >= data.length() - offset {
+      data.length() - offset
+    } else {
+      64 - self.buf_index
+    }
+    self.buf.blit(self.buf_index, data, offset, min_len)
+    self.buf_index += min_len
+    if self.buf_index == 64 {
+      self.len += 512UL
+      self.buf_index = 0
+      let _ = self.transform(self.buf)
 
-pub fn update_from_iter(self : SM3Context, data : Iter[Byte]) -> Unit {
-  self.sm3_update(data)
+    }
+    offset += min_len
+  }
 }
 
 fn sm3_compute(
   self : SM3Context,
   ~data : Iter[Byte] = Iter::empty()
-) -> Array[UInt] {
-  self.sm3_update(data)
+) -> FixedArray[UInt] {
+  self.update_from_iter(data)
   let msg = self.pad()
   if msg.length() > 64 {
     let _ = self.transform(msg)
@@ -216,15 +232,22 @@ fn sm3_compute(
   }
 }
 
+/// Compute the SM3 digest from given SM3Context
+pub fn finalize(self : SM3Context) -> Bytes {
+  arr_u32_to_u8be(self.sm3_compute())
+}
+
 /// Compute the SM3 digest in `UInt[]` of some `data`
-fn sm3_u32_from_iter(data : Iter[Byte]) -> Array[UInt] {
+fn sm3_u32_from_iter(data : Iter[Byte]) -> FixedArray[UInt] {
   let ctx = SM3Context::new()
-  let _ = ctx.sm3_update(data)
+  let _ = ctx.update_from_iter(data)
   ctx.sm3_compute()
 }
 
-fn sm3_u32(data : Bytes) -> Array[UInt] {
-  sm3_u32_from_iter(bytes_to_iter(data))
+fn sm3_u32(data : Bytes) -> FixedArray[UInt] {
+  let ctx = SM3Context::new()
+  let _ = ctx.update(data)
+  ctx.sm3_compute()
 }
 
 /// Compute the SM3 digest in `Bytes` of some `data`. Note that SM3 is big-endian.
@@ -234,11 +257,6 @@ pub fn sm3(data : Bytes) -> Bytes {
 
 pub fn sm3_from_iter(data : Iter[Byte]) -> Bytes {
   arr_u32_to_u8be(sm3_u32_from_iter(data))
-}
-
-/// an alias of `SM3Context::compute()`
-pub fn finalize(self : SM3Context) -> Bytes {
-  arr_u32_to_u8be(self.sm3_compute())
 }
 
 test {
@@ -269,4 +287,21 @@ test {
   ctx.update(b"\x62")
   ctx.update(b"\x63")
   @test.eq!(hash1, bytes_to_hex_string(ctx.finalize()))
+  let ctx = SM3Context::new()
+  let data = b"\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64"
+  for i = 0; i < data.length(); i = i + 1 {
+    ctx.update(Bytes::make(1, data[i]))
+  }
+  @test.eq!(
+    bytes_to_hex_string(ctx.finalize()),
+    "debe9ff92275b8a138604889c18e5a4d6fdb70e5387e5765293dcba39c0c5732",
+  )
+  let ctx = SM3Context::new()
+  for i = 0; i < data.length(); i = i + 4 {
+    ctx.update_from_iter(bytes_to_iter(b"\x61\x62\x63\x64"))
+  }
+  @test.eq!(
+    bytes_to_hex_string(ctx.finalize()),
+    "debe9ff92275b8a138604889c18e5a4d6fdb70e5387e5765293dcba39c0c5732",
+  )
 }

--- a/crypto/sm3_test.mbt
+++ b/crypto/sm3_test.mbt
@@ -16,8 +16,8 @@ fn sm3test(s : String) -> String {
   @crypto.bytes_to_hex_string(@crypto.sm3(s.to_bytes()))
 }
 
-// testcases from GM/T 0004-2012
-test "sm3_default" {
+// additional
+test "sm3-additional" {
   @test.eq!(
     sm3test(""),
     "1ab21d8355cfa17f8e61194831e81a8f22bec8c728fefb747ed035eb5082aa2b",

--- a/crypto/utils.mbt
+++ b/crypto/utils.mbt
@@ -35,17 +35,15 @@ pub fn bytes_to_hex_string(input : Bytes) -> String {
 fn uint_to_hex_string(input : UInt) -> String {
   let ret = FixedArray::make(8, "0")
   let mut mut_input = input
-  let mut i = 7
-  for cnt = 0; cnt < 8; cnt = cnt + 1 {
-    ret[i] = hex_digits[(mut_input & 0xf).to_int()]
+  for cnt = 7; cnt >= 0; cnt = cnt - 1 {
+    ret[cnt] = hex_digits[(mut_input & 0xf).to_int()]
     mut_input = mut_input.lsr(4)
-    i -= 1
   }
   ret.fold_left(String::op_add, init="")
 }
 
 /// print a sequence of uint in hex representation
-pub fn uints_to_hex_string(input : Array[UInt]) -> String {
+pub fn uints_to_hex_string(input : FixedArray[UInt]) -> String {
   input.map(uint_to_hex_string).fold_left(String::op_add, init="")
 }
 
@@ -94,8 +92,8 @@ fn bytes_u8_to_u32be(x : Bytes, ~i : Int = 0) -> UInt {
 
 /// convert a UInt to 4 bytes
 
-fn u32_to_u8be(x : UInt) -> Array[Byte] {
-  let b = Array::make(4, b'\x00')
+fn u32_to_u8be(x : UInt) -> FixedArray[Byte] {
+  let b = FixedArray::make(4, b'\x00')
   b[0] = x.lsr(24).to_byte()
   b[1] = x.lsr(16).to_byte()
   b[2] = x.lsr(8).to_byte()
@@ -105,7 +103,7 @@ fn u32_to_u8be(x : UInt) -> Array[Byte] {
 
 /// convert an array of UInt to Bytes in big endian
 
-fn arr_u32_to_u8be(x : Array[UInt]) -> Bytes {
+fn arr_u32_to_u8be(x : FixedArray[UInt]) -> Bytes {
   let temp : Bytes = Bytes::make(x.length() * 4, b'\x00')
   for index = 0; index < x.length(); index = index + 1 {
     let u8 = u32_to_u8be(x[index])

--- a/crypto/utils.mbt
+++ b/crypto/utils.mbt
@@ -43,8 +43,8 @@ fn uint_to_hex_string(input : UInt) -> String {
 }
 
 /// print a sequence of uint in hex representation
-pub fn uints_to_hex_string(input : FixedArray[UInt]) -> String {
-  input.map(uint_to_hex_string).fold_left(String::op_add, init="")
+pub fn uints_to_hex_string(input : Iter[UInt]) -> String {
+  input.map(uint_to_hex_string).fold(String::op_add, init="")
 }
 
 fn urotate_left(x : UInt, n : Int) -> UInt {
@@ -90,28 +90,18 @@ fn bytes_u8_to_u32be(x : Bytes, ~i : Int = 0) -> UInt {
   )
 }
 
-/// convert a UInt to 4 bytes
-
-fn u32_to_u8be(x : UInt) -> FixedArray[Byte] {
-  let b = FixedArray::make(4, b'\x00')
-  b[0] = x.lsr(24).to_byte()
-  b[1] = x.lsr(16).to_byte()
-  b[2] = x.lsr(8).to_byte()
-  b[3] = x.to_byte()
-  b
-}
-
 /// convert an array of UInt to Bytes in big endian
 
-fn arr_u32_to_u8be(x : FixedArray[UInt]) -> Bytes {
-  let temp : Bytes = Bytes::make(x.length() * 4, b'\x00')
-  for index = 0; index < x.length(); index = index + 1 {
-    let u8 = u32_to_u8be(x[index])
-    temp[index * 4] = u8[0]
-    temp[index * 4 + 1] = u8[1]
-    temp[index * 4 + 2] = u8[2]
-    temp[index * 4 + 3] = u8[3]
-  }
+fn arr_u32_to_u8be(x : Iter[UInt]) -> Bytes {
+  let temp : Bytes = Bytes::make(x.count() * 4, b'\x00')
+  x.eachi(
+    fn(i, d) {
+      temp[i * 4 + 0] = d.lsr(24).to_byte()
+      temp[i * 4 + 1] = d.lsr(16).to_byte()
+      temp[i * 4 + 2] = d.lsr(8).to_byte()
+      temp[i * 4 + 3] = d.to_byte()
+    },
+  )
   temp
 }
 


### PR DESCRIPTION
sm3 bytes api now does not convert to iter[byte], yielding better performance.