### PR TITLE
Fix errors from moonc v0.1.20250126+8dbf9490d

### DIFF
--- a/encoding/decoding.mbt
+++ b/encoding/decoding.mbt
@@ -98,10 +98,10 @@ pub fn decode_strict(encoding : Encoding, src : Bytes) -> StrictChars {
 
 ///|
 fn decoder(encoding : Encoding, src : Bytes) -> Decoder {
-  let i = src
+  let i = src.to_fixedarray()
   let i_pos = 0
   let i_max = src.length() - 1
-  let t = b"\x00\x00\x00\x00"
+  let t = b"\x00\x00\x00\x00".to_fixedarray()
   let t_len = 0
   let t_need = 0
   let k = match encoding {
@@ -131,7 +131,7 @@ fn i_rem(self : Decoder) -> Int {
 
 ///|
 fn eoi(self : Decoder) -> Unit {
-  self.i = @bytes.default()
+  self.i = []
   self.i_pos = 0
   self.i_max = @int.min_value
 }
@@ -152,7 +152,13 @@ fn t_need(self : Decoder, need : Int) -> Unit {
 ///|
 fn t_fill(k : Cont, decoder : Decoder) -> Decode {
   fn blit(decoder : Decoder, l : Int) -> Unit {
-    decoder.i.blit(decoder.i_pos, decoder.t, decoder.t_len, l)
+    FixedArray::unsafe_blit(
+      decoder.i,
+      decoder.i_pos,
+      decoder.t,
+      decoder.t_len,
+      l,
+    )
     decoder.i_pos = decoder.i_pos + 1
     decoder.t_len = decoder.t_len + 1
   }
@@ -193,10 +199,16 @@ fn decode_utf_8(self : Decoder) -> Decode {
         let j = self.i_pos
         if need == 0 {
           self.i_pos = self.i_pos + 1
-          self.ret(decode_utf_8, malformed(self.i, j, 1))
+          self.ret(
+            decode_utf_8,
+            malformed(Bytes::from_fixedarray(self.i), j, 1),
+          )
         } else {
           self.i_pos = self.i_pos + need
-          self.ret(decode_utf_8, r_utf_8(self.i, j, need))
+          self.ret(
+            decode_utf_8,
+            r_utf_8(Bytes::from_fixedarray(self.i), j, need),
+          )
         }
       }
     }
@@ -207,9 +219,9 @@ fn decode_utf_8(self : Decoder) -> Decode {
 ///|
 fn t_decode_utf_8(self : Decoder) -> Decode {
   if self.t_len < self.t_need {
-    malformed(self.t, 0, self.t_len)
+    malformed(Bytes::from_fixedarray(self.t), 0, self.t_len)
   } else {
-    r_utf_8(self.t, 0, self.t_len)
+    r_utf_8(Bytes::from_fixedarray(self.t), 0, self.t_len)
   }
 }
 
@@ -324,7 +336,9 @@ fn decode_utf_16le(self : Decoder) -> Decode {
         let j = self.i_pos
         self.i_pos = self.i_pos + 2
         // mark
-        self.decode_utf_16le_lo(r_utf_16(self.i, j + 1, j))
+        self.decode_utf_16le_lo(
+          r_utf_16(Bytes::from_fixedarray(self.i), j + 1, j),
+        )
       }
     _ => abort("unreachable")
   }
@@ -333,9 +347,12 @@ fn decode_utf_16le(self : Decoder) -> Decode {
 ///|
 fn t_decode_utf_16le(self : Decoder) -> Decode {
   if self.t_len < self.t_need {
-    self.ret(decode_utf_16le, malformed(self.t, 0, self.t_len))
+    self.ret(
+      decode_utf_16le,
+      malformed(Bytes::from_fixedarray(self.t), 0, self.t_len),
+    )
   } else {
-    self.decode_utf_16le_lo(r_utf_16(self.t, 1, 0))
+    self.decode_utf_16le_lo(r_utf_16(Bytes::from_fixedarray(self.t), 1, 0))
   }
 }
 
@@ -352,7 +369,7 @@ fn decode_utf_16le_lo(self : Decoder, v : UTF16Decode) -> Decode {
       } else {
         let j = self.i_pos
         self.i_pos = self.i_pos + 2
-        r_utf_16_lo(hi, self.i, j + 1, j)
+        r_utf_16_lo(hi, Bytes::from_fixedarray(self.i), j + 1, j)
       }
     }
   }
@@ -363,10 +380,19 @@ fn t_decode_utf_16le_lo(hi : Int, decoder : Decoder) -> Decode {
   if decoder.t_len < decoder.t_need {
     decoder.ret(
       decode_utf_16le,
-      malformed_pair(false, hi, decoder.t, 0, decoder.t_len),
+      malformed_pair(
+        false,
+        hi,
+        Bytes::from_fixedarray(decoder.t),
+        0,
+        decoder.t_len,
+      ),
     )
   } else {
-    decoder.ret(decode_utf_16le, r_utf_16_lo(hi, decoder.t, 1, 0))
+    decoder.ret(
+      decode_utf_16le,
+      r_utf_16_lo(hi, Bytes::from_fixedarray(decoder.t), 1, 0),
+    )
   }
 }
 
@@ -420,7 +446,9 @@ fn decode_utf_16be(self : Decoder) -> Decode {
       } else {
         let j = self.i_pos
         self.i_pos = self.i_pos + 2
-        self.decode_utf_16be_lo(r_utf_16(self.i, j, j + 1))
+        self.decode_utf_16be_lo(
+          r_utf_16(Bytes::from_fixedarray(self.i), j, j + 1),
+        )
       }
     _ => abort("unreachable")
   }
@@ -429,9 +457,12 @@ fn decode_utf_16be(self : Decoder) -> Decode {
 ///|
 fn t_decode_utf_16be(self : Decoder) -> Decode {
   if self.t_len < self.t_need {
-    self.ret(decode_utf_16be, malformed(self.t, 0, self.t_len))
+    self.ret(
+      decode_utf_16be,
+      malformed(Bytes::from_fixedarray(self.t), 0, self.t_len),
+    )
   } else {
-    self.decode_utf_16be_lo(r_utf_16(self.t, 0, 1))
+    self.decode_utf_16be_lo(r_utf_16(Bytes::from_fixedarray(self.t), 0, 1))
   }
 }
 
@@ -448,7 +479,10 @@ fn decode_utf_16be_lo(self : Decoder, decode : UTF16Decode) -> Decode {
       } else {
         let j = self.i_pos
         self.i_pos = self.i_pos + 2
-        self.ret(decode_utf_16be, r_utf_16_lo(hi, self.i, j, j + 1))
+        self.ret(
+          decode_utf_16be,
+          r_utf_16_lo(hi, Bytes::from_fixedarray(self.i), j, j + 1),
+        )
       }
     }
   }
@@ -457,8 +491,14 @@ fn decode_utf_16be_lo(self : Decoder, decode : UTF16Decode) -> Decode {
 ///|
 fn t_decode_utf_16be_lo(hi : Int, self : Decoder) -> Decode {
   if self.t_len < self.t_need {
-    self.ret(decode_utf_16be, malformed_pair(true, hi, self.t, 0, self.t_len))
+    self.ret(
+      decode_utf_16be,
+      malformed_pair(true, hi, Bytes::from_fixedarray(self.t), 0, self.t_len),
+    )
   } else {
-    self.ret(decode_utf_16be, r_utf_16_lo(hi, self.t, 0, 1))
+    self.ret(
+      decode_utf_16be,
+      r_utf_16_lo(hi, Bytes::from_fixedarray(self.t), 0, 1),
+    )
   }
 }

--- a/encoding/types.mbt
+++ b/encoding/types.mbt
@@ -30,7 +30,7 @@ priv struct Decoder {
   // Input bytes
   // Stores the input bytes that need to be decoded.
   // The primary data source from which characters are read and decoded.
-  mut i : Bytes
+  mut i : FixedArray[Byte]
   // Input position
   // Keeps track of the current position within the input bytes `i`.
   // Indicates the next byte (starting point) to read from `i` during the decoding process
@@ -43,7 +43,7 @@ priv struct Decoder {
   // Temporary bytes
   // Used to temporarily store bytes that are read in parts
   // (which might happen for multi-byte encoded characters).
-  t : Bytes
+  t : FixedArray[Byte]
   // Temporary Length
   // Tracks how many bytes currently reside in the temporary bytes `t`.
   mut t_len : Int
@@ -65,9 +65,8 @@ priv enum Decode {
 
 ///|
 fn slice(bytes : Bytes, offset : Int, length : Int) -> Bytes {
-  let new_bytes = Bytes::new(length)
-  new_bytes.blit(0, bytes, offset, length)
-  new_bytes
+  let new_bytes = FixedArray::makei(length, fn(i) { bytes[offset + i] })
+  Bytes::from_fixedarray(new_bytes)
 }
 
 ///|


### PR DESCRIPTION
While working on #100, I realized that it has errors due to the bleeding-edge compiler: `moonc v0.1.20250126+8dbf9490d`
here: https://github.com/moonbitlang/x/actions/runs/13073683308/job/36480607181?pr=100

```
Run moon check --deny-warn
Error: [2000]
failed: moonc check -error-format json -w @a-31-32 -alert @all-raise-throw-unsafe+deprecated /home/runner/work/x/x/encoding/encoding.mbt /home/runner/work/x/x/encoding/decoding.mbt /home/runner/work/x/x/encoding/types.mbt -w -29 -o /home/runner/work/x/x/target/wasm-gc/release/check/encoding/encoding.mi -pkg moonbitlang/x/encoding -std-path /home/runner/.moon/lib/core/target/wasm-gc/release/bundle -pkg-sources moonbitlang/x/encoding:/home/runner/work/x/x/encoding -target wasm-gc
    ╭─[/home/runner/work/x/x/encoding/types.mbt:69:13]
    │
 69 │   new_bytes.blit(0, bytes, offset, length)
    │             ──┬─  
    │               ╰─── Error (Alert deprecated): Bytes is about to be changed to immutable, use `FixedArray[Byte]` instead
────╯
Error: [2000]
     ╭─[/home/runner/work/x/x/encoding/decoding.mbt:1[5](https://github.com/moonbitlang/x/actions/runs/13073683308/job/36480607181?pr=100#step:8:6)5:15]
     │
 155 │     decoder.i.blit(decoder.i_pos, decoder.t, decoder.t_len, l)
     │               ──┬─  
     │                 ╰─── Error (Alert deprecated): Bytes is about to be changed to immutable, use `FixedArray[Byte]` instead
─────╯
error: failed when checking
Error: Process completed with exit code 255.
```

This PR should fix those errors.