### PR TITLE
feat: streaming input decoding

### DIFF
--- a/encoding/README.md
+++ b/encoding/README.md
@@ -1,0 +1,62 @@
+# Moonbit/Core Encoding
+
+## Overview
+
+The `@encoding` package provides an implementation for encoding and decoding strings using various character encodings (e.g., UTF-8).
+
+It supports both streaming and non-streaming (bulk) operations, making it flexible for different use-cases.
+
+## Supported Encoding
+
+- UTF8
+- UTF16 // alias for UTF16LE
+- UTF16LE
+- UTF16BE
+
+## Usage
+
+### Decoding
+
+Decode a UTF-8 byte stream:
+
+```moonbit
+// Initialize a streaming UTF-8 decoder
+let decoder = @encoding.decoder(UTF8)
+
+// Consume byte chunks
+let inputs = [b"abc", b"\xf0", b"\x9f\x90\xb0"] // UTF8(🐰) == <F09F 90B0>
+inspect!(decoder.consume!(inputs[0]), content="abc")
+inspect!(decoder.consume!(inputs[1]), content="")
+inspect!(decoder.consume!(inputs[2]), content="🐰")
+
+// Finish decoding
+assert_true!(decoder.finish!().is_empty())
+```
+
+### Encoding
+
+Encode a string to UTF-8 bytes:
+
+```moonbit
+// Encode a string to UTF-8
+let src = "你好👀"
+let bytes = @encoding.encode(UTF8, src)
+inspect!(
+  bytes,
+  content=
+    #|b"\xe4\xbd\xa0\xe5\xa5\xbd\xf0\x9f\x91\x80"
+  ,
+)
+```
+
+Encode a single character to UTF-8 bytes:
+
+```moonbit
+inspect!(
+  @encoding.to_utf8_bytes('A'),
+  content=
+    #|b"\x41"
+  ,
+)
+```
+

--- a/encoding/decoding.mbt
+++ b/encoding/decoding.mbt
@@ -46,8 +46,13 @@ pub fn decoder(encoding : Encoding) -> Decoder {
 }
 
 ///|
