### PR TITLE
add get_cli_args support for native

### DIFF
--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,6 +1,6 @@
 {
   "name": "moonbitlang/x",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "readme": "README.md",
   "repository": "https://github.com/moonbitlang/x",
   "license": "Apache-2.0",

--- a/sys/internal/ffi/moon.pkg.json
+++ b/sys/internal/ffi/moon.pkg.json
@@ -1,6 +1,7 @@
 {
     "import": [
-        "moonbitlang/x/internal/ffi"
+        "moonbitlang/x/internal/ffi",
+        "moonbitlang/x/encoding"
     ],
     "targets": {
         "sys_wasm.mbt": ["wasm", "wasm-gc"],

--- a/sys/internal/ffi/sys_native.mbt
+++ b/sys/internal/ffi/sys_native.mbt
@@ -13,9 +13,17 @@
 // limitations under the License.
 
 ///|
+fn internal_get_cli_args() -> FixedArray[Bytes] = "$moonbit.get_cli_args"
+
+///|
 pub fn get_cli_args() -> Array[String] {
-  // not implement yet
-  panic()
+  Array::from_fixed_array(
+    internal_get_cli_args().map(fn {
+      // Here we assume that the CLI arguments are encoded in well-formed UTF-8.
+      // TODO: Handle other encodings.
+      arg => @encoding.decode_strict(UTF8, arg).to_string?().unwrap()
+    }),
+  )
 }
 
 ///|


### PR DESCRIPTION
This MR leaves support for encodings other than utf-8 as TODO in future.