### PR TITLE
fix: change FFI export macro key

### DIFF
--- a/benchmark/internal/benchmark_ffi/native_stub.c
+++ b/benchmark/internal/benchmark_ffi/native_stub.c
@@ -4,13 +4,13 @@
 
 #include <windows.h>
 
-MOONBIT_FFI_EXPORT int64_t instant_now_ffi() {
+MOONBIT_EXPORT int64_t instant_now_ffi() {
   LARGE_INTEGER t;
   QueryPerformanceCounter(&t);
   return t.QuadPart;
 }
 
-MOONBIT_FFI_EXPORT double instant_as_secs_f64_ffi(int64_t t) {
+MOONBIT_EXPORT double instant_as_secs_f64_ffi(int64_t t) {
   LARGE_INTEGER freq;
   QueryPerformanceFrequency(&freq);
   return ((double)t) / ((double)freq.QuadPart);
@@ -22,14 +22,14 @@ MOONBIT_FFI_EXPORT double instant_as_secs_f64_ffi(int64_t t) {
 
 void timespec_delete(void *_t) {}
 
-MOONBIT_FFI_EXPORT struct timespec *instant_now_ffi() {
+MOONBIT_EXPORT struct timespec *instant_now_ffi() {
   struct timespec *res =
       moonbit_make_external_object(&timespec_delete, sizeof(struct timespec));
   clock_gettime(CLOCK_MONOTONIC, res);
   return res;
 }
 
-MOONBIT_FFI_EXPORT double instant_as_secs_f64_ffi(struct timespec *t) {
+MOONBIT_EXPORT double instant_as_secs_f64_ffi(struct timespec *t) {
   return ((double)t->tv_sec) + ((double)t->tv_nsec) * 1e-9;
 }
 

--- a/sys/internal/ffi/native_stub.c
+++ b/sys/internal/ffi/native_stub.c
@@ -12,7 +12,7 @@
 #include <unistd.h>
 #endif
 
-MOONBIT_FFI_EXPORT moonbit_bytes_t* get_env_vars() {
+MOONBIT_EXPORT moonbit_bytes_t* get_env_vars() {
 #ifdef _WIN32
     // Get environment block
     LPCH env_block = GetEnvironmentStrings();
@@ -98,7 +98,7 @@ MOONBIT_FFI_EXPORT moonbit_bytes_t* get_env_vars() {
 #endif
 }
 
-MOONBIT_FFI_EXPORT void set_env_var(moonbit_bytes_t key, moonbit_bytes_t value) {
+MOONBIT_EXPORT void set_env_var(moonbit_bytes_t key, moonbit_bytes_t value) {
 #ifdef _WIN32
     SetEnvironmentVariable(key, value);
 #else
@@ -106,7 +106,7 @@ MOONBIT_FFI_EXPORT void set_env_var(moonbit_bytes_t key, moonbit_bytes_t value) 
 #endif
 }
 
-MOONBIT_FFI_EXPORT void unset_env_var(moonbit_bytes_t key) {
+MOONBIT_EXPORT void unset_env_var(moonbit_bytes_t key) {
 #ifdef _WIN32
     SetEnvironmentVariable(key, NULL);
 #else


### PR DESCRIPTION
It does not support `MOONBIT_FFI_EXPORT` in the latest version.

It will break the compilation.