-pub fn decode!(self : Decoder, input : Bytes, stream~ : Bool = true) -> String {
-  self.i_cont(input)
+pub fn decode!(self : Decoder, input : Bytes, stream~ : Bool = false) -> String {
+  if input.length() > 0 {
+    self.i_cont(input)
+  }
+  if self.i_rem() == 0 {
+    return String::default()
+  }
 
   // drive decoder to decode
   let chars = []
@@ -73,12 +78,27 @@ pub fn decode!(self : Decoder, input : Bytes, stream~ : Bool = true) -> String {
 }
 
 ///|
+pub fn decode_continue!(self : Decoder, input : Bytes) -> String {
+  self.decode!(input, stream=true)
+}
+
+///|
+pub fn decode_finish!(self : Decoder, input~ : Bytes = b"") -> String {
+  self.decode!(input, stream=false)
+}
+
+///|
 pub fn decode_lossy(
   self : Decoder,
   input : Bytes,
-  stream~ : Bool = true
+  stream~ : Bool = false
 ) -> String {
-  self.i_cont(input)
+  if input.length() > 0 {
+    self.i_cont(input)
+  }
+  if self.i_rem() == 0 {
+    return String::default()
+  }
 
   // drive decoder to decode
   let chars = []
@@ -102,6 +122,16 @@ pub fn decode_lossy(
         continue self.decode_()
       }
   }
+}
+
+///|
+pub fn decode_lossy_continue(self : Decoder, input : Bytes) -> String {
+  self.decode_lossy(input, stream=true)
+}
+
+///|
+pub fn decode_lossy_finish(self : Decoder, input~ : Bytes = b"") -> String {
+  self.decode_lossy(input, stream=false)
 }
 
 ///|

--- a/encoding/decoding.mbt
+++ b/encoding/decoding.mbt
@@ -380,6 +380,17 @@ fn r_utf_16_lo(
   let b1 = bytes[offset1].to_int()
   let lo = (b0 << 8) | b1
   if lo < 0xDC00 || lo > 0xDFFF {
+    // TODO(jinser): try to skip lo and then parse the following
+    //
+    // For example, b"\xD8\x00\x00\x48" (BE)
+    // Since \xD8\x00 is *legal* hi, here will try to parse lo next,
+    // however the whole \xD8\x00\x00\x48 is *illegal* so the result will be a `Malformed[b"\xD8\x00\x00\x48"]`
+    //
+    // But \x00\x48 itself is a *legal* UTF16 code point with a value of `H`,
+    // the ideal result should be: `[Malformed(b"\xD8\x00"), Uchar('H')]`
+    //
+    // > printf '\xD8\x00\x00\x48' | uconv --from-code UTF16BE --to-code UTF8 --from-callback substitute
+    // �H
     malformed_pair(
       offset0 < offset1,
       hi,

--- a/encoding/decoding.mbt
+++ b/encoding/decoding.mbt
@@ -380,8 +380,12 @@ fn decode_utf_16le_lo(self : Decoder, v : UTF16Decode) -> Decode {
         t_fill(@tuple.curry(t_decode_utf_16le_lo)(hi), self)
       } else {
         let j = self.i_pos
-        self.i_pos += 2
-        self.ret(decode_utf_16le, r_utf_16_lo(hi, self.i, j + 1, j))
+        let dcd = r_utf_16_lo(hi, self.i, j + 1, j)
+        match dcd {
+          Uchar(_) => self.i_pos += 2
+          _ => ()
+        }
+        self.ret(decode_utf_16le, dcd)
       }
     }
   }
@@ -410,7 +414,7 @@ fn r_utf_16_lo(
   let b1 = bytes[offset1].to_int()
   let lo = (b0 << 8) | b1
   if lo < 0xDC00 || lo > 0xDFFF {
-    // TODO(jinser): try to skip lo and then parse the following
+    // NOTE(jinser): only hi malformed, skip lo if lo is illegal
     //
     // For example, b"\xD8\x00\x00\x48" (BE)
     // Since \xD8\x00 is *legal* hi, here will try to parse lo next,
@@ -421,13 +425,7 @@ fn r_utf_16_lo(
     //
     // > printf '\xD8\x00\x00\x48' | uconv --from-code UTF16BE --to-code UTF8 --from-callback substitute
     // �H
-    malformed_pair(
-      offset0 < offset1,
-      hi,
-      bytes,
-      @math.minimum(offset0, offset1),
-      2,
-    )
+    Malformed([bytes[offset0], bytes[offset1]])
   } else {
     Uchar(Char::from_int(((hi & 0x3FF) << 10) | ((lo & 0x3FF) + 0x10000)))
   }
@@ -489,8 +487,12 @@ fn decode_utf_16be_lo(self : Decoder, decode : UTF16Decode) -> Decode {
         t_fill(@tuple.curry(t_decode_utf_16be_lo)(hi), self)
       } else {
         let j = self.i_pos
-        self.i_pos += 2
-        self.ret(decode_utf_16be, r_utf_16_lo(hi, self.i, j, j + 1))
+        let dcd = r_utf_16_lo(hi, self.i, j, j + 1)
+        match dcd {
+          Uchar(_) => self.i_pos += 2
+          _ => ()
+        }
+        self.ret(decode_utf_16be, dcd)
       }
     }
   }

--- a/encoding/decoding.mbt
+++ b/encoding/decoding.mbt
@@ -33,7 +33,7 @@ let utf_8_len = [
 pub fn decoder(encoding : Encoding) -> Decoder {
   let i = FixedArray::default()
   let i_pos = 0
-  let t = FixedArray::make(4, b'0')
+  let t = FixedArray::make(4, Byte::default())
   let t_len = 0
   let t_need = 0
   let k = match encoding {

--- a/encoding/decoding.mbt
+++ b/encoding/decoding.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-const U_REP = '\u{FFFD}'
+// const U_REP = '\u{FFFD}' // TODO: should usable in some case
 
 ///|
 let utf_8_len = [
@@ -30,78 +30,10 @@ let utf_8_len = [
 ]
 
 ///|
-/// Decodes bytes from a specified encoding into lossily decoded characters.
-///
-/// # Parameters
-/// - `encoding`: The character encoding of the input `bytes`.
-/// - `src`: A `bytes` representing the encoded string in the specified format.
-///
-/// # Returns
-///
-/// A `LossyChars` iterator representing the decoded characters, with invalid byte sequences replaced by a replacement character.
-///
-/// # Behavior
-///
-/// - Any invalid sequences in the `bytes` are replaced with a replacement character (`\u{FFFD}`), preventing decoding errors.
-///
-/// # Examples
-///
-/// ```moonbit
-/// let buf = @buffer.new(size_hint=10)
-/// buf.write_bytes(b"\xe4\xbd\xa0") // "你" in UTF8
-/// buf.write_bytes(b"\xe5\xa5\xbd") // "好" in UTF8
-/// buf.write_bytes(b"\xf0\x9f\x91\x80") // "👀" in UTF8
-/// let chars = @encoding.decode_lossy(UTF8, buf.to_bytes())
-/// let arr = chars.iter().collect() // Array of unicode point code: `['你', '好', '👀']`
-/// let str = String::from_array(arr) // MoonBit String, representing as UTF16LE: `"你好👀"`
-/// // or
-/// let str = chars.to_string()
-/// ```
-pub fn decode_lossy(encoding : Encoding, src : Bytes) -> LossyChars {
-  let decoder = decoder(encoding, src)
-  decoder
-}
-
-///|
-/// Decodes bytes from a specified encoding into strictly decoded characters.
-///
-/// # Parameters
-///
-/// - `encoding`: The character encoding of the input `bytes`.
-/// - `src`: A `bytes` representing the encoded string in the specified format.
-///
-/// # Returns
-///
-/// A `StrictChars` iterator representing the decoded characters.
-///
-/// # Behavior
-///
-/// - Assumes all sequences in the `bytes` are valid and will raise errors if invalid sequences are encountered.
-///
-/// # Examples
-///
-/// ```moonbit
-/// let buf = @buffer.new(size_hint=10)
-/// buf.write_bytes(b"\xe4\xbd\xa0") // "你" in UTF8
-/// buf.write_bytes(b"\xe5\xa5\xbd") // "好" in UTF8
-/// buf.write_bytes(b"\xf0\x9f\x91\x80") // "👀" in UTF8
-/// let chars = @encoding.decode_strict(UTF8, buf.to_bytes())
-/// let arr = chars.iter().collect() // Array of unicode point code: `[Ok('你'), Ok('好'), Ok('👀')]`
-/// let str = chars.to_string() // MoonBit String, representing as UTF16LE: `"你好👀"`
-/// ```
-pub fn decode_strict(encoding : Encoding, src : Bytes) -> StrictChars {
-  let decoder = decoder(encoding, src)
-  decoder
-}
-
-// Implementations
-
-///|
-fn decoder(encoding : Encoding, src : Bytes) -> Decoder {
-  let i = src.to_fixedarray()
+pub fn decoder(encoding : Encoding) -> Decoder {
+  let i = FixedArray::default()
   let i_pos = 0
-  let i_max = src.length() - 1
-  let t = b"\x00\x00\x00\x00".to_fixedarray()
+  let t = FixedArray::make(4, b'0')
   let t_len = 0
   let t_need = 0
   let k = match encoding {
@@ -110,11 +42,40 @@ fn decoder(encoding : Encoding, src : Bytes) -> Decoder {
     UTF16LE => decode_utf_16le
     UTF16BE => decode_utf_16be
   }
-  { i, i_pos, i_max, t, t_len, t_need, k }
+  { i, i_pos, t, t_len, t_need, k }
 }
 
 ///|
-fn decode(self : Decoder) -> Decode {
+pub fn decode!(self : Decoder, input : Bytes) -> String {
+  // concat `input` to `i`, drop decoded `i`
+  // init a new `i`
+  let i_rem = self.i_rem()
+  let new_len = i_rem + input.length()
+  let new_i = FixedArray::make(new_len, Byte::default())
+  // copy the remainder of the old `i` into the new `i`
+  self.i.blit_to(new_i, len=i_rem, src_offset=self.i_pos)
+  // copy all `input` into new `i`, starting at the remainder of the old `i`
+  new_i.blit_from_bytes(i_rem, input, 0, input.length())
+  self.i = new_i
+  // reset position to starting position
+  self.i_pos = 0
+
+  // drive decoder to decode
+  let chars = []
+  loop self.decode_() {
+    Uchar(u) => {
+      chars.push(u)
+      continue self.decode_()
+    }
+    Malformed(bs) => raise MalformedError(bs)
+    End | Refill => String::from_array(chars)
+  }
+}
+
+// Implementations
+
+///|
+fn decode_(self : Decoder) -> Decode {
   (self.k)(self)
 }
 
@@ -126,21 +87,7 @@ fn ret(self : Decoder, k : Cont, v : Decode) -> Decode {
 
 ///|
 fn i_rem(self : Decoder) -> Int {
-  self.i_max - self.i_pos + 1
-}
-
-///|
-fn eoi(self : Decoder) -> Unit {
-  self.i = []
-  self.i_pos = 0
-  self.i_max = @int.min_value
-}
-
-///|
-fn refill(self : Decoder, k : Cont) -> Decode {
-  // only Bytes
-  self.eoi()
-  k(self)
+  self.i.length() - self.i_pos
 }
 
 ///|
@@ -152,12 +99,11 @@ fn t_need(self : Decoder, need : Int) -> Unit {
 ///|
 fn t_fill(k : Cont, decoder : Decoder) -> Decode {
   fn blit(decoder : Decoder, l : Int) -> Unit {
-    FixedArray::unsafe_blit(
+    decoder.t.blit_to(
       decoder.i,
-      decoder.i_pos,
-      decoder.t,
-      decoder.t_len,
-      l,
+      len=l,
+      dst_offset=decoder.i_pos,
+      src_offset=decoder.t_len,
     )
     decoder.i_pos = decoder.i_pos + 1
     decoder.t_len = decoder.t_len + 1
@@ -169,8 +115,7 @@ fn t_fill(k : Cont, decoder : Decoder) -> Decode {
   } else {
     let need = decoder.t_need - decoder.t_len
     if rem < need {
-      blit(decoder, rem)
-      decoder.refill(@tuple.curry(t_fill)(k))
+      Decode::Refill
     } else {
       blit(decoder, need)
       k(decoder)
@@ -183,50 +128,38 @@ fn t_fill(k : Cont, decoder : Decoder) -> Decode {
 ///|
 fn decode_utf_8(self : Decoder) -> Decode {
   let rem = self.i_rem()
-  match rem.compare(0) {
-    // rem < 0
-    -1 => Decode::End
-    // rem = 0
-    0 => self.refill(decode_utf_8)
-    // rem > 0
-    1 => {
-      let idx = self.i[self.i_pos].to_int()
-      let need = utf_8_len[idx]
-      if rem < need {
-        self.t_need(need)
-        t_fill(t_decode_utf_8, self)
+  if rem <= 0 {
+    Decode::End
+  } else {
+    let idx = self.i[self.i_pos].to_int()
+    let need = utf_8_len[idx]
+    if rem < need {
+      self.t_need(need)
+      t_fill(t_decode_utf_8, self)
+    } else {
+      let j = self.i_pos
+      if need == 0 {
+        self.i_pos = self.i_pos + 1
+        self.ret(decode_utf_8, Decode::Refill)
       } else {
-        let j = self.i_pos
-        if need == 0 {
-          self.i_pos = self.i_pos + 1
-          self.ret(
-            decode_utf_8,
-            malformed(Bytes::from_fixedarray(self.i), j, 1),
-          )
-        } else {
-          self.i_pos = self.i_pos + need
-          self.ret(
-            decode_utf_8,
-            r_utf_8(Bytes::from_fixedarray(self.i), j, need),
-          )
-        }
+        self.i_pos = self.i_pos + need
+        self.ret(decode_utf_8, r_utf_8(self.i, j, need))
       }
     }
-    _ => abort("unreachable")
   }
 }
 
 ///|
 fn t_decode_utf_8(self : Decoder) -> Decode {
   if self.t_len < self.t_need {
-    malformed(Bytes::from_fixedarray(self.t), 0, self.t_len)
+    malformed(self.t, 0, self.t_len)
   } else {
-    r_utf_8(Bytes::from_fixedarray(self.t), 0, self.t_len)
+    r_utf_8(self.t, 0, self.t_len)
   }
 }
 
 ///|
-fn r_utf_8(bytes : Bytes, offset : Int, length : Int) -> Decode {
+fn r_utf_8(bytes : FixedArray[Byte], offset : Int, length : Int) -> Decode {
   fn uchar(c : Int) {
     Uchar(Char::from_int(c))
   }
@@ -322,37 +255,24 @@ priv enum UTF16Decode {
 ///|
 fn decode_utf_16le(self : Decoder) -> Decode {
   let rem = self.i_rem()
-  match rem.compare(0) {
-    // rem < 0
-    -1 => Decode::End
-    // rem = 0
-    0 => self.refill(decode_utf_16le)
-    // rem > 0
-    1 =>
-      if rem < 2 {
-        self.t_need(2)
-        t_fill(t_decode_utf_16le, self)
-      } else {
-        let j = self.i_pos
-        self.i_pos = self.i_pos + 2
-        // mark
-        self.decode_utf_16le_lo(
-          r_utf_16(Bytes::from_fixedarray(self.i), j + 1, j),
-        )
-      }
-    _ => abort("unreachable")
+  if rem <= 0 {
+    Decode::End
+  } else if rem < 2 {
+    self.t_need(2)
+    t_fill(t_decode_utf_16le, self)
+  } else {
+    let j = self.i_pos
+    self.i_pos = self.i_pos + 2
+    self.decode_utf_16le_lo(r_utf_16(self.i, j + 1, j))
   }
 }
 
 ///|
 fn t_decode_utf_16le(self : Decoder) -> Decode {
   if self.t_len < self.t_need {
-    self.ret(
-      decode_utf_16le,
-      malformed(Bytes::from_fixedarray(self.t), 0, self.t_len),
-    )
+    self.ret(decode_utf_16le, malformed(self.t, 0, self.t_len))
   } else {
-    self.decode_utf_16le_lo(r_utf_16(Bytes::from_fixedarray(self.t), 1, 0))
+    self.decode_utf_16le_lo(r_utf_16(self.t, 1, 0))
   }
 }
 
@@ -369,7 +289,7 @@ fn decode_utf_16le_lo(self : Decoder, v : UTF16Decode) -> Decode {
       } else {
         let j = self.i_pos
         self.i_pos = self.i_pos + 2
-        r_utf_16_lo(hi, Bytes::from_fixedarray(self.i), j + 1, j)
+        r_utf_16_lo(hi, self.i, j + 1, j)
       }
     }
   }
@@ -380,24 +300,20 @@ fn t_decode_utf_16le_lo(hi : Int, decoder : Decoder) -> Decode {
   if decoder.t_len < decoder.t_need {
     decoder.ret(
       decode_utf_16le,
-      malformed_pair(
-        false,
-        hi,
-        Bytes::from_fixedarray(decoder.t),
-        0,
-        decoder.t_len,
-      ),
+      malformed_pair(false, hi, decoder.t, 0, decoder.t_len),
     )
   } else {
-    decoder.ret(
-      decode_utf_16le,
-      r_utf_16_lo(hi, Bytes::from_fixedarray(decoder.t), 1, 0),
-    )
+    decoder.ret(decode_utf_16le, r_utf_16_lo(hi, decoder.t, 1, 0))
   }
 }
 
 ///|
-fn r_utf_16_lo(hi : Int, bytes : Bytes, offset0 : Int, offset1 : Int) -> Decode {
+fn r_utf_16_lo(
+  hi : Int,
+  bytes : FixedArray[Byte],
+  offset0 : Int,
+  offset1 : Int
+) -> Decode {
   let b0 = bytes[offset0].to_int()
   let b1 = bytes[offset1].to_int()
   let lo = (b0 << 8) | b1
@@ -415,7 +331,11 @@ fn r_utf_16_lo(hi : Int, bytes : Bytes, offset0 : Int, offset1 : Int) -> Decode 
 }
 
 ///|
-fn r_utf_16(bytes : Bytes, offset0 : Int, offset1 : Int) -> UTF16Decode {
+fn r_utf_16(
+  bytes : FixedArray[Byte],
+  offset0 : Int,
+  offset1 : Int
+) -> UTF16Decode {
   let b0 = bytes[offset0].to_int()
   let b1 = bytes[offset1].to_int()
   let u = (b0 << 8) | b1
@@ -433,36 +353,24 @@ fn r_utf_16(bytes : Bytes, offset0 : Int, offset1 : Int) -> UTF16Decode {
 ///|
 fn decode_utf_16be(self : Decoder) -> Decode {
   let rem = self.i_rem()
-  match rem.compare(0) {
-    // rem < 0
-    -1 => Decode::End
-    // rem = 0
-    0 => self.refill(decode_utf_16be)
-    // rem > 0
-    1 =>
-      if rem < 2 {
-        self.t_need(2)
-        t_fill(t_decode_utf_16be, self)
-      } else {
-        let j = self.i_pos
-        self.i_pos = self.i_pos + 2
-        self.decode_utf_16be_lo(
-          r_utf_16(Bytes::from_fixedarray(self.i), j, j + 1),
-        )
-      }
-    _ => abort("unreachable")
+  if rem <= 0 {
+    Decode::End
+  } else if rem < 2 {
+    self.t_need(2)
+    t_fill(t_decode_utf_16be, self)
+  } else {
+    let j = self.i_pos
+    self.i_pos = self.i_pos + 2
+    self.decode_utf_16be_lo(r_utf_16(self.i, j, j + 1))
   }
 }
 
 ///|
 fn t_decode_utf_16be(self : Decoder) -> Decode {
   if self.t_len < self.t_need {
-    self.ret(
-      decode_utf_16be,
-      malformed(Bytes::from_fixedarray(self.t), 0, self.t_len),
-    )
+    self.ret(decode_utf_16be, malformed(self.t, 0, self.t_len))
   } else {
-    self.decode_utf_16be_lo(r_utf_16(Bytes::from_fixedarray(self.t), 0, 1))
+    self.decode_utf_16be_lo(r_utf_16(self.t, 0, 1))
   }
 }
 
@@ -479,10 +387,7 @@ fn decode_utf_16be_lo(self : Decoder, decode : UTF16Decode) -> Decode {
       } else {
         let j = self.i_pos
         self.i_pos = self.i_pos + 2
-        self.ret(
-          decode_utf_16be,
-          r_utf_16_lo(hi, Bytes::from_fixedarray(self.i), j, j + 1),
-        )
+        self.ret(decode_utf_16be, r_utf_16_lo(hi, self.i, j, j + 1))
       }
     }
   }
@@ -491,14 +396,8 @@ fn decode_utf_16be_lo(self : Decoder, decode : UTF16Decode) -> Decode {
 ///|
 fn t_decode_utf_16be_lo(hi : Int, self : Decoder) -> Decode {
   if self.t_len < self.t_need {
-    self.ret(
-      decode_utf_16be,
-      malformed_pair(true, hi, Bytes::from_fixedarray(self.t), 0, self.t_len),
-    )
+    self.ret(decode_utf_16be, malformed_pair(true, hi, self.t, 0, self.t_len))
   } else {
-    self.ret(
-      decode_utf_16be,
-      r_utf_16_lo(hi, Bytes::from_fixedarray(self.t), 0, 1),
-    )
+    self.ret(decode_utf_16be, r_utf_16_lo(hi, self.t, 0, 1))
   }
 }

--- a/encoding/decoding.mbt
+++ b/encoding/decoding.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-// const U_REP = '\u{FFFD}' // TODO: should usable in some case
+pub const U_REP = '\u{FFFD}'
 
 ///|
 let utf_8_len = [
@@ -46,19 +46,8 @@ pub fn decoder(encoding : Encoding) -> Decoder {
 }
 
 ///|
-pub fn decode!(self : Decoder, input : Bytes) -> String {
-  // concat `input` to `i`, drop decoded `i`
-  // init a new `i`
-  let i_rem = self.i_rem()
-  let new_len = i_rem + input.length()
-  let new_i = FixedArray::make(new_len, Byte::default())
-  // copy the remainder of the old `i` into the new `i`
-  self.i.blit_to(new_i, len=i_rem, src_offset=self.i_pos)
-  // copy all `input` into new `i`, starting at the remainder of the old `i`
-  new_i.blit_from_bytes(i_rem, input, 0, input.length())
-  self.i = new_i
-  // reset position to starting position
-  self.i_pos = 0
+pub fn decode!(self : Decoder, input : Bytes, stream~ : Bool = true) -> String {
+  self.i_cont(input)
 
   // drive decoder to decode
   let chars = []
@@ -67,9 +56,70 @@ pub fn decode!(self : Decoder, input : Bytes) -> String {
       chars.push(u)
       continue self.decode_()
     }
-    Malformed(bs) => raise MalformedError(bs)
-    End | Refill => String::from_array(chars)
+    Malformed(bs) =>
+      if stream && self.t_need > 0 {
+        String::from_array(chars)
+      } else {
+        raise MalformedError(bs)
+      }
+    End => String::from_array(chars)
+    Refill(t) =>
+      if stream {
+        String::from_array(chars)
+      } else {
+        raise TruncatedError(t)
+      }
   }
+}
+
+///|
+pub fn decode_lossy(
+  self : Decoder,
+  input : Bytes,
+  stream~ : Bool = true
+) -> String {
+  self.i_cont(input)
+
+  // drive decoder to decode
+  let chars = []
+  loop self.decode_() {
+    Uchar(u) => {
+      chars.push(u)
+      continue self.decode_()
+    }
+    Malformed(_) =>
+      if stream && self.t_need > 0 {
+        String::from_array(chars)
+      } else {
+        chars.push(U_REP)
+        continue self.decode_()
+      }
+    End => String::from_array(chars)
+    Refill(_) =>
+      if stream {
+        String::from_array(chars)
+      } else {
+        continue self.decode_()
+      }
+  }
+}
+
+///|
+fn i_cont(self : Decoder, input : Bytes) -> Unit {
+  // concat `input` to `i`, drop decoded `i`
+  let i_rem = @math.maximum(self.i_rem(), 0)
+  let new_len = i_rem + input.length()
+  // init a new `i`
+  let new_i = FixedArray::make(new_len, Byte::default())
+  if i_rem > 0 {
+    // copy the remainder of the old `i` into the new `i`
+    self.i.blit_to(new_i, len=i_rem, src_offset=self.i_pos)
+  }
+  // copy all `input` into new `i`, starting at the remainder of the old `i`
+  new_i.blit_from_bytes(i_rem, input, 0, input.length())
+  self.i = new_i
+  // reset position to starting position
+  self.i_pos = 0
 }
 
 // Implementations
@@ -97,16 +147,27 @@ fn t_need(self : Decoder, need : Int) -> Unit {
 }
 
 ///|
+fn eoi(self : Decoder) -> Unit {
+  self.i = FixedArray::default()
+}
+
+///|
+fn refill(self : Decoder, k : Cont) -> Decode {
+  self.eoi()
+  self.ret(k, Decode::Refill(Bytes::from_fixedarray(self.t)))
+}
+
+///|
 fn t_fill(k : Cont, decoder : Decoder) -> Decode {
   fn blit(decoder : Decoder, l : Int) -> Unit {
-    decoder.t.blit_to(
-      decoder.i,
+    decoder.i.blit_to(
+      decoder.t,
       len=l,
-      dst_offset=decoder.i_pos,
-      src_offset=decoder.t_len,
+      dst_offset=decoder.t_len,
+      src_offset=decoder.i_pos,
     )
-    decoder.i_pos = decoder.i_pos + 1
-    decoder.t_len = decoder.t_len + 1
+    decoder.i_pos += l
+    decoder.t_len += l
   }
 
   let rem = decoder.i_rem()
@@ -115,7 +176,8 @@ fn t_fill(k : Cont, decoder : Decoder) -> Decode {
   } else {
     let need = decoder.t_need - decoder.t_len
     if rem < need {
-      Decode::Refill
+      blit(decoder, rem)
+      decoder.refill(@tuple.curry(t_fill)(k))
     } else {
       blit(decoder, need)
       k(decoder)
@@ -139,10 +201,10 @@ fn decode_utf_8(self : Decoder) -> Decode {
     } else {
       let j = self.i_pos
       if need == 0 {
-        self.i_pos = self.i_pos + 1
-        self.ret(decode_utf_8, Decode::Refill)
+        self.i_pos += 1
+        self.ret(decode_utf_8, malformed(self.i, j, 1))
       } else {
-        self.i_pos = self.i_pos + need
+        self.i_pos += need
         self.ret(decode_utf_8, r_utf_8(self.i, j, need))
       }
     }
@@ -152,9 +214,9 @@ fn decode_utf_8(self : Decoder) -> Decode {
 ///|
 fn t_decode_utf_8(self : Decoder) -> Decode {
   if self.t_len < self.t_need {
-    malformed(self.t, 0, self.t_len)
+    self.ret(decode_utf_8, malformed(self.t, 0, self.t_len))
   } else {
-    r_utf_8(self.t, 0, self.t_len)
+    self.ret(decode_utf_8, r_utf_8(self.t, 0, self.t_len))
   }
 }
 
@@ -262,7 +324,7 @@ fn decode_utf_16le(self : Decoder) -> Decode {
     t_fill(t_decode_utf_16le, self)
   } else {
     let j = self.i_pos
-    self.i_pos = self.i_pos + 2
+    self.i_pos += 2
     self.decode_utf_16le_lo(r_utf_16(self.i, j + 1, j))
   }
 }
@@ -279,8 +341,8 @@ fn t_decode_utf_16le(self : Decoder) -> Decode {
 ///|
 fn decode_utf_16le_lo(self : Decoder, v : UTF16Decode) -> Decode {
   match v {
-    UTF16Uchar(u) => Uchar(u)
-    UTF16Malformed(s) => Malformed(s)
+    UTF16Uchar(u) => self.ret(decode_utf_16le, Uchar(u))
+    UTF16Malformed(s) => self.ret(decode_utf_16le, Malformed(s))
     Hi(hi) => {
       let rem = self.i_rem()
       if rem < 2 {
@@ -288,8 +350,8 @@ fn decode_utf_16le_lo(self : Decoder, v : UTF16Decode) -> Decode {
         t_fill(@tuple.curry(t_decode_utf_16le_lo)(hi), self)
       } else {
         let j = self.i_pos
-        self.i_pos = self.i_pos + 2
-        r_utf_16_lo(hi, self.i, j + 1, j)
+        self.i_pos += 2
+        self.ret(decode_utf_16le, r_utf_16_lo(hi, self.i, j + 1, j))
       }
     }
   }
@@ -360,7 +422,7 @@ fn decode_utf_16be(self : Decoder) -> Decode {
     t_fill(t_decode_utf_16be, self)
   } else {
     let j = self.i_pos
-    self.i_pos = self.i_pos + 2
+    self.i_pos += 2
     self.decode_utf_16be_lo(r_utf_16(self.i, j, j + 1))
   }
 }
@@ -386,7 +448,7 @@ fn decode_utf_16be_lo(self : Decoder, decode : UTF16Decode) -> Decode {
         t_fill(@tuple.curry(t_decode_utf_16be_lo)(hi), self)
       } else {
         let j = self.i_pos
-        self.i_pos = self.i_pos + 2
+        self.i_pos += 2
         self.ret(decode_utf_16be, r_utf_16_lo(hi, self.i, j, j + 1))
       }
     }

--- a/encoding/decoding.mbt
+++ b/encoding/decoding.mbt
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-///|
+///| The Unicode Replacement Character, which is used to replace invalid or unrecognized sequences during lossy decoding.
+/// https://unicode.org/charts/nameslist/n_FFF0.html
 pub const U_REP = '\u{FFFD}'
 
 ///|
@@ -30,6 +31,27 @@ let utf_8_len = [
 ]
 
 ///|
+/// Create and return a `Decoder` for the specified character encoding.
+///
+/// The `Decoder` consumes byte sequences and decodes them into the original string format.
+///
+/// # Parameters
+///
+/// - `encoding`: The character encoding format to be used for decoding the input byte sequences.
+///
+/// # Returns
+///
+/// A `Decoder` instance that can be used to decode byte sequences into strings.
+///
+/// # Examples
+///
+/// ```moonbit
+/// let inputs = [b"abc", b"\xf0", b"\x9f\x90\xb0"] // UTF8(🐰) == <F09F 90B0>
+/// let decoder = decoder(UTF8)
+/// inspect!(decoder.consume!(inputs[0]), content="abc")
+/// inspect!(decoder.consume!(inputs[1]), content="")
+/// inspect!(decoder.consume!(inputs[2]), content="🐰")
+/// assert_true!(decoder.finish!().is_empty())
 pub fn decoder(encoding : Encoding) -> Decoder {
   let i = FixedArray::default()
   let i_pos = 0
@@ -46,6 +68,35 @@ pub fn decoder(encoding : Encoding) -> Decoder {
 }
 
 ///|
+/// Decode the given byte sequence using the specified `Decoder` and return the resulting string.
+///
+/// This function can work in streaming mode where bytes are consumed incrementally.
+/// When `stream` is `false`, it indicates the end of the input and triggers the final decoding step.
+///
+/// # Parameters
+///
+/// - `self`: The `Decoder` instance used to decode the byte sequence.
+/// - `input`: The byte sequence to be decoded.
+/// - `stream~`: A boolean indicating whether more bytes will be supplied for decoding. It defaults to `false`.
+///
+/// # Returns
+///
+/// A `String` representing the decoded content from the input byte sequence.
+///
+/// # Errors
+///
+/// `MalformedError`: when the byte sequence is not properly formatted according to the specified encoding.
+/// `TruncatedError`: when the byte sequence ends prematurely, implying that more data is expected for complete decoding.
+///
+/// # Examples
+///
+/// ```moonbit
+/// let inputs = [b"abc", b"\xf0", b"\x9f\x90\xb0"] // UTF8(🐰) == <F09F 90B0>
+/// let decoder = @encoding.decoder(UTF8)
+/// inspect!(decoder.decode!(inputs[0], stream=true), content="abc")
+/// inspect!(decoder.decode!(inputs[1], stream=true), content="")
+/// inspect!(decoder.decode!(inputs[2], stream=false), content="🐰")
+/// ```
 pub fn decode!(self : Decoder, input : Bytes, stream~ : Bool = false) -> String {
   if input.length() > 0 {
     self.i_cont(input)
@@ -78,16 +129,64 @@ pub fn decode!(self : Decoder, input : Bytes, stream~ : Bool = false) -> String 
 }
 
 ///|
+/// Consume the given byte sequence using the specified `Decoder` and return the resulting string incrementally.
+///
+/// This function calls `decode!` with the `stream` parameter set to `true`, indicating that more bytes will follow for decoding.
+///
+/// # Parameters
+///
+/// - `self`: The `Decoder` instance used to consume the byte sequence.
+/// - `input`: The byte sequence to be consumed and decoded incrementally.
+///
+/// # Returns
+///
+/// A `String` representing the partially decoded content from the input byte sequence, as more bytes are expected.
+///
+/// # Errors
+///
+/// `MalformedError`: when the byte sequence is not properly formatted according to the specified encoding.
+/// `TruncatedError`: when the byte sequence ends prematurely, implying that more data is expected for complete decoding.
 pub fn consume!(self : Decoder, input : Bytes) -> String {
   self.decode!(input, stream=true)
 }
 
 ///|
+/// Finalize the decoding process and return the remaining decoded string.
+///
+/// This function calls `decode!` with the `stream` parameter set to `false`, indicating that no more bytes will be supplied
+/// and triggering the final decoding step to produce the remaining output.
+///
+/// # Parameters
+///
+/// - `self`: The `Decoder` instance used to finalize the decoding process.
+///
+/// # Returns
+///
+/// A `String` representing the final part of the decoded content, after all byte sequences have been processed.
+///
+/// # Errors
+///
+/// `MalformedError`: This error is raised if the remaining byte sequence is not properly formatted according to the specified encoding.
+/// `TruncatedError`: This error is raised if the remaining byte sequence ends prematurely, implying that more data was expected for complete decoding.
 pub fn finish!(self : Decoder) -> String {
   self.decode!(b"", stream=false)
 }
 
 ///|
+/// Decode the given byte sequence using the specified `Decoder` and return the resulting string, replacing any invalid sequences with the Unicode Replacement Character (`U+FFFD`).
+///
+/// This function can work in streaming mode where bytes are consumed incrementally.
+/// When `stream` is `false`, it indicates the end of the input and triggers the final decoding step.
+///
+/// # Parameters
+///
+/// - `self`: The `Decoder` instance used to decode the byte sequence.
+/// - `input`: The byte sequence to be decoded.
+/// - `stream~`: A boolean indicating whether more bytes will be supplied for decoding. It defaults to `false`.
+///
+/// # Returns
+///
+/// A `String` representing the decoded content from the input byte sequence, with any invalid sequences replaced by the Unicode Replacement Character (`U+FFFD`).
 pub fn decode_lossy(
   self : Decoder,
   input : Bytes,
@@ -125,11 +224,35 @@ pub fn decode_lossy(
 }
 
 ///|
+/// Consume the given byte sequence using the specified `Decoder` and return the resulting string incrementally, replacing any invalid sequences with the Unicode Replacement Character (`U+FFFD`).
+///
+/// This function calls `decode_lossy` with the `stream` parameter set to `true`, indicating that more bytes will follow for decoding.
+///
+/// # Parameters
+///
+/// - `self`: The `Decoder` instance used to consume and decode the byte sequence.
+/// - `input`: The byte sequence to be consumed and decoded incrementally.
+///
+/// # Returns
+///
+/// A `String` representing the partially decoded content from the input byte sequence, with any invalid sequences replaced by the Unicode Replacement Character (`U+FFFD`), as more bytes are expected.
 pub fn lossy_consume(self : Decoder, input : Bytes) -> String {
   self.decode_lossy(input, stream=true)
 }
 
 ///|
+/// Finalize the lossy decoding process and return the remaining decoded string, replacing any invalid sequences with the Unicode Replacement Character (`U+FFFD`).
+///
+/// This function calls `decode_lossy` with the `stream` parameter set to `false`, indicating that no more bytes will be supplied
+/// and triggering the final decoding step to produce the remaining output.
+///
+/// # Parameters
+///
+/// - `self`: The `Decoder` instance used to finalize the lossy decoding process.
+///
+/// # Returns
+///
+/// A `String` representing the final part of the decoded content, with any invalid sequences replaced by the Unicode Replacement Character (`U+FFFD`), after all byte sequences have been processed.
 pub fn lossy_finish(self : Decoder) -> String {
   self.decode_lossy(b"", stream=false)
 }

--- a/encoding/decoding.mbt
+++ b/encoding/decoding.mbt
@@ -78,13 +78,13 @@ pub fn decode!(self : Decoder, input : Bytes, stream~ : Bool = false) -> String 
 }
 
 ///|
-pub fn decode_continue!(self : Decoder, input : Bytes) -> String {
+pub fn consume!(self : Decoder, input : Bytes) -> String {
   self.decode!(input, stream=true)
 }
 
 ///|
-pub fn decode_finish!(self : Decoder, input~ : Bytes = b"") -> String {
-  self.decode!(input, stream=false)
+pub fn finish!(self : Decoder) -> String {
+  self.decode!(b"", stream=false)
 }
 
 ///|
@@ -125,13 +125,13 @@ pub fn decode_lossy(
 }
 
 ///|
-pub fn decode_lossy_continue(self : Decoder, input : Bytes) -> String {
+pub fn lossy_consume(self : Decoder, input : Bytes) -> String {
   self.decode_lossy(input, stream=true)
 }
 
 ///|
-pub fn decode_lossy_finish(self : Decoder, input~ : Bytes = b"") -> String {
-  self.decode_lossy(input, stream=false)
+pub fn lossy_finish(self : Decoder) -> String {
+  self.decode_lossy(b"", stream=false)
 }
 
 ///|

--- a/encoding/decoding_test.mbt
+++ b/encoding/decoding_test.mbt
@@ -16,11 +16,19 @@
 
 ///|
 test "streaming decoding UTF8 rabbit" {
-  let inputs = [b"abc", b"\xf0\x9f", b"\x90\xb0"] // utf8(🐰) == F0 9F 90 B0
+  let inputs = [b"abc", b"\xf0", b"\x9f\x90\xb0"] // UTF8(🐰) == <F09F 90B0>
   let decoder = @encoding.decoder(UTF8)
   inspect!(decoder.decode!(inputs[0]), content="abc")
   inspect!(decoder.decode!(inputs[1]), content="")
   inspect!(decoder.decode!(inputs[2]), content="🐰")
+}
+
+///|
+test "streaming decoding UTF16LE rabbit" {
+  let inputs = [b"\x3D\xD8", b"\x30\xDC"] // UTF16LE(🐰) == <3DD8 30DC>
+  let decoder = @encoding.decoder(UTF16LE)
+  inspect!(decoder.decode!(inputs[0]), content="")
+  inspect!(decoder.decode!(inputs[1]), content="🐰")
 }
 
 ///|
@@ -170,7 +178,7 @@ test "streaming decoding UTF16BE Tao71" {
 // In one go
 
 ///|
-test "decoding String (UTF16LE encoded) to String (buffer.write_bytes) in one go" {
+test "decoding String (UTF16LE encoded) to String (buffer.write_bytes)" {
   let src = "你好👀"
   let buf = @buffer.new(size_hint=src.to_bytes().length())
   buf.write_bytes(src.to_bytes())
@@ -186,7 +194,7 @@ test "decoding String (UTF16LE encoded) to String (buffer.write_bytes) in one go
 }
 
 ///|
-test "decoding String (UTF16LE encoded) to String (buffer.write_char) in one go" {
+test "decoding String (UTF16LE encoded) to String (buffer.write_char)" {
   let src = "👋再见"
   let buf = @buffer.new(size_hint=10)
   for s in src {
@@ -204,7 +212,7 @@ test "decoding String (UTF16LE encoded) to String (buffer.write_char) in one go"
 }
 
 ///|
-test "decoding UTF16LE encoded data to String in one go" {
+test "decoding UTF16LE encoded data to String" {
   let buf = @buffer.new(size_hint=10)
   buf.write_bytes(b"\x60\x4f") // 你
   buf.write_bytes(b"\x7d\x59") // 好
@@ -221,7 +229,7 @@ test "decoding UTF16LE encoded data to String in one go" {
 }
 
 ///|
-test "decoding UTF16 (alias for UTF16LE) encoded data to String in one go" {
+test "decoding UTF16 (alias for UTF16LE) encoded data to String" {
   let buf = @buffer.new(size_hint=20)
   buf.write_bytes(b"\x65\x18")
   buf.write_bytes(b"\x20\x18")
@@ -242,7 +250,7 @@ test "decoding UTF16 (alias for UTF16LE) encoded data to String in one go" {
 }
 
 ///|
-test "decoding UTF16BE encoded data to String in one go" {
+test "decoding UTF16BE encoded data to String" {
   let buf = @buffer.new(size_hint=10)
   buf.write_bytes(b"\xd8\x3d\xdc\x08")
   buf.write_bytes(b"\xd8\x3d\xdc\x31")
@@ -260,7 +268,7 @@ test "decoding UTF16BE encoded data to String in one go" {
 }
 
 ///|
-test "decoding UTF8 encoded data to String in one go" {
+test "decoding UTF8 encoded data to String" {
   let buf = @buffer.new(size_hint=10)
   buf.write_bytes(b"\xe4\xbd\xa0") // 你
   buf.write_bytes(b"\xe5\xa5\xbd") // 好
@@ -277,7 +285,7 @@ test "decoding UTF8 encoded data to String in one go" {
 }
 
 ///|
-test "decoding UTF8 encoded bytes to String in one go" {
+test "decoding UTF8 encoded bytes to String" {
   let src = "👋再见"
   let buf = @buffer.new(size_hint=10)
   for s in src {
@@ -295,7 +303,7 @@ test "decoding UTF8 encoded bytes to String in one go" {
 }
 
 ///|
-test "decoding UTF8 encoded data in one go" {
+test "decoding UTF8 encoded data" {
   let src = "👋再见"
   let buf = @buffer.new(size_hint=10)
   for s in src {
@@ -313,7 +321,7 @@ test "decoding UTF8 encoded data in one go" {
 }
 
 ///|
-test "panic decoding UTF16LE encoded data with UTF8 in one go" {
+test "panic decoding UTF16LE encoded data with UTF8" {
   let src = "跑步🏃游泳🏊"
   let buf = @buffer.new(size_hint=10)
   for s in src {
@@ -326,16 +334,12 @@ test "panic decoding UTF16LE encoded data with UTF8 in one go" {
     ,
   )
   let decoder = @encoding.decoder(UTF8)
-  // FIXME: how to U_REP?
+  // NOTE: Expected to be malformed here
   decoder.decode!(buf.to_bytes()) |> ignore
-  // inspect!(
-  //   chars.iter().collect(),
-  //   content="['э', 'e', 'k', '<', '�', '�', 'n', '�', '�']",
-  // )
 }
 
 ///|
-test "decoding UTF8 encoded data with UTF16LE in one go" {
+test "decoding UTF8 encoded data with UTF16LE" {
   let src = "跑步🏃游泳🏊"
   let buf = @buffer.new(size_hint=10)
   for s in src {
@@ -357,7 +361,7 @@ test "decoding UTF8 encoded data with UTF16LE in one go" {
 }
 
 ///|
-test "decoding UTF16BE encoded data with UTF8 in one go" {
+test "decoding UTF16BE encoded data with UTF8" {
   let src = "跑步🏃游泳🏊"
   let buf = @buffer.new(size_hint=10)
   for s in src {
@@ -371,13 +375,14 @@ test "decoding UTF16BE encoded data with UTF8 in one go" {
   )
   let decoder = @encoding.decoder(UTF8)
   let chars = decoder.decode!(buf.to_bytes())
-  // NOTE: decoder generates `Refill` and waits for continued input,
-  //       so here is an empty string (`String::default()`)
+  // NOTE: decoder generates `Refill` and waits for continued input.
+  //       This is a decoded string, it is empty,
+  //       indicating that no UTF16BE bytes were successfully UTF8 decoded into a string
   inspect!(chars, content="")
 }
 
 ///|
-test "decoding UTF8 encoded data with UTF16BE in one go" {
+test "decoding UTF8 encoded data with UTF16BE" {
   let src = "跑步🏃游泳🏊"
   let buf = @buffer.new(size_hint=10)
   for s in src {
@@ -399,7 +404,7 @@ test "decoding UTF8 encoded data with UTF16BE in one go" {
 }
 
 ///|
-test "decoding UTF16LE encoded data with UTF16BE in one go" {
+test "decoding UTF16LE encoded data with UTF16BE" {
   let src = "跑步🏃游泳🏊"
   let buf = @buffer.new(size_hint=10)
   for s in src {
@@ -421,7 +426,7 @@ test "decoding UTF16LE encoded data with UTF16BE in one go" {
 }
 
 ///|
-test "decoding UTF16BE encoded data with UTF16LE in one go" {
+test "decoding UTF16BE encoded data with UTF16LE" {
   let src = "跑步🏃游泳🏊"
   let buf = @buffer.new(size_hint=10)
   for s in src {
@@ -440,6 +445,96 @@ test "decoding UTF16BE encoded data with UTF16LE in one go" {
     chars.to_array(),
     content="['톍', '敫', '㳘', '쏟', '㡮', '', '㳘', '쫟']",
   )
+}
+
+///|
+test "lossy decoding UTF16LE encoded data with UTF8" {
+  let src = "跑步🏃游泳🏊"
+  let buf = @buffer.new(size_hint=10)
+  for s in src {
+    @encoding.write_utf16le_char(buf, s)
+  }
+  inspect!(
+    buf.to_bytes(),
+    content=
+      #|b"\xd1\x8d\x65\x6b\x3c\xd8\xc3\xdf\x38\x6e\xf3\x6c\x3c\xd8\xca\xdf"
+    ,
+  )
+  let decoder = @encoding.decoder(UTF8)
+  let chars = decoder.decode_lossy(buf.to_bytes())
+  inspect!(
+    chars.to_array(),
+    content="['э', 'e', 'k', '<', '�', '�', 'n', '�', '�']",
+  )
+}
+
+// ///|
+// test "lossy decoding UTF16LE incorrectly encoded data to String" {
+//   let buf = @buffer.new(size_hint=10)
+//   buf.write_bytes(b"") // 👀 \x3d\xd8\x40\xdc
+//   inspect!(
+//     buf.to_bytes(),
+//     content=
+//       #|b"\x60\x40\x70\x50\x00\xd0\x40\x00"
+//     ,
+//   )
+//   let decoder = @encoding.decoder(UTF16LE)
+//   let chars = decoder.decode!(buf.to_bytes())
+//   inspect!(chars, content="你好👀")
+// }
+
+// ///|
+// test "lossy decoding UTF16 (alias for UTF16LE) incorrectly encoded data to String" {
+//   let buf = @buffer.new(size_hint=20)
+//   buf.write_bytes(b"\x65\x18")
+//   buf.write_bytes(b"\x20\x18")
+//   buf.write_bytes(b"\x73\x18")
+//   buf.write_bytes(b"\x64\x18")
+//   buf.write_bytes(b"\x73\x18")
+//   buf.write_bytes(b"\x36\x18")
+//   buf.write_bytes(b"\x20\x18")
+//   inspect!(
+//     buf.to_bytes(),
+//     content=
+//       #|b"\x65\x18\x20\x18\x73\x18\x64\x18\x73\x18\x36\x18\x20\x18"
+//     ,
+//   )
+//   let decoder = @encoding.decoder(UTF16)
+//   let chars = decoder.decode!(buf.to_bytes())
+//   inspect!(chars, content="ᡥᠠᡳᡤᡳᠶᠠ")
+// }
+
+///|
+test "lossy decoding UTF16BE incorrectly encoded data to String" {
+  let src = b"\xD8\x00"
+  inspect!(
+    src,
+    content=
+      #|b"\xd8\x00"
+    ,
+  )
+  let decoder = @encoding.decoder(UTF16BE)
+  let chars = decoder.decode_lossy(src, stream=false)
+  inspect!(chars, content="�")
+  assert_eq!(chars[0], @encoding.U_REP)
+}
+
+///|
+/// Well-Formed UTF-8 Byte Sequences
+/// https://www.unicode.org/versions/Unicode16.0.0/core-spec/chapter-3/#G27506
+test "lossy decoding UTF8 incorrectly encoded data to String" {
+  let buf = @buffer.new(size_hint=10)
+  buf.write_bytes(b"\xE0\x9F\x80")
+  inspect!(
+    buf.to_bytes(),
+    content=
+      #|b"\xe0\x9f\x80"
+    ,
+  )
+  let decoder = @encoding.decoder(UTF8)
+  let chars = decoder.decode_lossy(buf.to_bytes())
+  inspect!(chars, content="�")
+  assert_eq!(chars[0], @encoding.U_REP)
 }
 
 ///| https://learn.microsoft.com/en-us/windows/win32/intl/surrogates-and-supplementary-characters

--- a/encoding/decoding_test.mbt
+++ b/encoding/decoding_test.mbt
@@ -189,12 +189,7 @@ test "decoding String (UTF16LE encoded) to String (buffer.write_bytes)" {
   let src = "你好👀"
   let buf = @buffer.new(size_hint=src.to_bytes().length())
   buf.write_bytes(src.to_bytes())
-  inspect!(
-    buf.to_bytes(),
-    content=
-      #|b"\x60\x4f\x7d\x59\x3d\xd8\x40\xdc"
-    ,
-  )
+  assert_eq!(buf.to_bytes(), b"\x60\x4f\x7d\x59\x3d\xd8\x40\xdc")
   let decoder = @encoding.decoder(UTF16LE)
   let chars = decoder.decode!(buf.to_bytes())
   inspect!(chars, content=src)
@@ -207,12 +202,7 @@ test "decoding String (UTF16LE encoded) to String (buffer.write_char)" {
   for s in src {
     buf.write_char(s)
   }
-  inspect!(
-    buf.to_bytes(),
-    content=
-      #|b"\x3d\xd8\x4b\xdc\x8d\x51\xc1\x89"
-    ,
-  )
+  assert_eq!(buf.to_bytes(), b"\x3d\xd8\x4b\xdc\x8d\x51\xc1\x89")
   let decoder = @encoding.decoder(UTF16LE)
   let chars = decoder.decode!(buf.to_bytes())
   inspect!(chars, content=src)
@@ -224,12 +214,7 @@ test "decoding UTF16LE encoded data to String" {
   buf.write_bytes(b"\x60\x4f") // 你
   buf.write_bytes(b"\x7d\x59") // 好
   buf.write_bytes(b"\x3d\xd8\x40\xdc") // 👀
-  inspect!(
-    buf.to_bytes(),
-    content=
-      #|b"\x60\x4f\x7d\x59\x3d\xd8\x40\xdc"
-    ,
-  )
+  assert_eq!(buf.to_bytes(), b"\x60\x4f\x7d\x59\x3d\xd8\x40\xdc")
   let decoder = @encoding.decoder(UTF16LE)
   let chars = decoder.decode!(buf.to_bytes())
   inspect!(chars, content="你好👀")
@@ -245,11 +230,9 @@ test "decoding UTF16 (alias for UTF16LE) encoded data to String" {
   buf.write_bytes(b"\x73\x18")
   buf.write_bytes(b"\x36\x18")
   buf.write_bytes(b"\x20\x18")
-  inspect!(
+  assert_eq!(
     buf.to_bytes(),
-    content=
-      #|b"\x65\x18\x20\x18\x73\x18\x64\x18\x73\x18\x36\x18\x20\x18"
-    ,
+    b"\x65\x18\x20\x18\x73\x18\x64\x18\x73\x18\x36\x18\x20\x18",
   )
   let decoder = @encoding.decoder(UTF16)
   let chars = decoder.decode!(buf.to_bytes())
@@ -263,11 +246,9 @@ test "decoding UTF16BE encoded data to String" {
   buf.write_bytes(b"\xd8\x3d\xdc\x31")
   buf.write_bytes(b"\xd8\x3d\xdc\x07")
   buf.write_bytes(b"\xd8\x3d\xdc\x30")
-  inspect!(
+  assert_eq!(
     buf.to_bytes(),
-    content=
-      #|b"\xd8\x3d\xdc\x08\xd8\x3d\xdc\x31\xd8\x3d\xdc\x07\xd8\x3d\xdc\x30"
-    ,
+    b"\xd8\x3d\xdc\x08\xd8\x3d\xdc\x31\xd8\x3d\xdc\x07\xd8\x3d\xdc\x30",
   )
   let decoder = @encoding.decoder(UTF16BE)
   let chars = decoder.decode!(buf.to_bytes())
@@ -280,12 +261,7 @@ test "decoding UTF8 encoded data to String" {
   buf.write_bytes(b"\xe4\xbd\xa0") // 你
   buf.write_bytes(b"\xe5\xa5\xbd") // 好
   buf.write_bytes(b"\xf0\x9f\x91\x80") // 👀
-  inspect!(
-    buf.to_bytes(),
-    content=
-      #|b"\xe4\xbd\xa0\xe5\xa5\xbd\xf0\x9f\x91\x80"
-    ,
-  )
+  assert_eq!(buf.to_bytes(), b"\xe4\xbd\xa0\xe5\xa5\xbd\xf0\x9f\x91\x80")
   let decoder = @encoding.decoder(UTF8)
   let chars = decoder.decode!(buf.to_bytes())
   inspect!(chars, content="你好👀")
@@ -298,12 +274,7 @@ test "decoding UTF8 encoded bytes to String" {
   for s in src {
     @encoding.write_utf8_char(buf, s)
   }
-  inspect!(
-    buf.to_bytes(),
-    content=
-      #|b"\xf0\x9f\x91\x8b\xe5\x86\x8d\xe8\xa7\x81"
-    ,
-  )
+  assert_eq!(buf.to_bytes(), b"\xf0\x9f\x91\x8b\xe5\x86\x8d\xe8\xa7\x81")
   let decoder = @encoding.decoder(UTF8)
   let chars = decoder.decode!(buf.to_bytes())
   inspect!(chars, content=src)
@@ -316,12 +287,7 @@ test "decoding UTF8 encoded data" {
   for s in src {
     @encoding.write_utf8_char(buf, s)
   }
-  inspect!(
-    buf.to_bytes(),
-    content=
-      #|b"\xf0\x9f\x91\x8b\xe5\x86\x8d\xe8\xa7\x81"
-    ,
-  )
+  assert_eq!(buf.to_bytes(), b"\xf0\x9f\x91\x8b\xe5\x86\x8d\xe8\xa7\x81")
   let decoder = @encoding.decoder(UTF8)
   let chars = decoder.decode!(buf.to_bytes())
   inspect!(chars.iter().collect(), content="['👋', '再', '见']")
@@ -334,11 +300,9 @@ test "decoding UTF16LE encoded data with UTF8" {
   for s in src {
     @encoding.write_utf16le_char(buf, s)
   }
-  inspect!(
+  assert_eq!(
     buf.to_bytes(),
-    content=
-      #|b"\xd1\x8d\x65\x6b\x3c\xd8\xc3\xdf\x38\x6e\xf3\x6c\x3c\xd8\xca\xdf"
-    ,
+    b"\xd1\x8d\x65\x6b\x3c\xd8\xc3\xdf\x38\x6e\xf3\x6c\x3c\xd8\xca\xdf",
   )
   let decoder = @encoding.decoder(UTF8)
   // NOTE: Expected to be malformed here
@@ -357,11 +321,9 @@ test "decoding UTF8 encoded data with UTF16LE" {
   for s in src {
     @encoding.write_utf8_char(buf, s)
   }
-  inspect!(
+  assert_eq!(
     buf.to_bytes(),
-    content=
-      #|b"\xe8\xb7\x91\xe6\xad\xa5\xf0\x9f\x8f\x83\xe6\xb8\xb8\xe6\xb3\xb3\xf0\x9f\x8f\x8a"
-    ,
+    b"\xe8\xb7\x91\xe6\xad\xa5\xf0\x9f\x8f\x83\xe6\xb8\xb8\xe6\xb3\xb3\xf0\x9f\x8f\x8a",
   )
   let decoder = @encoding.decoder(UTF16LE)
   let chars = decoder.decode!(buf.to_bytes())
@@ -379,11 +341,9 @@ test "decoding UTF16BE encoded data with UTF8" {
   for s in src {
     @encoding.write_utf16be_char(buf, s)
   }
-  inspect!(
+  assert_eq!(
     buf.to_bytes(),
-    content=
-      #|b"\x8d\xd1\x6b\x65\xd8\x3c\xdf\xc3\x6e\x38\x6c\xf3\xd8\x3c\xdf\xca"
-    ,
+    b"\x8d\xd1\x6b\x65\xd8\x3c\xdf\xc3\x6e\x38\x6c\xf3\xd8\x3c\xdf\xca",
   )
   let decoder = @encoding.decoder(UTF8)
   // NOTE: Expected to be malformed here
@@ -402,11 +362,9 @@ test "decoding UTF8 encoded data with UTF16BE" {
   for s in src {
     @encoding.write_utf8_char(buf, s)
   }
-  inspect!(
+  assert_eq!(
     buf.to_bytes(),
-    content=
-      #|b"\xe8\xb7\x91\xe6\xad\xa5\xf0\x9f\x8f\x83\xe6\xb8\xb8\xe6\xb3\xb3\xf0\x9f\x8f\x8a"
-    ,
+    b"\xe8\xb7\x91\xe6\xad\xa5\xf0\x9f\x8f\x83\xe6\xb8\xb8\xe6\xb3\xb3\xf0\x9f\x8f\x8a",
   )
   let decoder = @encoding.decoder(UTF16BE)
   let chars = decoder.decode!(buf.to_bytes())
@@ -424,11 +382,9 @@ test "decoding UTF16LE encoded data with UTF16BE" {
   for s in src {
     @encoding.write_utf16le_char(buf, s)
   }
-  inspect!(
+  assert_eq!(
     buf.to_bytes(),
-    content=
-      #|b"\xd1\x8d\x65\x6b\x3c\xd8\xc3\xdf\x38\x6e\xf3\x6c\x3c\xd8\xca\xdf"
-    ,
+    b"\xd1\x8d\x65\x6b\x3c\xd8\xc3\xdf\x38\x6e\xf3\x6c\x3c\xd8\xca\xdf",
   )
   let decoder = @encoding.decoder(UTF16BE)
   let chars = decoder.decode!(buf.to_bytes())
@@ -446,11 +402,9 @@ test "decoding UTF16BE encoded data with UTF16LE" {
   for s in src {
     @encoding.write_utf16be_char(buf, s)
   }
-  inspect!(
+  assert_eq!(
     buf.to_bytes(),
-    content=
-      #|b"\x8d\xd1\x6b\x65\xd8\x3c\xdf\xc3\x6e\x38\x6c\xf3\xd8\x3c\xdf\xca"
-    ,
+    b"\x8d\xd1\x6b\x65\xd8\x3c\xdf\xc3\x6e\x38\x6c\xf3\xd8\x3c\xdf\xca",
   )
   let decoder = @encoding.decoder(UTF16LE)
   let chars = decoder.decode!(buf.to_bytes())
@@ -468,11 +422,9 @@ test "lossy decoding UTF16LE encoded data with UTF8" {
   for s in src {
     @encoding.write_utf16le_char(buf, s)
   }
-  inspect!(
+  assert_eq!(
     buf.to_bytes(),
-    content=
-      #|b"\xd1\x8d\x65\x6b\x3c\xd8\xc3\xdf\x38\x6e\xf3\x6c\x3c\xd8\xca\xdf"
-    ,
+    b"\xd1\x8d\x65\x6b\x3c\xd8\xc3\xdf\x38\x6e\xf3\x6c\x3c\xd8\xca\xdf",
   )
   let decoder = @encoding.decoder(UTF8)
   let chars = decoder.decode_lossy(buf.to_bytes())
@@ -485,12 +437,7 @@ test "lossy decoding UTF16LE encoded data with UTF8" {
 ///|
 test "lossy decoding UTF16LE incorrectly encoded data to String" {
   let src = b"\x00\xD8"
-  inspect!(
-    src,
-    content=
-      #|b"\x00\xd8"
-    ,
-  )
+  assert_eq!(src, b"\x00\xd8")
   let decoder = @encoding.decoder(UTF16LE)
   let chars = decoder.decode_lossy(src, stream=false)
   inspect!(chars, content="�")
@@ -501,12 +448,7 @@ test "lossy decoding UTF16LE incorrectly encoded data to String" {
 ///|
 test "lossy decoding UTF16 (alias for UTF16LE) incorrectly encoded data to String" {
   let src = b"\x00\xD8"
-  inspect!(
-    src,
-    content=
-      #|b"\x00\xd8"
-    ,
-  )
+  assert_eq!(src, b"\x00\xd8")
   let decoder = @encoding.decoder(UTF16)
   let chars = decoder.decode_lossy(src, stream=false)
   inspect!(chars, content="�")
@@ -517,12 +459,7 @@ test "lossy decoding UTF16 (alias for UTF16LE) incorrectly encoded data to Strin
 ///|
 test "lossy decoding UTF16BE incorrectly encoded data to String" {
   let src = b"\xD8\x00"
-  inspect!(
-    src,
-    content=
-      #|b"\xd8\x00"
-    ,
-  )
+  assert_eq!(src, b"\xd8\x00")
   let decoder = @encoding.decoder(UTF16BE)
   let chars = decoder.decode_lossy(src, stream=false)
   inspect!(chars, content="�")
@@ -533,12 +470,7 @@ test "lossy decoding UTF16BE incorrectly encoded data to String" {
 ///|
 test "lossy decoding UTF16BE which is `HI+!LO`" {
   let src = b"\xD8\x00\x00\x48"
-  inspect!(
-    src,
-    content=
-      #|b"\xd8\x00\x00\x48"
-    ,
-  )
+  assert_eq!(src, b"\xd8\x00\x00\x48")
   let decoder = @encoding.decoder(UTF16BE)
   let chars = decoder.decode_lossy(src, stream=false)
 
@@ -557,12 +489,7 @@ test "lossy decoding UTF16BE which is `HI+!LO`" {
 test "lossy decoding UTF8 incorrectly encoded data to String" {
   let buf = @buffer.new(size_hint=10)
   buf.write_bytes(b"\xE0\x9F\x80")
-  inspect!(
-    buf.to_bytes(),
-    content=
-      #|b"\xe0\x9f\x80"
-    ,
-  )
+  assert_eq!(buf.to_bytes(), b"\xe0\x9f\x80")
   let decoder = @encoding.decoder(UTF8)
   let chars = decoder.decode_lossy(buf.to_bytes())
   inspect!(chars, content="�")

--- a/encoding/decoding_test.mbt
+++ b/encoding/decoding_test.mbt
@@ -66,6 +66,107 @@ test "streaming decoding UTF16LE ASCII" {
   inspect!(acc, content=ascii)
 }
 
+///|
+test "streaming decoding UTF8 Emoji" {
+  let art =
+    #|   🎩
+    #|   👶
+    #| ✋👕🌂
+    #|   ‼️
+    #|   👞👞
+  let art_bytes = @encoding.encode(UTF8, art)
+  let from_array = Bytes::from_array
+  let decoder = @encoding.decoder(UTF8)
+  let buf = @buffer.new(size_hint=art_bytes.length())
+  buf.write_bytes(art_bytes)
+  let chunks = buf.contents().to_array().chunks(13)
+  assert_eq!(chunks.length(), 4)
+
+  // chunk by chunk
+  assert_eq!(
+    from_array(chunks[0]),
+    b"\x20\x20\x20\xf0\x9f\x8e\xa9\x0a\x20\x20\x20\xf0\x9f",
+  )
+  inspect!(decoder.decode!(from_array(chunks[0])), content="   🎩\n   ")
+  assert_eq!(
+    from_array(chunks[1]),
+    b"\x91\xb6\x0a\x20\xe2\x9c\x8b\xf0\x9f\x91\x95\xf0\x9f",
+  )
+  inspect!(decoder.decode!(from_array(chunks[1])), content="👶\n ✋👕")
+  assert_eq!(
+    from_array(chunks[2]),
+    b"\x8c\x82\x0a\x20\x20\x20\xe2\x80\xbc\xef\xb8\x8f\x0a",
+  )
+  inspect!(decoder.decode!(from_array(chunks[2])), content="🌂\n   ‼️\n")
+  assert_eq!(
+    from_array(chunks[3]),
+    b"\x20\x20\x20\xf0\x9f\x91\x9e\xf0\x9f\x91\x9e",
+  )
+  inspect!(decoder.decode!(from_array(chunks[3])), content="   👞👞")
+
+  // check accumulator
+  let decoder = @encoding.decoder(UTF8)
+  let mut acc = ""
+  for chunk in art_bytes.to_array().chunks(7) {
+    acc += decoder.decode!(from_array(chunk))
+  }
+  inspect!(acc, content=art)
+}
+
+///|
+test "streaming decoding UTF16BE Tao71" {
+  let tao71 = "知不知，尚矣；不知知，病也。圣人不病，以其病病，夫惟病病，是以不病。"
+  let tao71_bytes = @encoding.encode(UTF16BE, tao71)
+  let from_array = Bytes::from_array
+  let decoder = @encoding.decoder(UTF16BE)
+  let buf = @buffer.new(size_hint=tao71_bytes.length())
+  buf.write_bytes(tao71_bytes)
+  let chunks = buf.contents().to_array().chunks(17)
+  assert_eq!(chunks.length(), 4)
+
+  // chunk by chunk
+  assert_eq!(
+    from_array(chunks[0]),
+    b"\x77\xe5\x4e\x0d\x77\xe5\xff\x0c\x5c\x1a\x77\xe3\xff\x1b\x4e\x0d\x77",
+  )
+  inspect!(
+    decoder.decode!(from_array(chunks[0])),
+    content="知不知，尚矣；不",
+  )
+  assert_eq!(
+    from_array(chunks[1]),
+    b"\xe5\x77\xe5\xff\x0c\x75\xc5\x4e\x5f\x30\x02\x57\x23\x4e\xba\x4e\x0d",
+  )
+  inspect!(
+    decoder.decode!(from_array(chunks[1])),
+    content="知知，病也。圣人不",
+  )
+  assert_eq!(
+    from_array(chunks[2]),
+    b"\x75\xc5\xff\x0c\x4e\xe5\x51\x76\x75\xc5\x75\xc5\xff\x0c\x59\x2b\x60",
+  )
+  inspect!(
+    decoder.decode!(from_array(chunks[2])),
+    content="病，以其病病，夫",
+  )
+  assert_eq!(
+    from_array(chunks[3]),
+    b"\xdf\x75\xc5\x75\xc5\xff\x0c\x66\x2f\x4e\xe5\x4e\x0d\x75\xc5\x30\x02",
+  )
+  inspect!(
+    decoder.decode!(from_array(chunks[3])),
+    content="惟病病，是以不病。",
+  )
+
+  // check accumulator
+  let decoder = @encoding.decoder(UTF16BE)
+  let mut acc = ""
+  for chunk in tao71_bytes.to_array().chunks(7) {
+    acc += decoder.decode!(from_array(chunk))
+  }
+  inspect!(acc, content=tao71)
+}
+
 // In one go
 
 ///|

--- a/encoding/decoding_test.mbt
+++ b/encoding/decoding_test.mbt
@@ -474,7 +474,7 @@ test "lossy decoding UTF16BE which is `HI+!LO`" {
   let decoder = @encoding.decoder(UTF16BE)
   let chars = decoder.decode_lossy(src, stream=false)
 
-  // FIXME: should decode as many characters as possible
+  // FIXME(jinser): should decode as many characters as possible
   // > printf '\xD8\x00\x00\x48' | uconv --from-code UTF16BE --to-code UTF8 --from-callback substitute
   inspect!(chars, content="�") // ❌
   // inspect!(chars, content="�H") // ✅

--- a/encoding/decoding_test.mbt
+++ b/encoding/decoding_test.mbt
@@ -80,7 +80,7 @@ test "streaming decoding UTF16LE ASCII" {
     acc += decoder.decode_continue!(from_array(chunk))
   }
   decoder.decode_finish!() |> ignore
-  inspect!(acc, content=ascii)
+  assert_eq!(acc, ascii)
 }
 
 ///|
@@ -138,7 +138,7 @@ test "streaming decoding UTF8 Emoji" {
     acc += decoder.decode_continue!(from_array(chunk))
   }
   decoder.decode_finish!() |> ignore
-  inspect!(acc, content=art)
+  assert_eq!(acc, art)
 }
 
 ///|
@@ -193,7 +193,7 @@ test "streaming decoding UTF16BE Tao71" {
     acc += decoder.decode_continue!(from_array(chunk))
   }
   decoder.decode_finish!() |> ignore
-  inspect!(acc, content=tao71)
+  assert_eq!(acc, tao71)
 }
 
 // In one go
@@ -206,7 +206,7 @@ test "decoding String (UTF16LE encoded) to String (buffer.write_bytes)" {
   assert_eq!(buf.to_bytes(), b"\x60\x4f\x7d\x59\x3d\xd8\x40\xdc")
   let decoder = @encoding.decoder(UTF16LE)
   let chars = decoder.decode!(buf.to_bytes())
-  inspect!(chars, content=src)
+  assert_eq!(chars, src)
 }
 
 ///|
@@ -219,7 +219,7 @@ test "decoding String (UTF16LE encoded) to String (buffer.write_char)" {
   assert_eq!(buf.to_bytes(), b"\x3d\xd8\x4b\xdc\x8d\x51\xc1\x89")
   let decoder = @encoding.decoder(UTF16LE)
   let chars = decoder.decode!(buf.to_bytes())
-  inspect!(chars, content=src)
+  assert_eq!(chars, src)
 }
 
 ///|
@@ -291,7 +291,7 @@ test "decoding UTF8 encoded bytes to String" {
   assert_eq!(buf.to_bytes(), b"\xf0\x9f\x91\x8b\xe5\x86\x8d\xe8\xa7\x81")
   let decoder = @encoding.decoder(UTF8)
   let chars = decoder.decode!(buf.to_bytes())
-  inspect!(chars, content=src)
+  assert_eq!(chars, src)
 }
 
 ///|

--- a/encoding/decoding_test.mbt
+++ b/encoding/decoding_test.mbt
@@ -18,9 +18,9 @@
 test "streaming decoding UTF8 rabbit" {
   let inputs = [b"abc", b"\xf0", b"\x9f\x90\xb0"] // UTF8(🐰) == <F09F 90B0>
   let decoder = @encoding.decoder(UTF8)
-  inspect!(decoder.decode!(inputs[0]), content="abc")
-  inspect!(decoder.decode!(inputs[1]), content="")
-  inspect!(decoder.decode!(inputs[2]), content="🐰")
+  inspect!(decoder.decode_continue!(inputs[0]), content="abc")
+  inspect!(decoder.decode_continue!(inputs[1]), content="")
+  inspect!(decoder.decode_finish!(input=inputs[2]), content="🐰")
 }
 
 ///|
@@ -30,12 +30,12 @@ test "streaming decoding UTF16LE rabbit" {
     b"\x3D", b"\xD8\x30\xDC", b"\x3D\xD8", b"\x30\xDC", b"\x3D\xD8\x30", b"\xDC",
   ]
   let decoder = @encoding.decoder(UTF16LE)
-  inspect!(decoder.decode!(inputs[0]), content="")
-  inspect!(decoder.decode!(inputs[1]), content="🐰")
-  inspect!(decoder.decode!(inputs[2]), content="")
-  inspect!(decoder.decode!(inputs[3]), content="🐰")
-  inspect!(decoder.decode!(inputs[4]), content="")
-  inspect!(decoder.decode!(inputs[5]), content="🐰")
+  inspect!(decoder.decode_continue!(inputs[0]), content="")
+  inspect!(decoder.decode_continue!(inputs[1]), content="🐰")
+  inspect!(decoder.decode_continue!(inputs[2]), content="")
+  inspect!(decoder.decode_continue!(inputs[3]), content="🐰")
+  inspect!(decoder.decode_continue!(inputs[4]), content="")
+  inspect!(decoder.decode_finish!(input=inputs[5]), content="🐰")
 }
 
 ///|
@@ -53,31 +53,33 @@ test "streaming decoding UTF16LE ASCII" {
     from_array(chunks[0]),
     b"\x48\x00\x6f\x00\x77\x00\x20\x00\x64\x00\x6f\x00\x20\x00\x77\x00\x65",
   )
-  inspect!(decoder.decode!(from_array(chunks[0])), content="How do w")
+  inspect!(decoder.decode_continue!(from_array(chunks[0])), content="How do w")
   assert_eq!(
     from_array(chunks[1]),
     b"\x00\x20\x00\x67\x00\x72\x00\x61\x00\x73\x00\x70\x00\x20\x00\x61\x00",
   )
-  inspect!(decoder.decode!(from_array(chunks[1])), content="e grasp a")
+  inspect!(decoder.decode_continue!(from_array(chunks[1])), content="e grasp a")
   assert_eq!(
     from_array(chunks[2]),
     b"\x6c\x00\x6c\x00\x20\x00\x74\x00\x68\x00\x65\x00\x20\x00\x61\x00\x70",
   )
-  inspect!(decoder.decode!(from_array(chunks[2])), content="ll the a")
+  inspect!(decoder.decode_continue!(from_array(chunks[2])), content="ll the a")
   assert_eq!(
     from_array(chunks[3]),
     b"\x00\x70\x00\x6c\x00\x65\x00\x73\x00\x20\x00\x61\x00\x74\x00\x20\x00",
   )
-  inspect!(decoder.decode!(from_array(chunks[3])), content="pples at ")
+  inspect!(decoder.decode_continue!(from_array(chunks[3])), content="pples at ")
   assert_eq!(from_array(chunks[4]), b"\x6f\x00\x6e\x00\x63\x00\x65\x00\x3f\x00")
-  inspect!(decoder.decode!(from_array(chunks[4])), content="once?")
+  // `decode_finish!(input)` is an alias for `decode!(input, stream=false)`
+  inspect!(decoder.decode_finish!(input=from_array(chunks[4])), content="once?")
 
   // check accumulator
   let decoder = @encoding.decoder(UTF16LE)
   let mut acc = ""
   for chunk in ascii.to_bytes().to_array().chunks(7) {
-    acc += decoder.decode!(from_array(chunk))
+    acc += decoder.decode_continue!(from_array(chunk))
   }
+  decoder.decode_finish!() |> ignore
   inspect!(acc, content=ascii)
 }
 
@@ -102,29 +104,40 @@ test "streaming decoding UTF8 Emoji" {
     from_array(chunks[0]),
     b"\x20\x20\x20\xf0\x9f\x8e\xa9\x0a\x20\x20\x20\xf0\x9f",
   )
-  inspect!(decoder.decode!(from_array(chunks[0])), content="   🎩\n   ")
+  inspect!(
+    decoder.decode_continue!(from_array(chunks[0])),
+    content="   🎩\n   ",
+  )
   assert_eq!(
     from_array(chunks[1]),
     b"\x91\xb6\x0a\x20\xe2\x9c\x8b\xf0\x9f\x91\x95\xf0\x9f",
   )
-  inspect!(decoder.decode!(from_array(chunks[1])), content="👶\n ✋👕")
+  inspect!(
+    decoder.decode_continue!(from_array(chunks[1])),
+    content="👶\n ✋👕",
+  )
   assert_eq!(
     from_array(chunks[2]),
     b"\x8c\x82\x0a\x20\x20\x20\xe2\x80\xbc\xef\xb8\x8f\x0a",
   )
-  inspect!(decoder.decode!(from_array(chunks[2])), content="🌂\n   ‼️\n")
+  inspect!(
+    decoder.decode_continue!(from_array(chunks[2])),
+    content="🌂\n   ‼️\n",
+  )
   assert_eq!(
     from_array(chunks[3]),
     b"\x20\x20\x20\xf0\x9f\x91\x9e\xf0\x9f\x91\x9e",
   )
+  // stream default to false
   inspect!(decoder.decode!(from_array(chunks[3])), content="   👞👞")
 
   // check accumulator
   let decoder = @encoding.decoder(UTF8)
   let mut acc = ""
   for chunk in art_bytes.to_array().chunks(7) {
-    acc += decoder.decode!(from_array(chunk))
+    acc += decoder.decode_continue!(from_array(chunk))
   }
+  decoder.decode_finish!() |> ignore
   inspect!(acc, content=art)
 }
 
@@ -145,7 +158,7 @@ test "streaming decoding UTF16BE Tao71" {
     b"\x77\xe5\x4e\x0d\x77\xe5\xff\x0c\x5c\x1a\x77\xe3\xff\x1b\x4e\x0d\x77",
   )
   inspect!(
-    decoder.decode!(from_array(chunks[0])),
+    decoder.decode_continue!(from_array(chunks[0])),
     content="知不知，尚矣；不",
   )
   assert_eq!(
@@ -153,7 +166,7 @@ test "streaming decoding UTF16BE Tao71" {
     b"\xe5\x77\xe5\xff\x0c\x75\xc5\x4e\x5f\x30\x02\x57\x23\x4e\xba\x4e\x0d",
   )
   inspect!(
-    decoder.decode!(from_array(chunks[1])),
+    decoder.decode_continue!(from_array(chunks[1])),
     content="知知，病也。圣人不",
   )
   assert_eq!(
@@ -161,7 +174,7 @@ test "streaming decoding UTF16BE Tao71" {
     b"\x75\xc5\xff\x0c\x4e\xe5\x51\x76\x75\xc5\x75\xc5\xff\x0c\x59\x2b\x60",
   )
   inspect!(
-    decoder.decode!(from_array(chunks[2])),
+    decoder.decode_continue!(from_array(chunks[2])),
     content="病，以其病病，夫",
   )
   assert_eq!(
@@ -177,8 +190,9 @@ test "streaming decoding UTF16BE Tao71" {
   let decoder = @encoding.decoder(UTF16BE)
   let mut acc = ""
   for chunk in tao71_bytes.to_array().chunks(7) {
-    acc += decoder.decode!(from_array(chunk))
+    acc += decoder.decode_continue!(from_array(chunk))
   }
+  decoder.decode_finish!() |> ignore
   inspect!(acc, content=tao71)
 }
 

--- a/encoding/decoding_test.mbt
+++ b/encoding/decoding_test.mbt
@@ -12,10 +12,64 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// lossy
+// Streaming
 
 ///|
-test "lossy decoding String (UTF16LE encoded) to String (buffer.write_bytes)" {
+test "streaming decoding UTF8 rabbit" {
+  let inputs = [b"abc", b"\xf0\x9f", b"\x90\xb0"] // utf8(🐰) == F0 9F 90 B0
+  let decoder = @encoding.decoder(UTF8)
+  inspect!(decoder.decode!(inputs[0]), content="abc")
+  inspect!(decoder.decode!(inputs[1]), content="")
+  inspect!(decoder.decode!(inputs[2]), content="🐰")
+}
+
+///|
+test "streaming decoding UTF16LE ASCII" {
+  let ascii = "How do we grasp all the apples at once?"
+  let from_array = Bytes::from_array
+  let decoder = @encoding.decoder(UTF16LE)
+
+  // NOTE: `to_bytes` means `to_utf16le_bytes` to MoonBit String
+  let chunks = ascii.to_bytes().to_array().chunks(17)
+  assert_eq!(chunks.length(), 5)
+
+  // chunk by chunk
+  assert_eq!(
+    from_array(chunks[0]),
+    b"\x48\x00\x6f\x00\x77\x00\x20\x00\x64\x00\x6f\x00\x20\x00\x77\x00\x65",
+  )
+  inspect!(decoder.decode!(from_array(chunks[0])), content="How do w")
+  assert_eq!(
+    from_array(chunks[1]),
+    b"\x00\x20\x00\x67\x00\x72\x00\x61\x00\x73\x00\x70\x00\x20\x00\x61\x00",
+  )
+  inspect!(decoder.decode!(from_array(chunks[1])), content="e grasp a")
+  assert_eq!(
+    from_array(chunks[2]),
+    b"\x6c\x00\x6c\x00\x20\x00\x74\x00\x68\x00\x65\x00\x20\x00\x61\x00\x70",
+  )
+  inspect!(decoder.decode!(from_array(chunks[2])), content="ll the a")
+  assert_eq!(
+    from_array(chunks[3]),
+    b"\x00\x70\x00\x6c\x00\x65\x00\x73\x00\x20\x00\x61\x00\x74\x00\x20\x00",
+  )
+  inspect!(decoder.decode!(from_array(chunks[3])), content="pples at ")
+  assert_eq!(from_array(chunks[4]), b"\x6f\x00\x6e\x00\x63\x00\x65\x00\x3f\x00")
+  inspect!(decoder.decode!(from_array(chunks[4])), content="once?")
+
+  // check accumulator
+  let decoder = @encoding.decoder(UTF16LE)
+  let mut acc = ""
+  for chunk in ascii.to_bytes().to_array().chunks(7) {
+    acc += decoder.decode!(from_array(chunk))
+  }
+  inspect!(acc, content=ascii)
+}
+
+// In one go
+
+///|
+test "decoding String (UTF16LE encoded) to String (buffer.write_bytes) in one go" {
   let src = "你好👀"
   let buf = @buffer.new(size_hint=src.to_bytes().length())
   buf.write_bytes(src.to_bytes())
@@ -25,12 +79,13 @@ test "lossy decoding String (UTF16LE encoded) to String (buffer.write_bytes)" {
       #|b"\x60\x4f\x7d\x59\x3d\xd8\x40\xdc"
     ,
   )
-  let chars = @encoding.decode_lossy(UTF16LE, buf.to_bytes())
+  let decoder = @encoding.decoder(UTF16LE)
+  let chars = decoder.decode!(buf.to_bytes())
   inspect!(chars, content=src)
 }
 
 ///|
-test "lossy decoding String (UTF16LE encoded) to String (buffer.write_char)" {
+test "decoding String (UTF16LE encoded) to String (buffer.write_char) in one go" {
   let src = "👋再见"
   let buf = @buffer.new(size_hint=10)
   for s in src {
@@ -42,28 +97,30 @@ test "lossy decoding String (UTF16LE encoded) to String (buffer.write_char)" {
       #|b"\x3d\xd8\x4b\xdc\x8d\x51\xc1\x89"
     ,
   )
-  let chars = @encoding.decode_lossy(UTF16LE, buf.to_bytes())
+  let decoder = @encoding.decoder(UTF16LE)
+  let chars = decoder.decode!(buf.to_bytes())
   inspect!(chars, content=src)
 }
 
 ///|
-test "lossy decoding UTF16LE encoded data to String" {
+test "decoding UTF16LE encoded data to String in one go" {
   let buf = @buffer.new(size_hint=10)
-  buf.write_bytes(b"\x60\x4f")
-  buf.write_bytes(b"\x7d\x59")
-  buf.write_bytes(b"\x3d\xd8\x40\xdc")
+  buf.write_bytes(b"\x60\x4f") // 你
+  buf.write_bytes(b"\x7d\x59") // 好
+  buf.write_bytes(b"\x3d\xd8\x40\xdc") // 👀
   inspect!(
     buf.to_bytes(),
     content=
       #|b"\x60\x4f\x7d\x59\x3d\xd8\x40\xdc"
     ,
   )
-  let chars = @encoding.decode_lossy(UTF16LE, buf.to_bytes())
+  let decoder = @encoding.decoder(UTF16LE)
+  let chars = decoder.decode!(buf.to_bytes())
   inspect!(chars, content="你好👀")
 }
 
 ///|
-test "lossy decoding UTF16 (alias for UTF16LE) encoded data to String" {
+test "decoding UTF16 (alias for UTF16LE) encoded data to String in one go" {
   let buf = @buffer.new(size_hint=20)
   buf.write_bytes(b"\x65\x18")
   buf.write_bytes(b"\x20\x18")
@@ -78,12 +135,13 @@ test "lossy decoding UTF16 (alias for UTF16LE) encoded data to String" {
       #|b"\x65\x18\x20\x18\x73\x18\x64\x18\x73\x18\x36\x18\x20\x18"
     ,
   )
-  let chars = @encoding.decode_lossy(UTF16, buf.to_bytes())
+  let decoder = @encoding.decoder(UTF16)
+  let chars = decoder.decode!(buf.to_bytes())
   inspect!(chars, content="ᡥᠠᡳᡤᡳᠶᠠ")
 }
 
 ///|
-test "lossy decoding UTF16BE encoded data to String" {
+test "decoding UTF16BE encoded data to String in one go" {
   let buf = @buffer.new(size_hint=10)
   buf.write_bytes(b"\xd8\x3d\xdc\x08")
   buf.write_bytes(b"\xd8\x3d\xdc\x31")
@@ -95,28 +153,30 @@ test "lossy decoding UTF16BE encoded data to String" {
       #|b"\xd8\x3d\xdc\x08\xd8\x3d\xdc\x31\xd8\x3d\xdc\x07\xd8\x3d\xdc\x30"
     ,
   )
-  let chars = @encoding.decode_lossy(UTF16BE, buf.to_bytes())
+  let decoder = @encoding.decoder(UTF16BE)
+  let chars = decoder.decode!(buf.to_bytes())
   inspect!(chars, content="🐈🐱🐇🐰")
 }
 
 ///|
-test "lossy decoding UTF8 encoded data to String" {
+test "decoding UTF8 encoded data to String in one go" {
   let buf = @buffer.new(size_hint=10)
-  buf.write_bytes(b"\xe4\xbd\xa0")
-  buf.write_bytes(b"\xe5\xa5\xbd")
-  buf.write_bytes(b"\xf0\x9f\x91\x80")
+  buf.write_bytes(b"\xe4\xbd\xa0") // 你
+  buf.write_bytes(b"\xe5\xa5\xbd") // 好
+  buf.write_bytes(b"\xf0\x9f\x91\x80") // 👀
   inspect!(
     buf.to_bytes(),
     content=
       #|b"\xe4\xbd\xa0\xe5\xa5\xbd\xf0\x9f\x91\x80"
     ,
   )
-  let chars = @encoding.decode_lossy(UTF8, buf.to_bytes())
+  let decoder = @encoding.decoder(UTF8)
+  let chars = decoder.decode!(buf.to_bytes())
   inspect!(chars, content="你好👀")
 }
 
 ///|
-test "lossy decoding UTF8 encoded bytes to String" {
+test "decoding UTF8 encoded bytes to String in one go" {
   let src = "👋再见"
   let buf = @buffer.new(size_hint=10)
   for s in src {
@@ -128,12 +188,13 @@ test "lossy decoding UTF8 encoded bytes to String" {
       #|b"\xf0\x9f\x91\x8b\xe5\x86\x8d\xe8\xa7\x81"
     ,
   )
-  let chars = @encoding.decode_lossy(UTF8, buf.to_bytes())
+  let decoder = @encoding.decoder(UTF8)
+  let chars = decoder.decode!(buf.to_bytes())
   inspect!(chars, content=src)
 }
 
 ///|
-test "lossy decoding UTF8 encoded data" {
+test "decoding UTF8 encoded data in one go" {
   let src = "👋再见"
   let buf = @buffer.new(size_hint=10)
   for s in src {
@@ -145,12 +206,13 @@ test "lossy decoding UTF8 encoded data" {
       #|b"\xf0\x9f\x91\x8b\xe5\x86\x8d\xe8\xa7\x81"
     ,
   )
-  let chars = @encoding.decode_lossy(UTF8, buf.to_bytes())
+  let decoder = @encoding.decoder(UTF8)
+  let chars = decoder.decode!(buf.to_bytes())
   inspect!(chars.iter().collect(), content="['👋', '再', '见']")
 }
 
 ///|
-test "lossy decoding UTF16LE encoded data with UTF8" {
+test "panic decoding UTF16LE encoded data with UTF8 in one go" {
   let src = "跑步🏃游泳🏊"
   let buf = @buffer.new(size_hint=10)
   for s in src {
@@ -162,15 +224,17 @@ test "lossy decoding UTF16LE encoded data with UTF8" {
       #|b"\xd1\x8d\x65\x6b\x3c\xd8\xc3\xdf\x38\x6e\xf3\x6c\x3c\xd8\xca\xdf"
     ,
   )
-  let chars = @encoding.decode_lossy(UTF8, buf.to_bytes())
-  inspect!(
-    chars.iter().collect(),
-    content="['э', 'e', 'k', '<', '�', '�', 'n', '�', '�']",
-  )
+  let decoder = @encoding.decoder(UTF8)
+  // FIXME: how to U_REP?
+  decoder.decode!(buf.to_bytes()) |> ignore
+  // inspect!(
+  //   chars.iter().collect(),
+  //   content="['э', 'e', 'k', '<', '�', '�', 'n', '�', '�']",
+  // )
 }
 
 ///|
-test "lossy decoding UTF8 encoded data with UTF16LE" {
+test "decoding UTF8 encoded data with UTF16LE in one go" {
   let src = "跑步🏃游泳🏊"
   let buf = @buffer.new(size_hint=10)
   for s in src {
@@ -182,7 +246,9 @@ test "lossy decoding UTF8 encoded data with UTF16LE" {
       #|b"\xe8\xb7\x91\xe6\xad\xa5\xf0\x9f\x8f\x83\xe6\xb8\xb8\xe6\xb3\xb3\xf0\x9f\x8f\x8a"
     ,
   )
-  let chars = @encoding.decode_lossy(UTF16LE, buf.to_bytes())
+  let decoder = @encoding.decoder(UTF16LE)
+  let chars = decoder.decode!(buf.to_bytes())
+  // NOTE: Happens to be legal UTF16LE
   inspect!(
     chars.iter().collect(),
     content="['럨', '', 'ꖭ', '鿰', '莏', '룦', '', '뎳', '鿰', '誏']",
@@ -190,7 +256,7 @@ test "lossy decoding UTF8 encoded data with UTF16LE" {
 }
 
 ///|
-test "lossy decoding UTF16BE encoded data with UTF8" {
+test "decoding UTF16BE encoded data with UTF8 in one go" {
   let src = "跑步🏃游泳🏊"
   let buf = @buffer.new(size_hint=10)
   for s in src {
@@ -202,17 +268,15 @@ test "lossy decoding UTF16BE encoded data with UTF8" {
       #|b"\x8d\xd1\x6b\x65\xd8\x3c\xdf\xc3\x6e\x38\x6c\xf3\xd8\x3c\xdf\xca"
     ,
   )
-  let chars = @encoding.decode_lossy(UTF8, buf.to_bytes())
-  inspect!(
-    chars.iter().collect(),
-    content=
-      #|['�', '�', 'e', '�', '�', 'n', '8', 'l', '�', '�']
-    ,
-  )
+  let decoder = @encoding.decoder(UTF8)
+  let chars = decoder.decode!(buf.to_bytes())
+  // NOTE: decoder generates `Refill` and waits for continued input,
+  //       so here is an empty string (`String::default()`)
+  inspect!(chars, content="")
 }
 
 ///|
-test "lossy decoding UTF8 encoded data with UTF16BE" {
+test "decoding UTF8 encoded data with UTF16BE in one go" {
   let src = "跑步🏃游泳🏊"
   let buf = @buffer.new(size_hint=10)
   for s in src {
@@ -224,15 +288,17 @@ test "lossy decoding UTF8 encoded data with UTF16BE" {
       #|b"\xe8\xb7\x91\xe6\xad\xa5\xf0\x9f\x8f\x83\xe6\xb8\xb8\xe6\xb3\xb3\xf0\x9f\x8f\x8a"
     ,
   )
-  let chars = @encoding.decode_lossy(UTF16BE, buf.to_bytes())
+  let decoder = @encoding.decoder(UTF16BE)
+  let chars = decoder.decode!(buf.to_bytes())
+  // NOTE: Happens to be legal UTF16BE
   inspect!(
-    chars.iter().collect(),
+    chars.to_array(),
     content="['', '釦', '궥', '', '较', '', '룦', '뎳', '', '辊']",
   )
 }
 
 ///|
-test "lossy decoding UTF16LE encoded data with UTF16BE" {
+test "decoding UTF16LE encoded data with UTF16BE in one go" {
   let src = "跑步🏃游泳🏊"
   let buf = @buffer.new(size_hint=10)
   for s in src {
@@ -244,15 +310,17 @@ test "lossy decoding UTF16LE encoded data with UTF16BE" {
       #|b"\xd1\x8d\x65\x6b\x3c\xd8\xc3\xdf\x38\x6e\xf3\x6c\x3c\xd8\xca\xdf"
     ,
   )
-  let chars = @encoding.decode_lossy(UTF16BE, buf.to_bytes())
+  let decoder = @encoding.decoder(UTF16BE)
+  let chars = decoder.decode!(buf.to_bytes())
+  // NOTE: Happens to be legal UTF16BE
   inspect!(
-    chars.iter().collect(),
+    chars.to_array(),
     content="['톍', '敫', '㳘', '쏟', '㡮', '', '㳘', '쫟']",
   )
 }
 
 ///|
-test "lossy decoding UTF16BE encoded data with UTF16LE" {
+test "decoding UTF16BE encoded data with UTF16LE in one go" {
   let src = "跑步🏃游泳🏊"
   let buf = @buffer.new(size_hint=10)
   for s in src {
@@ -264,99 +332,41 @@ test "lossy decoding UTF16BE encoded data with UTF16LE" {
       #|b"\x8d\xd1\x6b\x65\xd8\x3c\xdf\xc3\x6e\x38\x6c\xf3\xd8\x3c\xdf\xca"
     ,
   )
-  let chars = @encoding.decode_lossy(UTF16LE, buf.to_bytes())
+  let decoder = @encoding.decoder(UTF16LE)
+  let chars = decoder.decode!(buf.to_bytes())
+  // NOTE: Happens to be legal UTF16LE
   inspect!(
-    chars.iter().collect(),
+    chars.to_array(),
     content="['톍', '敫', '㳘', '쏟', '㡮', '', '㳘', '쫟']",
   )
 }
 
-// strictly
+///| https://learn.microsoft.com/en-us/windows/win32/intl/surrogates-and-supplementary-characters
+/// > The first (high) surrogate is a 16-bit code value in the range U+D800 to U+DBFF.
+/// > The second (low) surrogate is a 16-bit code value in the range U+DC00 to U+DFFF.
+test "Not all UTF16LE is format-legal UTF16BE and vice versa" {
+  let bytes_le = b"\xD8\x00\xD9\x00"
 
-///|
-test "strictly decoding UTF16LE encoded data with UTF8" {
-  let src = "跑步🏃游泳🏊"
-  let buf = @buffer.new(size_hint=10)
-  for s in src {
-    @encoding.write_utf16le_char(buf, s)
-  }
-  inspect!(
-    buf.to_bytes(),
-    content=
-      #|b"\xd1\x8d\x65\x6b\x3c\xd8\xc3\xdf\x38\x6e\xf3\x6c\x3c\xd8\xca\xdf"
-    ,
-  )
-  let chars = @encoding.decode_strict(UTF8, buf.to_bytes())
-  inspect!(
-    chars.iter().collect(),
-    content=
-      #|[Ok('э'), Ok('e'), Ok('k'), Ok('<'), Err(b"\xd8\xc3"), Err(b"\xdf\x38"), Ok('n'), Err(b"\xf3\x6c\x3c\xd8"), Err(b"\xca\xdf")]
-    ,
-  )
-}
+  // valid in UTF16LE
+  let decoder_utf16le = @encoding.decoder(UTF16LE)
+  let chars_utf16le = decoder_utf16le.decode!(bytes_le)
+  inspect!(chars_utf16le, content="ØÙ")
 
-///|
-test "strictly decoding UTF8 encoded data with UTF16LE" {
-  let src = "跑步🏃游泳🏊"
-  let buf = @buffer.new(size_hint=10)
-  for s in src {
-    @encoding.write_utf8_char(buf, s)
-  }
-  inspect!(
-    buf.to_bytes(),
-    content=
-      #|b"\xe8\xb7\x91\xe6\xad\xa5\xf0\x9f\x8f\x83\xe6\xb8\xb8\xe6\xb3\xb3\xf0\x9f\x8f\x8a"
-    ,
-  )
-  let chars = @encoding.decode_strict(UTF16LE, buf.to_bytes())
-  inspect!(
-    chars.iter().collect(),
-    content=
-      #|[Ok('럨'), Ok(''), Ok('ꖭ'), Ok('鿰'), Ok('莏'), Ok('룦'), Ok(''), Ok('뎳'), Ok('鿰'), Ok('誏')]
-    ,
-  )
-}
+  // invalid in UTF16BE
+  let decoder_utf16be = @encoding.decoder(UTF16BE)
+  let malformedError = decoder_utf16be.decode?(bytes_le)
+  assert_true!(malformedError.is_err())
 
-///|
-test "strictly decoding UTF8 encoded data with UTF16BE" {
-  let src = "跑步🏃游泳🏊"
-  let buf = @buffer.new(size_hint=10)
-  for s in src {
-    @encoding.write_utf8_char(buf, s)
-  }
-  inspect!(
-    buf.to_bytes(),
-    content=
-      #|b"\xe8\xb7\x91\xe6\xad\xa5\xf0\x9f\x8f\x83\xe6\xb8\xb8\xe6\xb3\xb3\xf0\x9f\x8f\x8a"
-    ,
-  )
-  let chars = @encoding.decode_strict(UTF16BE, buf.to_bytes())
-  inspect!(
-    chars.iter().collect(),
-    content=
-      #|[Ok(''), Ok('釦'), Ok('궥'), Ok(''), Ok('较'), Ok(''), Ok('룦'), Ok('뎳'), Ok(''), Ok('辊')]
-    ,
-  )
-}
+  // vice versa
+  let bytes_be = b"\x00\xD8\x00\xD9"
 
-///|
-test "strictly decoding UTF16BE encoded data with UTF8" {
-  let src = "跑步🏃游泳🏊"
-  let buf = @buffer.new(size_hint=10)
-  for s in src {
-    @encoding.write_utf16be_char(buf, s)
-  }
-  inspect!(
-    buf.to_bytes(),
-    content=
-      #|b"\x8d\xd1\x6b\x65\xd8\x3c\xdf\xc3\x6e\x38\x6c\xf3\xd8\x3c\xdf\xca"
-    ,
-  )
-  let chars = @encoding.decode_strict(UTF8, buf.to_bytes())
-  inspect!(
-    chars.iter().collect(),
-    content=
-      #|[Err(b"\x8d"), Err(b"\xd1\x6b"), Ok('e'), Err(b"\xd8\x3c"), Err(b"\xdf\xc3"), Ok('n'), Ok('8'), Ok('l'), Err(b"\xf3\xd8\x3c\xdf"), Err(b"\x00")]
-    ,
-  )
+  // valid in UTF16BE
+  let decoder_utf16be = @encoding.decoder(UTF16BE)
+  let chars_utf16be = decoder_utf16be.decode!(bytes_be)
+  inspect!(chars_utf16be, content="ØÙ")
+
+  // invalid in UTF16LE
+  let decoder_utf16le = @encoding.decoder(UTF16LE)
+  let malformedError = decoder_utf16le.decode?(bytes_be)
+  assert_true!(malformedError.is_err())
 }

--- a/encoding/decoding_test.mbt
+++ b/encoding/decoding_test.mbt
@@ -25,10 +25,17 @@ test "streaming decoding UTF8 rabbit" {
 
 ///|
 test "streaming decoding UTF16LE rabbit" {
-  let inputs = [b"\x3D\xD8", b"\x30\xDC"] // UTF16LE(🐰) == <3DD8 30DC>
+  // UTF16LE(🐰) == <3DD8 30DC>
+  let inputs = [
+    b"\x3D", b"\xD8\x30\xDC", b"\x3D\xD8", b"\x30\xDC", b"\x3D\xD8\x30", b"\xDC",
+  ]
   let decoder = @encoding.decoder(UTF16LE)
   inspect!(decoder.decode!(inputs[0]), content="")
   inspect!(decoder.decode!(inputs[1]), content="🐰")
+  inspect!(decoder.decode!(inputs[2]), content="")
+  inspect!(decoder.decode!(inputs[3]), content="🐰")
+  inspect!(decoder.decode!(inputs[4]), content="")
+  inspect!(decoder.decode!(inputs[5]), content="🐰")
 }
 
 ///|
@@ -321,7 +328,7 @@ test "decoding UTF8 encoded data" {
 }
 
 ///|
-test "panic decoding UTF16LE encoded data with UTF8" {
+test "decoding UTF16LE encoded data with UTF8" {
   let src = "跑步🏃游泳🏊"
   let buf = @buffer.new(size_hint=10)
   for s in src {
@@ -335,7 +342,12 @@ test "panic decoding UTF16LE encoded data with UTF8" {
   )
   let decoder = @encoding.decoder(UTF8)
   // NOTE: Expected to be malformed here
-  decoder.decode!(buf.to_bytes()) |> ignore
+  let chars = decoder.decode?(buf.to_bytes())
+  assert_true!(chars.is_err())
+  inspect!(
+    chars,
+    content="Err(moonbitlang/x/encoding.MalformedError.MalformedError)",
+  )
 }
 
 ///|
@@ -374,11 +386,13 @@ test "decoding UTF16BE encoded data with UTF8" {
     ,
   )
   let decoder = @encoding.decoder(UTF8)
-  let chars = decoder.decode!(buf.to_bytes())
-  // NOTE: decoder generates `Refill` and waits for continued input.
-  //       This is a decoded string, it is empty,
-  //       indicating that no UTF16BE bytes were successfully UTF8 decoded into a string
-  inspect!(chars, content="")
+  // NOTE: Expected to be malformed here
+  let chars = decoder.decode?(buf.to_bytes())
+  assert_true!(chars.is_err())
+  inspect!(
+    chars,
+    content="Err(moonbitlang/x/encoding.MalformedError.MalformedError)",
+  )
 }
 
 ///|
@@ -468,41 +482,37 @@ test "lossy decoding UTF16LE encoded data with UTF8" {
   )
 }
 
-// ///|
-// test "lossy decoding UTF16LE incorrectly encoded data to String" {
-//   let buf = @buffer.new(size_hint=10)
-//   buf.write_bytes(b"") // 👀 \x3d\xd8\x40\xdc
-//   inspect!(
-//     buf.to_bytes(),
-//     content=
-//       #|b"\x60\x40\x70\x50\x00\xd0\x40\x00"
-//     ,
-//   )
-//   let decoder = @encoding.decoder(UTF16LE)
-//   let chars = decoder.decode!(buf.to_bytes())
-//   inspect!(chars, content="你好👀")
-// }
+///|
+test "lossy decoding UTF16LE incorrectly encoded data to String" {
+  let src = b"\x00\xD8"
+  inspect!(
+    src,
+    content=
+      #|b"\x00\xd8"
+    ,
+  )
+  let decoder = @encoding.decoder(UTF16LE)
+  let chars = decoder.decode_lossy(src, stream=false)
+  inspect!(chars, content="�")
+  assert_eq!(chars.length(), 1)
+  assert_eq!(chars[0], @encoding.U_REP)
+}
 
-// ///|
-// test "lossy decoding UTF16 (alias for UTF16LE) incorrectly encoded data to String" {
-//   let buf = @buffer.new(size_hint=20)
-//   buf.write_bytes(b"\x65\x18")
-//   buf.write_bytes(b"\x20\x18")
-//   buf.write_bytes(b"\x73\x18")
-//   buf.write_bytes(b"\x64\x18")
-//   buf.write_bytes(b"\x73\x18")
-//   buf.write_bytes(b"\x36\x18")
-//   buf.write_bytes(b"\x20\x18")
-//   inspect!(
-//     buf.to_bytes(),
-//     content=
-//       #|b"\x65\x18\x20\x18\x73\x18\x64\x18\x73\x18\x36\x18\x20\x18"
-//     ,
-//   )
-//   let decoder = @encoding.decoder(UTF16)
-//   let chars = decoder.decode!(buf.to_bytes())
-//   inspect!(chars, content="ᡥᠠᡳᡤᡳᠶᠠ")
-// }
+///|
+test "lossy decoding UTF16 (alias for UTF16LE) incorrectly encoded data to String" {
+  let src = b"\x00\xD8"
+  inspect!(
+    src,
+    content=
+      #|b"\x00\xd8"
+    ,
+  )
+  let decoder = @encoding.decoder(UTF16)
+  let chars = decoder.decode_lossy(src, stream=false)
+  inspect!(chars, content="�")
+  assert_eq!(chars.length(), 1)
+  assert_eq!(chars[0], @encoding.U_REP)
+}
 
 ///|
 test "lossy decoding UTF16BE incorrectly encoded data to String" {
@@ -516,7 +526,29 @@ test "lossy decoding UTF16BE incorrectly encoded data to String" {
   let decoder = @encoding.decoder(UTF16BE)
   let chars = decoder.decode_lossy(src, stream=false)
   inspect!(chars, content="�")
+  assert_eq!(chars.length(), 1)
   assert_eq!(chars[0], @encoding.U_REP)
+}
+
+///|
+test "lossy decoding UTF16BE which is `HI+!LO`" {
+  let src = b"\xD8\x00\x00\x48"
+  inspect!(
+    src,
+    content=
+      #|b"\xd8\x00\x00\x48"
+    ,
+  )
+  let decoder = @encoding.decoder(UTF16BE)
+  let chars = decoder.decode_lossy(src, stream=false)
+
+  // FIXME: should decode as many characters as possible
+  // > printf '\xD8\x00\x00\x48' | uconv --from-code UTF16BE --to-code UTF8 --from-callback substitute
+  inspect!(chars, content="�") // ❌
+  // inspect!(chars, content="�H") // ✅
+  // assert_eq!(chars.length(), 2)
+  assert_eq!(chars[0], @encoding.U_REP)
+  // assert_eq!(chars[1], 'H')
 }
 
 ///|

--- a/encoding/decoding_test.mbt
+++ b/encoding/decoding_test.mbt
@@ -175,6 +175,7 @@ test "streaming decoding UTF16BE Tao71" {
     from_array(chunks[3]),
     b"\xdf\x75\xc5\x75\xc5\xff\x0c\x66\x2f\x4e\xe5\x4e\x0d\x75\xc5\x30\x02",
   )
+  // decoder.decode!(input, stream~ = false)
   inspect!(
     decoder.decode!(from_array(chunks[3])),
     content="惟病病，是以不病。",

--- a/encoding/decoding_test.mbt
+++ b/encoding/decoding_test.mbt
@@ -18,9 +18,10 @@
 test "streaming decoding UTF8 rabbit" {
   let inputs = [b"abc", b"\xf0", b"\x9f\x90\xb0"] // UTF8(🐰) == <F09F 90B0>
   let decoder = @encoding.decoder(UTF8)
-  inspect!(decoder.decode_continue!(inputs[0]), content="abc")
-  inspect!(decoder.decode_continue!(inputs[1]), content="")
-  inspect!(decoder.decode_finish!(input=inputs[2]), content="🐰")
+  inspect!(decoder.consume!(inputs[0]), content="abc")
+  inspect!(decoder.consume!(inputs[1]), content="")
+  inspect!(decoder.consume!(inputs[2]), content="🐰")
+  assert_true!(decoder.finish!().is_empty())
 }
 
 ///|
@@ -30,12 +31,13 @@ test "streaming decoding UTF16LE rabbit" {
     b"\x3D", b"\xD8\x30\xDC", b"\x3D\xD8", b"\x30\xDC", b"\x3D\xD8\x30", b"\xDC",
   ]
   let decoder = @encoding.decoder(UTF16LE)
-  inspect!(decoder.decode_continue!(inputs[0]), content="")
-  inspect!(decoder.decode_continue!(inputs[1]), content="🐰")
-  inspect!(decoder.decode_continue!(inputs[2]), content="")
-  inspect!(decoder.decode_continue!(inputs[3]), content="🐰")
-  inspect!(decoder.decode_continue!(inputs[4]), content="")
-  inspect!(decoder.decode_finish!(input=inputs[5]), content="🐰")
+  inspect!(decoder.consume!(inputs[0]), content="")
+  inspect!(decoder.consume!(inputs[1]), content="🐰")
+  inspect!(decoder.consume!(inputs[2]), content="")
+  inspect!(decoder.consume!(inputs[3]), content="🐰")
+  inspect!(decoder.consume!(inputs[4]), content="")
+  inspect!(decoder.consume!(inputs[5]), content="🐰")
+  assert_true!(decoder.finish!().is_empty())
 }
 
 ///|
@@ -53,33 +55,34 @@ test "streaming decoding UTF16LE ASCII" {
     from_array(chunks[0]),
     b"\x48\x00\x6f\x00\x77\x00\x20\x00\x64\x00\x6f\x00\x20\x00\x77\x00\x65",
   )
-  inspect!(decoder.decode_continue!(from_array(chunks[0])), content="How do w")
+  inspect!(decoder.consume!(from_array(chunks[0])), content="How do w")
   assert_eq!(
     from_array(chunks[1]),
     b"\x00\x20\x00\x67\x00\x72\x00\x61\x00\x73\x00\x70\x00\x20\x00\x61\x00",
   )
-  inspect!(decoder.decode_continue!(from_array(chunks[1])), content="e grasp a")
+  inspect!(decoder.consume!(from_array(chunks[1])), content="e grasp a")
   assert_eq!(
     from_array(chunks[2]),
     b"\x6c\x00\x6c\x00\x20\x00\x74\x00\x68\x00\x65\x00\x20\x00\x61\x00\x70",
   )
-  inspect!(decoder.decode_continue!(from_array(chunks[2])), content="ll the a")
+  inspect!(decoder.consume!(from_array(chunks[2])), content="ll the a")
   assert_eq!(
     from_array(chunks[3]),
     b"\x00\x70\x00\x6c\x00\x65\x00\x73\x00\x20\x00\x61\x00\x74\x00\x20\x00",
   )
-  inspect!(decoder.decode_continue!(from_array(chunks[3])), content="pples at ")
+  inspect!(decoder.consume!(from_array(chunks[3])), content="pples at ")
   assert_eq!(from_array(chunks[4]), b"\x6f\x00\x6e\x00\x63\x00\x65\x00\x3f\x00")
-  // `decode_finish!(input)` is an alias for `decode!(input, stream=false)`
-  inspect!(decoder.decode_finish!(input=from_array(chunks[4])), content="once?")
+  inspect!(decoder.consume!(from_array(chunks[4])), content="once?")
+  // `decode_finish!()` is an alias for `decode!(b"", stream=false)`
+  assert_true!(decoder.finish!().is_empty())
 
   // check accumulator
   let decoder = @encoding.decoder(UTF16LE)
   let mut acc = ""
   for chunk in ascii.to_bytes().to_array().chunks(7) {
-    acc += decoder.decode_continue!(from_array(chunk))
+    acc += decoder.consume!(from_array(chunk))
   }
-  decoder.decode_finish!() |> ignore
+  assert_true!(decoder.finish!().is_empty())
   assert_eq!(acc, ascii)
 }
 
@@ -104,26 +107,17 @@ test "streaming decoding UTF8 Emoji" {
     from_array(chunks[0]),
     b"\x20\x20\x20\xf0\x9f\x8e\xa9\x0a\x20\x20\x20\xf0\x9f",
   )
-  inspect!(
-    decoder.decode_continue!(from_array(chunks[0])),
-    content="   🎩\n   ",
-  )
+  inspect!(decoder.consume!(from_array(chunks[0])), content="   🎩\n   ")
   assert_eq!(
     from_array(chunks[1]),
     b"\x91\xb6\x0a\x20\xe2\x9c\x8b\xf0\x9f\x91\x95\xf0\x9f",
   )
-  inspect!(
-    decoder.decode_continue!(from_array(chunks[1])),
-    content="👶\n ✋👕",
-  )
+  inspect!(decoder.consume!(from_array(chunks[1])), content="👶\n ✋👕")
   assert_eq!(
     from_array(chunks[2]),
     b"\x8c\x82\x0a\x20\x20\x20\xe2\x80\xbc\xef\xb8\x8f\x0a",
   )
-  inspect!(
-    decoder.decode_continue!(from_array(chunks[2])),
-    content="🌂\n   ‼️\n",
-  )
+  inspect!(decoder.consume!(from_array(chunks[2])), content="🌂\n   ‼️\n")
   assert_eq!(
     from_array(chunks[3]),
     b"\x20\x20\x20\xf0\x9f\x91\x9e\xf0\x9f\x91\x9e",
@@ -135,9 +129,9 @@ test "streaming decoding UTF8 Emoji" {
   let decoder = @encoding.decoder(UTF8)
   let mut acc = ""
   for chunk in art_bytes.to_array().chunks(7) {
-    acc += decoder.decode_continue!(from_array(chunk))
+    acc += decoder.consume!(from_array(chunk))
   }
-  decoder.decode_finish!() |> ignore
+  assert_true!(decoder.finish!().is_empty())
   assert_eq!(acc, art)
 }
 
@@ -158,7 +152,7 @@ test "streaming decoding UTF16BE Tao71" {
     b"\x77\xe5\x4e\x0d\x77\xe5\xff\x0c\x5c\x1a\x77\xe3\xff\x1b\x4e\x0d\x77",
   )
   inspect!(
-    decoder.decode_continue!(from_array(chunks[0])),
+    decoder.consume!(from_array(chunks[0])),
     content="知不知，尚矣；不",
   )
   assert_eq!(
@@ -166,7 +160,7 @@ test "streaming decoding UTF16BE Tao71" {
     b"\xe5\x77\xe5\xff\x0c\x75\xc5\x4e\x5f\x30\x02\x57\x23\x4e\xba\x4e\x0d",
   )
   inspect!(
-    decoder.decode_continue!(from_array(chunks[1])),
+    decoder.consume!(from_array(chunks[1])),
     content="知知，病也。圣人不",
   )
   assert_eq!(
@@ -174,7 +168,7 @@ test "streaming decoding UTF16BE Tao71" {
     b"\x75\xc5\xff\x0c\x4e\xe5\x51\x76\x75\xc5\x75\xc5\xff\x0c\x59\x2b\x60",
   )
   inspect!(
-    decoder.decode_continue!(from_array(chunks[2])),
+    decoder.consume!(from_array(chunks[2])),
     content="病，以其病病，夫",
   )
   assert_eq!(
@@ -190,9 +184,9 @@ test "streaming decoding UTF16BE Tao71" {
   let decoder = @encoding.decoder(UTF16BE)
   let mut acc = ""
   for chunk in tao71_bytes.to_array().chunks(7) {
-    acc += decoder.decode_continue!(from_array(chunk))
+    acc += decoder.consume!(from_array(chunk))
   }
-  decoder.decode_finish!() |> ignore
+  assert_true!(decoder.finish!().is_empty())
   assert_eq!(acc, tao71)
 }
 

--- a/encoding/decoding_test.mbt
+++ b/encoding/decoding_test.mbt
@@ -488,13 +488,11 @@ test "lossy decoding UTF16BE which is `HI+!LO`" {
   let decoder = @encoding.decoder(UTF16BE)
   let chars = decoder.decode_lossy(src, stream=false)
 
-  // FIXME(jinser): should decode as many characters as possible
-  // > printf '\xD8\x00\x00\x48' | uconv --from-code UTF16BE --to-code UTF8 --from-callback substitute
-  inspect!(chars, content="�") // ❌
-  // inspect!(chars, content="�H") // ✅
-  // assert_eq!(chars.length(), 2)
+  // NOTE(jinser): should decode as many characters as possible
+  inspect!(chars, content="�H") // ✅
+  assert_eq!(chars.length(), 2)
   assert_eq!(chars[0], @encoding.U_REP)
-  // assert_eq!(chars[1], 'H')
+  assert_eq!(chars[1], 'H')
 }
 
 ///|

--- a/encoding/encoding.mbti
+++ b/encoding/encoding.mbti
@@ -29,7 +29,11 @@ fn write_utf8_char(@buffer.T, Char) -> Unit
 type Decoder
 impl Decoder {
   decode(Self, Bytes, stream~ : Bool = ..) -> String!
+  decode_continue(Self, Bytes) -> String!
+  decode_finish(Self, input~ : Bytes = ..) -> String!
   decode_lossy(Self, Bytes, stream~ : Bool = ..) -> String
+  decode_lossy_continue(Self, Bytes) -> String
+  decode_lossy_finish(Self, input~ : Bytes = ..) -> String
 }
 
 pub(all) enum Encoding {

--- a/encoding/encoding.mbti
+++ b/encoding/encoding.mbti
@@ -3,6 +3,8 @@ package moonbitlang/x/encoding
 alias @moonbitlang/core/buffer as @buffer
 
 // Values
+const U_REP : Char = '�'
+
 fn decoder(Encoding) -> Decoder
 
 fn encode(Encoding, String) -> Bytes
@@ -26,7 +28,8 @@ fn write_utf8_char(@buffer.T, Char) -> Unit
 // Types and methods
 type Decoder
 impl Decoder {
-  decode(Self, Bytes) -> String!
+  decode(Self, Bytes, stream~ : Bool = ..) -> String!
+  decode_lossy(Self, Bytes, stream~ : Bool = ..) -> String
 }
 
 pub(all) enum Encoding {
@@ -37,6 +40,8 @@ pub(all) enum Encoding {
 }
 
 pub type! MalformedError Bytes
+
+pub type! TruncatedError Bytes
 
 // Type aliases
 

--- a/encoding/encoding.mbti
+++ b/encoding/encoding.mbti
@@ -3,9 +3,7 @@ package moonbitlang/x/encoding
 alias @moonbitlang/core/buffer as @buffer
 
 // Values
-fn decode_lossy(Encoding, Bytes) -> LossyChars
-
-fn decode_strict(Encoding, Bytes) -> StrictChars
+fn decoder(Encoding) -> Decoder
 
 fn encode(Encoding, String) -> Bytes
 
@@ -26,8 +24,25 @@ fn write_utf16le_char(@buffer.T, Char) -> Unit
 fn write_utf8_char(@buffer.T, Char) -> Unit
 
 // Types and methods
-pub(all) type! DecodeError Bytes
-impl Show for DecodeError
+pub enum Decode {
+  End
+  Refill
+  Malformed(Bytes)
+  Uchar(Char)
+}
+impl Show for Decode
+
+pub struct Decoder {
+  i : FixedArray[Byte]
+  i_pos : Int
+  t : FixedArray[Byte]
+  t_len : Int
+  t_need : Int
+  k : (Decoder) -> Decode
+}
+impl Decoder {
+  decode(Self, Bytes) -> String!
+}
 
 pub(all) enum Encoding {
   UTF8
@@ -36,21 +51,10 @@ pub(all) enum Encoding {
   UTF16BE
 }
 
-type LossyChars
-impl LossyChars {
-  iter(Self) -> Iter[Char]
-  to_string(Self) -> String
-}
-impl Show for LossyChars
-
-type StrictChars
-impl StrictChars {
-  iter(Self) -> Iter[Result[Char, DecodeError]]
-  to_string(Self) -> String!
-}
-impl Show for StrictChars
+pub type! MalformedError Bytes
 
 // Type aliases
+pub typealias Cont = (Decoder) -> Decode
 
 // Traits
 

--- a/encoding/encoding.mbti
+++ b/encoding/encoding.mbti
@@ -24,22 +24,7 @@ fn write_utf16le_char(@buffer.T, Char) -> Unit
 fn write_utf8_char(@buffer.T, Char) -> Unit
 
 // Types and methods
-pub enum Decode {
-  End
-  Refill
-  Malformed(Bytes)
-  Uchar(Char)
-}
-impl Show for Decode
-
-pub struct Decoder {
-  i : FixedArray[Byte]
-  i_pos : Int
-  t : FixedArray[Byte]
-  t_len : Int
-  t_need : Int
-  k : (Decoder) -> Decode
-}
+type Decoder
 impl Decoder {
   decode(Self, Bytes) -> String!
 }
@@ -54,7 +39,6 @@ pub(all) enum Encoding {
 pub type! MalformedError Bytes
 
 // Type aliases
-pub typealias Cont = (Decoder) -> Decode
 
 // Traits
 

--- a/encoding/encoding.mbti
+++ b/encoding/encoding.mbti
@@ -28,12 +28,12 @@ fn write_utf8_char(@buffer.T, Char) -> Unit
 // Types and methods
 type Decoder
 impl Decoder {
+  consume(Self, Bytes) -> String!
   decode(Self, Bytes, stream~ : Bool = ..) -> String!
-  decode_continue(Self, Bytes) -> String!
-  decode_finish(Self, input~ : Bytes = ..) -> String!
   decode_lossy(Self, Bytes, stream~ : Bool = ..) -> String
-  decode_lossy_continue(Self, Bytes) -> String
-  decode_lossy_finish(Self, input~ : Bytes = ..) -> String
+  finish(Self) -> String!
+  lossy_consume(Self, Bytes) -> String
+  lossy_finish(Self) -> String
 }
 
 pub(all) enum Encoding {

--- a/encoding/types.mbt
+++ b/encoding/types.mbt
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 ///|
-pub typealias Cont = (Decoder) -> Decode
-
-///|
 pub type! MalformedError Bytes
 
 ///|
@@ -29,7 +26,10 @@ pub(all) enum Encoding {
 // Decoder
 
 ///|
-pub struct Decoder {
+typealias Cont = (Decoder) -> Decode
+
+///|
+struct Decoder {
   // Input bytes
   // Stores the input bytes that need to be decoded.
   // The primary data source from which characters are read and decoded.
@@ -54,7 +54,7 @@ pub struct Decoder {
 }
 
 ///|
-pub enum Decode {
+priv enum Decode {
   End
   Refill
   Malformed(Bytes)

--- a/encoding/types.mbt
+++ b/encoding/types.mbt
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 ///|
-typealias Cont = (Decoder) -> Decode
+pub typealias Cont = (Decoder) -> Decode
+
+///|
+pub type! MalformedError Bytes
 
 ///|
 pub(all) enum Encoding {
@@ -26,7 +29,7 @@ pub(all) enum Encoding {
 // Decoder
 
 ///|
-priv struct Decoder {
+pub struct Decoder {
   // Input bytes
   // Stores the input bytes that need to be decoded.
   // The primary data source from which characters are read and decoded.
@@ -35,11 +38,6 @@ priv struct Decoder {
   // Keeps track of the current position within the input bytes `i`.
   // Indicates the next byte (starting point) to read from `i` during the decoding process
   mut i_pos : Int
-  // Input maximum
-  // Indicates the index of the last byte of the input bytes `i`.
-  // Helps bounds checking and limits how far the decoding process should go,
-  // ensuring that decoding does not go beyond the provided input length.
-  mut i_max : Int
   // Temporary bytes
   // Used to temporarily store bytes that are read in parts
   // (which might happen for multi-byte encoded characters).
@@ -51,26 +49,29 @@ priv struct Decoder {
   // The number of bytes still needed to complete the character code currently being processed.
   mut t_need : Int
   // Continuation
-  //
   // Called with a `Decoder` state.
   mut k : Cont
 }
 
 ///|
-priv enum Decode {
+pub enum Decode {
   End
+  Refill
   Malformed(Bytes)
   Uchar(Char)
-}
+} derive(Show)
+
+// helper constructor
 
 ///|
-fn slice(bytes : Bytes, offset : Int, length : Int) -> Bytes {
-  let new_bytes = FixedArray::makei(length, fn(i) { bytes[offset + i] })
+fn slice(bytes : FixedArray[Byte], offset : Int, length : Int) -> Bytes {
+  let new_bytes = FixedArray::make(length, b'0')
+  bytes.blit_to(new_bytes, len=length, src_offset=offset)
   Bytes::from_fixedarray(new_bytes)
 }
 
 ///|
-fn malformed(bytes : Bytes, offset : Int, length : Int) -> Decode {
+fn malformed(bytes : FixedArray[Byte], offset : Int, length : Int) -> Decode {
   Malformed(slice(bytes, offset, length))
 }
 
@@ -78,106 +79,20 @@ fn malformed(bytes : Bytes, offset : Int, length : Int) -> Decode {
 fn malformed_pair(
   be : Bool,
   hi : Int,
-  bytes : Bytes,
+  bytes : FixedArray[Byte],
   offset : Int,
   length : Int
 ) -> Decode {
-  let bs1 = bytes.to_unchecked_string(offset~, length~).to_bytes()
-  let bs0 = FixedArray::make(2, b'\x00')
+  let bs1 = FixedArray::make(length, Byte::default())
+  bytes.blit_to(bs1, len=length, src_offset=offset)
+  let bs0 = FixedArray::make(2, Byte::default())
   let (j0, j1) = if be { (0, 1) } else { (1, 0) }
   bs0[j0] = (hi >> 8).to_byte()
   bs0[j1] = hi.land(0xFF).to_byte()
   let bs = @buffer.new(size_hint=bs0.length() + bs1.length())
-  bs.write_bytes(Bytes::from_fixedarray(bs0))
-  bs.write_bytes(bs1)
-  Malformed(slice(bs.to_bytes(), 0, bs.length()))
-}
-
-// Chars
-
-///|
-type LossyChars Decoder
-
-///|
-pub fn iter(self : LossyChars) -> Iter[Char] {
-  Iter::new(fn(yield_) {
-    loop self._.decode() {
-      Uchar(u) => {
-        if yield_(u) == IterEnd {
-          break IterEnd
-        }
-        continue self._.decode()
-      }
-      Malformed(_) => {
-        if yield_(U_REP) == IterEnd {
-          break IterEnd
-        }
-        continue self._.decode()
-      }
-      End => break IterEnd
-    }
-  })
-}
-
-///|
-pub fn to_string(self : LossyChars) -> String {
-  let arr = self.iter().collect()
-  String::from_array(arr)
-}
-
-///|
-pub impl Show for LossyChars with output(self : LossyChars, logger : &Logger) -> Unit {
-  logger.write_string(self.to_string())
-}
-
-///|
-type StrictChars Decoder
-
-///|
-pub(all) type! DecodeError Bytes
-
-///|
-pub impl Show for DecodeError with output(self, logger) {
-  match self {
-    DecodeError(err) => err.output(logger)
-  }
-}
-
-///|
-pub fn StrictChars::iter(self : StrictChars) -> Iter[Result[Char, DecodeError]] {
-  Iter::new(fn(yield_) {
-    loop self._.decode() {
-      Uchar(u) => {
-        if yield_(Ok(u)) == IterEnd {
-          break IterEnd
-        }
-        continue self._.decode()
-      }
-      Malformed(s) => {
-        let err = DecodeError(s)
-        if yield_(Err(err)) == IterEnd {
-          break IterEnd
-        }
-        continue self._.decode()
-      }
-      End => break IterEnd
-    }
-  })
-}
-
-///|
-pub fn StrictChars::to_string(self : StrictChars) -> String! {
-  let arr = []
-  for element in self {
-    match element {
-      Ok(x) => arr.push(x)
-      Err(e) => raise e
-    }
-  }
-  String::from_array(arr)
-}
-
-///|
-pub impl Show for StrictChars with output(self : StrictChars, logger : &Logger) -> Unit {
-  logger.write_string(self.to_string?().to_string())
+  // specify a known length to skip call method `bs0.length()`
+  bs.write_bytes(Bytes::from_fixedarray(bs0, len=2))
+  // ditto
+  bs.write_bytes(Bytes::from_fixedarray(bs1, len=length))
+  Malformed(slice(bs.to_bytes().to_fixedarray(), 0, bs.length()))
 }

--- a/encoding/types.mbt
+++ b/encoding/types.mbt
@@ -16,6 +16,9 @@
 pub type! MalformedError Bytes
 
 ///|
+pub type! TruncatedError Bytes
+
+///|
 pub(all) enum Encoding {
   UTF8
   UTF16 // alias for UTF16LE
@@ -56,7 +59,7 @@ struct Decoder {
 ///|
 priv enum Decode {
   End
-  Refill
+  Refill(Bytes)
   Malformed(Bytes)
   Uchar(Char)
 } derive(Show)


### PR DESCRIPTION
Supports streaming bytes for parsing.


```moonbit
let inputs = [b"abc", b"\xf0", b"\x9f\x90\xb0"] // UTF8(🐰) == <F09F 90B0>
let decoder = @encoding.decoder(UTF8)
inspect!(decoder.decode!(inputs[0], stream=true), content="abc")
inspect!(decoder.consume!(inputs[1]), content="") // same with above
inspect!(decoder.consume!(inputs[2]), content="🐰")
assert_true!(decoder.finish!().is_empty())
```