### PR TITLE
time: make time.Weekday data type public so that it can be pattern matched

### DIFF
--- a/time/time.mbti
+++ b/time/time.mbti
@@ -172,8 +172,15 @@ impl PlainTime {
   with_second(Self, Int) -> Self!
 }
 
-pub enum Weekday
-
+pub enum Weekday {
+  Monday
+  Tuesday
+  Wednesday
+  Thursday
+  Friday
+  Saturday
+  Sunday
+}
 impl Weekday {
   op_equal(Self, Self) -> Bool
   to_string(Self) -> String

--- a/time/time.mbti
+++ b/time/time.mbti
@@ -172,7 +172,8 @@ impl PlainTime {
   with_second(Self, Int) -> Self!
 }
 
-type Weekday
+pub enum Weekday
+
 impl Weekday {
   op_equal(Self, Self) -> Bool
   to_string(Self) -> String

--- a/time/weekday.mbt
+++ b/time/weekday.mbt
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-enum Weekday {
+pub enum Weekday {
   Monday
   Tuesday
   Wednesday


### PR DESCRIPTION
This PR makes `time.Weekday` exportable/public so that consumers of this package can pattern match on it. My use case is that I have to get the weekday of the the parsed PlainDateTime and do certain action based on the returned value. 

At the moment I have to pattern match on a string value, like so
```
  let d = @time.PlainDateTime::of!(
    2000,
    2,
    29,
    hour=1,
    minute=10,
    second=30,
    nanosecond=1000,
  )

match d.weekday().to_string() {
"Monday" => ..
"Tuesday" => ...
"WednesDay" => ...
"Thursday" => ...
"Friday" => ...
"Saturday" => ...
"Sunday" => ...
_ => raise .. //
```
The `d.weekday()` value is already parsed and deemed to be valid, i.e. `PlainDateTime.of` is a success. It seems rather inconvenient to have to handle/pattern-match a case that we know will never occur. Exposing `@time.Weekday` as `pub` and exporting in `time.mbti` will remove this redundant match case. Also in a few instances I have found pattern matching on strings is rather fragile since there are chances of typos in the string which the compiler can't highlight during build time. Finally, `Weekday` values are rather stable (.i.e. they are not going to be changed, I think), so I think making it public should be quite future proof.