### PR TITLE
Add @time.fixed_zone_unvalidated

### DIFF
--- a/time/time.mbti
+++ b/time/time.mbti
@@ -5,6 +5,8 @@ fn date_time(Int, Int, Int, hour~ : Int = .., minute~ : Int = .., second~ : Int 
 
 fn fixed_zone(String, Int) -> Zone!
 
+fn fixed_zone_unvalidated(String, Int) -> Zone
+
 fn unix(Int64, nanosecond~ : Int = .., zone~ : Zone = ..) -> ZonedDateTime!
 
 let utc_offset : ZoneOffset

--- a/time/zone.mbt
+++ b/time/zone.mbt
@@ -28,6 +28,23 @@ pub fn fixed_zone(id : String, offset_seconds : Int) -> Zone!Error {
   Zone::{ id, offsets: [offset] }
 }
 
+///| Creates a time zone with fixed offset from time zone id and offset seconds
+/// but without validating the offset. This is needed so that a default zone
+/// can be used as a parameter to a function call.
+/// For example: `fn foo(zone~ : @time.Zone = @time.fixed_zone_unvalidated("EST", -18000)) {...}`
+/// If the validation fails, `utc_zone` will be returned.
+pub fn fixed_zone_unvalidated(id : String, offset_seconds : Int) -> Zone {
+  if id.is_empty() {
+    return utc_zone
+  }
+  try {
+    let offset = ZoneOffset::from_seconds!(offset_seconds)
+    Zone::{ id, offsets: [offset] }
+  } catch {
+    _ => utc_zone
+  }
+}
+
 ///| Checks if this zone only has one offset.
 pub fn is_fixed(self : Zone) -> Bool {
   self.offsets.length() == 1

--- a/time/zone_test.mbt
+++ b/time/zone_test.mbt
@@ -20,3 +20,32 @@ test "fixed" {
 test "utc" {
   inspect!(@time.utc_zone, content="UTC")
 }
+
+test "@time.fixed_zone_unvalidated/valid_offset" {
+  let now = 1737643180L
+  let zone = @time.fixed_zone_unvalidated("UTC+8", 8 * 3600)
+  let zdt = @time.unix!(now, zone~)
+  inspect!(zdt.to_string(), content="2025-01-23T22:39:40+08:00[UTC+8]")
+  let zone = @time.fixed_zone_unvalidated("GMT", 3600)
+  let zdt_gmt = @time.unix!(now, zone~)
+  inspect!(zdt_gmt.to_string(), content="2025-01-23T15:39:40+01:00[GMT]")
+  let zone = @time.fixed_zone_unvalidated("EST", -18000)
+  let zdt_est = @time.unix!(now, zone~)
+  inspect!(zdt_est.to_string(), content="2025-01-23T09:39:40-05:00[EST]")
+  let zone = @time.fixed_zone_unvalidated("MinBoundary", -64800)
+  let zdt = @time.unix!(now, zone~)
+  inspect!(zdt.to_string(), content="2025-01-22T20:39:40-18:00[MinBoundary]")
+  let zone = @time.fixed_zone_unvalidated("MaxBoundary", 64800)
+  let zdt = @time.unix!(now, zone~)
+  inspect!(zdt.to_string(), content="2025-01-24T08:39:40+18:00[MaxBoundary]")
+}
+
+test "@time.fixed_zone_unvalidated/invalid_offset" {
+  let now = 1737643180L
+  let zone = @time.fixed_zone_unvalidated("Invalid", 999999)
+  let zdt = @time.unix!(now, zone~)
+  inspect!(zdt.to_string(), content="2025-01-23T14:39:40Z")
+  let zone = @time.fixed_zone_unvalidated("", 0)
+  let zdt = @time.unix!(now, zone~)
+  inspect!(zdt.to_string(), content="2025-01-23T14:39:40Z")
+}


### PR DESCRIPTION
This function is needed so that a default `@time.Zone` can be passed to a function (other than `utc_zone`).

Another name for this could be `fixed_zone_or_utc` if `fixed_zone_unvalidated` is not wanted.

It fixed problems like this:

![need-unvalidated-time-zone-2025-01-23_09-19-46](https://github.com/user-attachments/assets/20a420cc-23b0-4ea7-8a3d-6139508ad81a)
