### PR TITLE
doc: add warning to benchmark

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,5 +1,9 @@
 # moonbitlang/x/benchmark
 
+⚠️Please note that this benchmark is a very temporary implementation and the credibility of the results may be low. Due to the lack of coordination in building the system, we need to measure the time twice (once for calculating Average Time and once for calculating the maximum and minimum values of a single measurement), so there may be situations where the average time is greater than the maximum time
+
+In the future, we will try more effective methods to benchmark
+
 ## Overview
 
 This section provides some benchmark APIs, which are unstable and may be removed or modified at any time.

--- a/benchmark/benchmark.mbt
+++ b/benchmark/benchmark.mbt
@@ -24,8 +24,8 @@ pub fn run(self : Task) -> TaskResult {
     (self.f)()
   }
   let time = @ffi.instant_elapsed_as_secs_f64(now)
-  let mut max : Double = @double.min_value
-  let mut min : Double = @double.max_value
+  let mut max = @double.min_value
+  let mut min = @double.max_value
   for i = 1; i <= self.count; i = i + 1 {
     let per_now = @ffi.instant_now()
     (self.f)()


### PR DESCRIPTION
Due to https://github.com/moonbitlang/core/pull/1456 I think it needs to be explained in advance that there is a situation where the average time is greater than the maximum time, and according to #66, I mentioned that this is a temporary implementation