### PR TITLE
feat(crypto): add HMAC implementation

### DIFF
--- a/crypto/crypto.mbti
+++ b/crypto/crypto.mbti
@@ -9,7 +9,7 @@ fn chacha20(FixedArray[UInt], UInt, FixedArray[Byte], nonce~ : UInt = ..) -> Fix
 
 fn chacha8(FixedArray[UInt], UInt, FixedArray[Byte], nonce~ : UInt = ..) -> FixedArray[Byte]!
 
-fn finalize(Sha256Context) -> FixedArray[Byte]
+fn hmac[H : CryptoHasher](H, FixedArray[Byte], FixedArray[Byte]) -> FixedArray[Byte]
 
 fn md5(FixedArray[Byte]) -> FixedArray[Byte]
 
@@ -29,35 +29,29 @@ fn sm3_from_iter(Iter[Byte]) -> FixedArray[Byte]
 
 fn uints_to_hex_string(Iter[UInt]) -> String
 
-fn update(Sha256Context, FixedArray[Byte]) -> Unit
-
-fn update_from_iter(Sha256Context, Iter[Byte]) -> Unit
-
 // Types and methods
-type MD5Context
-impl MD5Context {
-  finalize(Self) -> FixedArray[Byte]
+type MD5
+impl MD5 {
   new() -> Self
-  update(Self, FixedArray[Byte]) -> Unit
 }
+impl CryptoHasher for MD5
 
-type SM3Context
-impl SM3Context {
-  finalize(Self) -> FixedArray[Byte]
-  new() -> Self
-  update(Self, FixedArray[Byte]) -> Unit
-  update_from_iter(Self, Iter[Byte]) -> Unit
-}
-
-type Sha256Context
-impl Sha256Context {
-  finalize(Self) -> FixedArray[Byte]
+type SHA256
+impl SHA256 {
   new(reg~ : FixedArray[UInt] = ..) -> Self
-  update(Self, FixedArray[Byte]) -> Unit
   update_from_iter(Self, Iter[Byte]) -> Unit
 }
+impl CryptoHasher for SHA256
+
+type SM3
+impl SM3 {
+  new() -> Self
+  update_from_iter(Self, Iter[Byte]) -> Unit
+}
+impl CryptoHasher for SM3
 
 // Type aliases
 
 // Traits
+trait CryptoHasher
 

--- a/crypto/hmac.mbt
+++ b/crypto/hmac.mbt
@@ -1,0 +1,75 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Computes HMAC (Hash-based Message Authentication Code) using a specified
+/// cryptographic hash function.
+///
+/// Parameters:
+///
+/// * `hash` : A hash function implementation that satisfies the `CryptoHasher`
+/// trait.
+/// * `key` : The secret key used for generating the authentication code.
+/// * `message` : The message to be authenticated.
+///
+/// Returns a fixed-size array of bytes containing the HMAC value. The length of
+/// the output depends on the underlying hash function's output size.
+///
+pub fn hmac[H : CryptoHasher](
+  hash : H,
+  key : FixedArray[Byte],
+  message : FixedArray[Byte]
+) -> FixedArray[Byte] {
+  let block_size = hash.block_size()
+  let working_key = if key.length() > block_size {
+    // if key is longer than block size, hash it
+    hash.reset()
+    hash.update(key)
+    hash.finalize()
+  } else {
+    key
+  }
+  let padded_key = if working_key.length() < block_size {
+    // if key is shorter than block size, pad it with zeros
+    let padded = FixedArray::make(block_size, b'\x00')
+    working_key.blit_to(padded, len=working_key.length())
+    padded
+  } else {
+    working_key
+  }
+  // create inner and outer padding arrays
+  let ipad = FixedArray::make(block_size, b'\x36')
+  let opad = FixedArray::make(block_size, b'\x5c')
+  // calculate inner hash
+  let inner_key = xor_bytes(padded_key, ipad)
+  hash.reset()
+  hash.update(inner_key)
+  hash.update(message)
+  let inner_hash = hash.finalize()
+  // calculate outer hash
+  let outer_key = xor_bytes(padded_key, opad)
+  hash.reset()
+  hash.update(outer_key)
+  hash.update(inner_hash)
+  hash.finalize()
+}
+
+///|
+fn xor_bytes(a : FixedArray[Byte], b : FixedArray[Byte]) -> FixedArray[Byte] {
+  let result = FixedArray::make(a.length(), b'\x00')
+  for i = 0; i < a.length(); i = i + 1 {
+    result[i] = a[i] ^ b[i]
+  }
+  result
+}

--- a/crypto/hmac_test.mbt
+++ b/crypto/hmac_test.mbt
@@ -1,0 +1,68 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "hmac-sha256 short key" {
+  let h = SHA256::new()
+  let key = FixedArray::make(2, b'\x88')
+  let message = b"\x01\x02\x03".to_fixedarray()
+  inspect!(
+    bytes_to_hex_string(hmac(h, key, message)),
+    content="a4516484974d883f34f4ea0459359ca09019bd07409ead28c9785808acb5962b",
+  )
+}
+
+///|
+test "hmac-sha256 fit key" {
+  let h = SHA256::new()
+  let key = FixedArray::make(64, b'\x88')
+  let message = b"\x01\x02\x03".to_fixedarray()
+  inspect!(
+    bytes_to_hex_string(hmac(h, key, message)),
+    content="8ad8d49308ad8aeed002385f143de8a3f46a0de0feb15740c82eae99bdf36f89",
+  )
+}
+
+///|
+test "hmac-sha256 long key" {
+  let h = SHA256::new()
+  let key = FixedArray::make(128, b'\x88')
+  let message = b"\x01\x02\x03".to_fixedarray()
+  inspect!(
+    bytes_to_hex_string(hmac(h, key, message)),
+    content="7b50707a53d9ee7682f5527e061ec784ac80f0b95696b314030d3a08d109d960",
+  )
+}
+
+///|
+test "hmac-md5" {
+  let h = MD5::new()
+  let key = FixedArray::make(2, b'\x88')
+  let message = b"\x01\x02\x03".to_fixedarray()
+  inspect!(
+    bytes_to_hex_string(hmac(h, key, message)),
+    content="2df61055719493098ea2c97cdd656367",
+  )
+}
+
+///|
+test "hmac-sm3" {
+  let h = SM3::new()
+  let key = FixedArray::make(2, b'\x88')
+  let message = b"\x01\x02\x03".to_fixedarray()
+  inspect!(
+    bytes_to_hex_string(hmac(h, key, message)),
+    content="c4ffa25e4474ca5d732126bf5a0e87dfb83f697fdaddd0e40fdf087096b10724",
+  )
+}

--- a/crypto/md5.mbt
+++ b/crypto/md5.mbt
@@ -15,29 +15,47 @@
 // An MD5 message-digest algorithm implementation based on
 // [RFC1321]       https://www.ietf.org/rfc/rfc1321.txt
 // [Ron Rivest]    https://people.csail.mit.edu/rivest/Md5.c
-// [md5-0.7.0]     https://docs.rs/md5/0.7.0/src/md5/lib.rs.html 
+// [md5-0.7.0]     https://docs.rs/md5/0.7.0/src/md5/lib.rs.html
+
 ///|
-struct MD5Context {
-  state : FixedArray[UInt] // state 'a' 'b' 'c' 'd'
-  count : FixedArray[UInt]
-  buffer : FixedArray[Byte]
+struct MD5 {
+  mut state : FixedArray[UInt] // state 'a' 'b' 'c' 'd'
+  mut count : FixedArray[UInt]
+  mut buffer : FixedArray[Byte]
 }
 
 ///|
 let padding : FixedArray[Byte] = FixedArray::make(64, Byte::default())
 
+///|
+pub impl CryptoHasher for MD5 with size(_self : MD5) -> Int {
+  16
+}
+
+///|
+pub impl CryptoHasher for MD5 with block_size(_self : MD5) -> Int {
+  64
+}
+
+///|
+pub impl CryptoHasher for MD5 with reset(self : MD5) -> Unit {
+  self.state = [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476]
+  self.count = [0, 0]
+  self.buffer = FixedArray::make(64, Byte::default())
+}
+
 ///| update the state of given context from new `data` 
-pub fn MD5Context::update(self : MD5Context, data : FixedArray[Byte]) -> Unit {
+pub impl CryptoHasher for MD5 with update(self : MD5, data : FixedArray[Byte]) -> Unit {
   md5_update(self, data)
 }
 
 ///| an alias of `MD5Context::compute()`
-pub fn MD5Context::finalize(self : MD5Context) -> FixedArray[Byte] {
+pub impl CryptoHasher for MD5 with finalize(self : MD5) -> FixedArray[Byte] {
   self.md5_compute()
 }
 
 ///| Instantiate a MD5 context
-pub fn MD5Context::new() -> MD5Context {
+pub fn MD5::new() -> MD5 {
   padding[0] = b'\x80'
   {
     state: [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476],
@@ -47,7 +65,7 @@ pub fn MD5Context::new() -> MD5Context {
 }
 
 ///| compute MD5 digest from given context
-fn MD5Context::md5_compute(self : MD5Context) -> FixedArray[Byte] {
+fn MD5::md5_compute(self : MD5) -> FixedArray[Byte] {
   let input = FixedArray::make(16, 0U)
   let idx = ((self.count[0] >> 3) & 0x3f).reinterpret_as_int()
   input[14] = self.count[0]
@@ -92,27 +110,27 @@ fn MD5Context::md5_compute(self : MD5Context) -> FixedArray[Byte] {
 //          H(X,Y,Z) = X xor Y xor Z
 //          I(X,Y,Z) = Y xor (X v not(Z))
 ///|
-fn MD5Context::f(x : UInt, y : UInt, z : UInt) -> UInt {
+fn MD5::f(x : UInt, y : UInt, z : UInt) -> UInt {
   (x & y) | (x.lnot() & z)
 }
 
 ///|
-fn MD5Context::g(x : UInt, y : UInt, z : UInt) -> UInt {
+fn MD5::g(x : UInt, y : UInt, z : UInt) -> UInt {
   ((x ^ y) & z) ^ y
 }
 
 ///|
-fn MD5Context::h(x : UInt, y : UInt, z : UInt) -> UInt {
+fn MD5::h(x : UInt, y : UInt, z : UInt) -> UInt {
   x ^ y ^ z
 }
 
 ///|
-fn MD5Context::i(x : UInt, y : UInt, z : UInt) -> UInt {
+fn MD5::i(x : UInt, y : UInt, z : UInt) -> UInt {
   y ^ (x | z.lnot())
 }
 
 ///|
-fn md5_update(ctx : MD5Context, data : FixedArray[Byte]) -> Unit {
+fn md5_update(ctx : MD5, data : FixedArray[Byte]) -> Unit {
   let input = FixedArray::make(16, 0U)
   let mut idx = ((ctx.count[0] >> 3) & 0x3f).reinterpret_as_int()
   let length = data.length()
@@ -146,79 +164,79 @@ fn md5_transform(state : FixedArray[UInt], input : FixedArray[UInt]) -> Unit {
 
   // Round 1
   // s[ 0..15] := { 7, 12, 17, 22,  7, 12, 17, 22,  7, 12, 17, 22,  7, 12, 17, 22 }
-  a = b + rotate_left_u(a + MD5Context::f(b, c, d) + input[0] + 0xd76aa478, 7)
-  d = a + rotate_left_u(d + MD5Context::f(a, b, c) + input[1] + 0xe8c7b756, 12)
-  c = d + rotate_left_u(c + MD5Context::f(d, a, b) + input[2] + 0x242070db, 17)
-  b = c + rotate_left_u(b + MD5Context::f(c, d, a) + input[3] + 0xc1bdceee, 22)
-  a = b + rotate_left_u(a + MD5Context::f(b, c, d) + input[4] + 0xf57c0faf, 7)
-  d = a + rotate_left_u(d + MD5Context::f(a, b, c) + input[5] + 0x4787c62a, 12)
-  c = d + rotate_left_u(c + MD5Context::f(d, a, b) + input[6] + 0xa8304613, 17)
-  b = c + rotate_left_u(b + MD5Context::f(c, d, a) + input[7] + 0xfd469501, 22)
-  a = b + rotate_left_u(a + MD5Context::f(b, c, d) + input[8] + 0x698098d8, 7)
-  d = a + rotate_left_u(d + MD5Context::f(a, b, c) + input[9] + 0x8b44f7af, 12)
-  c = d + rotate_left_u(c + MD5Context::f(d, a, b) + input[10] + 0xffff5bb1, 17)
-  b = c + rotate_left_u(b + MD5Context::f(c, d, a) + input[11] + 0x895cd7be, 22)
-  a = b + rotate_left_u(a + MD5Context::f(b, c, d) + input[12] + 0x6b901122, 7)
-  d = a + rotate_left_u(d + MD5Context::f(a, b, c) + input[13] + 0xfd987193, 12)
-  c = d + rotate_left_u(c + MD5Context::f(d, a, b) + input[14] + 0xa679438e, 17)
-  b = c + rotate_left_u(b + MD5Context::f(c, d, a) + input[15] + 0x49b40821, 22)
+  a = b + rotate_left_u(a + MD5::f(b, c, d) + input[0] + 0xd76aa478, 7)
+  d = a + rotate_left_u(d + MD5::f(a, b, c) + input[1] + 0xe8c7b756, 12)
+  c = d + rotate_left_u(c + MD5::f(d, a, b) + input[2] + 0x242070db, 17)
+  b = c + rotate_left_u(b + MD5::f(c, d, a) + input[3] + 0xc1bdceee, 22)
+  a = b + rotate_left_u(a + MD5::f(b, c, d) + input[4] + 0xf57c0faf, 7)
+  d = a + rotate_left_u(d + MD5::f(a, b, c) + input[5] + 0x4787c62a, 12)
+  c = d + rotate_left_u(c + MD5::f(d, a, b) + input[6] + 0xa8304613, 17)
+  b = c + rotate_left_u(b + MD5::f(c, d, a) + input[7] + 0xfd469501, 22)
+  a = b + rotate_left_u(a + MD5::f(b, c, d) + input[8] + 0x698098d8, 7)
+  d = a + rotate_left_u(d + MD5::f(a, b, c) + input[9] + 0x8b44f7af, 12)
+  c = d + rotate_left_u(c + MD5::f(d, a, b) + input[10] + 0xffff5bb1, 17)
+  b = c + rotate_left_u(b + MD5::f(c, d, a) + input[11] + 0x895cd7be, 22)
+  a = b + rotate_left_u(a + MD5::f(b, c, d) + input[12] + 0x6b901122, 7)
+  d = a + rotate_left_u(d + MD5::f(a, b, c) + input[13] + 0xfd987193, 12)
+  c = d + rotate_left_u(c + MD5::f(d, a, b) + input[14] + 0xa679438e, 17)
+  b = c + rotate_left_u(b + MD5::f(c, d, a) + input[15] + 0x49b40821, 22)
 
   // Round 2
   // s[16..31] := { 5,  9, 14, 20,  5,  9, 14, 20,  5,  9, 14, 20,  5,  9, 14, 20 }
-  a = b + rotate_left_u(a + MD5Context::g(b, c, d) + input[1] + 0xf61e2562, 5)
-  d = a + rotate_left_u(d + MD5Context::g(a, b, c) + input[6] + 0xc040b340, 9)
-  c = d + rotate_left_u(c + MD5Context::g(d, a, b) + input[11] + 0x265e5a51, 14)
-  b = c + rotate_left_u(b + MD5Context::g(c, d, a) + input[0] + 0xe9b6c7aa, 20)
-  a = b + rotate_left_u(a + MD5Context::g(b, c, d) + input[5] + 0xd62f105d, 5)
-  d = a + rotate_left_u(d + MD5Context::g(a, b, c) + input[10] + 0x02441453, 9)
-  c = d + rotate_left_u(c + MD5Context::g(d, a, b) + input[15] + 0xd8a1e681, 14)
-  b = c + rotate_left_u(b + MD5Context::g(c, d, a) + input[4] + 0xe7d3fbc8, 20)
-  a = b + rotate_left_u(a + MD5Context::g(b, c, d) + input[9] + 0x21e1cde6, 5)
-  d = a + rotate_left_u(d + MD5Context::g(a, b, c) + input[14] + 0xc33707d6, 9)
-  c = d + rotate_left_u(c + MD5Context::g(d, a, b) + input[3] + 0xf4d50d87, 14)
-  b = c + rotate_left_u(b + MD5Context::g(c, d, a) + input[8] + 0x455a14ed, 20)
-  a = b + rotate_left_u(a + MD5Context::g(b, c, d) + input[13] + 0xa9e3e905, 5)
-  d = a + rotate_left_u(d + MD5Context::g(a, b, c) + input[2] + 0xfcefa3f8, 9)
-  c = d + rotate_left_u(c + MD5Context::g(d, a, b) + input[7] + 0x676f02d9, 14)
-  b = c + rotate_left_u(b + MD5Context::g(c, d, a) + input[12] + 0x8d2a4c8a, 20)
+  a = b + rotate_left_u(a + MD5::g(b, c, d) + input[1] + 0xf61e2562, 5)
+  d = a + rotate_left_u(d + MD5::g(a, b, c) + input[6] + 0xc040b340, 9)
+  c = d + rotate_left_u(c + MD5::g(d, a, b) + input[11] + 0x265e5a51, 14)
+  b = c + rotate_left_u(b + MD5::g(c, d, a) + input[0] + 0xe9b6c7aa, 20)
+  a = b + rotate_left_u(a + MD5::g(b, c, d) + input[5] + 0xd62f105d, 5)
+  d = a + rotate_left_u(d + MD5::g(a, b, c) + input[10] + 0x02441453, 9)
+  c = d + rotate_left_u(c + MD5::g(d, a, b) + input[15] + 0xd8a1e681, 14)
+  b = c + rotate_left_u(b + MD5::g(c, d, a) + input[4] + 0xe7d3fbc8, 20)
+  a = b + rotate_left_u(a + MD5::g(b, c, d) + input[9] + 0x21e1cde6, 5)
+  d = a + rotate_left_u(d + MD5::g(a, b, c) + input[14] + 0xc33707d6, 9)
+  c = d + rotate_left_u(c + MD5::g(d, a, b) + input[3] + 0xf4d50d87, 14)
+  b = c + rotate_left_u(b + MD5::g(c, d, a) + input[8] + 0x455a14ed, 20)
+  a = b + rotate_left_u(a + MD5::g(b, c, d) + input[13] + 0xa9e3e905, 5)
+  d = a + rotate_left_u(d + MD5::g(a, b, c) + input[2] + 0xfcefa3f8, 9)
+  c = d + rotate_left_u(c + MD5::g(d, a, b) + input[7] + 0x676f02d9, 14)
+  b = c + rotate_left_u(b + MD5::g(c, d, a) + input[12] + 0x8d2a4c8a, 20)
 
   // Round 3
   // s[32..47] := { 4, 11, 16, 23,  4, 11, 16, 23,  4, 11, 16, 23,  4, 11, 16, 23 }
-  a = b + rotate_left_u(a + MD5Context::h(b, c, d) + input[5] + 0xfffa3942, 4)
-  d = a + rotate_left_u(d + MD5Context::h(a, b, c) + input[8] + 0x8771f681, 11)
-  c = d + rotate_left_u(c + MD5Context::h(d, a, b) + input[11] + 0x6d9d6122, 16)
-  b = c + rotate_left_u(b + MD5Context::h(c, d, a) + input[14] + 0xfde5380c, 23)
-  a = b + rotate_left_u(a + MD5Context::h(b, c, d) + input[1] + 0xa4beea44, 4)
-  d = a + rotate_left_u(d + MD5Context::h(a, b, c) + input[4] + 0x4bdecfa9, 11)
-  c = d + rotate_left_u(c + MD5Context::h(d, a, b) + input[7] + 0xf6bb4b60, 16)
-  b = c + rotate_left_u(b + MD5Context::h(c, d, a) + input[10] + 0xbebfbc70, 23)
-  a = b + rotate_left_u(a + MD5Context::h(b, c, d) + input[13] + 0x289b7ec6, 4)
-  d = a + rotate_left_u(d + MD5Context::h(a, b, c) + input[0] + 0xeaa127fa, 11)
-  c = d + rotate_left_u(c + MD5Context::h(d, a, b) + input[3] + 0xd4ef3085, 16)
-  b = c + rotate_left_u(b + MD5Context::h(c, d, a) + input[6] + 0x04881d05, 23)
-  a = b + rotate_left_u(a + MD5Context::h(b, c, d) + input[9] + 0xd9d4d039, 4)
-  d = a + rotate_left_u(d + MD5Context::h(a, b, c) + input[12] + 0xe6db99e5, 11)
-  c = d + rotate_left_u(c + MD5Context::h(d, a, b) + input[15] + 0x1fa27cf8, 16)
-  b = c + rotate_left_u(b + MD5Context::h(c, d, a) + input[2] + 0xc4ac5665, 23)
+  a = b + rotate_left_u(a + MD5::h(b, c, d) + input[5] + 0xfffa3942, 4)
+  d = a + rotate_left_u(d + MD5::h(a, b, c) + input[8] + 0x8771f681, 11)
+  c = d + rotate_left_u(c + MD5::h(d, a, b) + input[11] + 0x6d9d6122, 16)
+  b = c + rotate_left_u(b + MD5::h(c, d, a) + input[14] + 0xfde5380c, 23)
+  a = b + rotate_left_u(a + MD5::h(b, c, d) + input[1] + 0xa4beea44, 4)
+  d = a + rotate_left_u(d + MD5::h(a, b, c) + input[4] + 0x4bdecfa9, 11)
+  c = d + rotate_left_u(c + MD5::h(d, a, b) + input[7] + 0xf6bb4b60, 16)
+  b = c + rotate_left_u(b + MD5::h(c, d, a) + input[10] + 0xbebfbc70, 23)
+  a = b + rotate_left_u(a + MD5::h(b, c, d) + input[13] + 0x289b7ec6, 4)
+  d = a + rotate_left_u(d + MD5::h(a, b, c) + input[0] + 0xeaa127fa, 11)
+  c = d + rotate_left_u(c + MD5::h(d, a, b) + input[3] + 0xd4ef3085, 16)
+  b = c + rotate_left_u(b + MD5::h(c, d, a) + input[6] + 0x04881d05, 23)
+  a = b + rotate_left_u(a + MD5::h(b, c, d) + input[9] + 0xd9d4d039, 4)
+  d = a + rotate_left_u(d + MD5::h(a, b, c) + input[12] + 0xe6db99e5, 11)
+  c = d + rotate_left_u(c + MD5::h(d, a, b) + input[15] + 0x1fa27cf8, 16)
+  b = c + rotate_left_u(b + MD5::h(c, d, a) + input[2] + 0xc4ac5665, 23)
 
   // Round 4
   // s[48..63] := { 6, 10, 15, 21,  6, 10, 15, 21,  6, 10, 15, 21,  6, 10, 15, 21 }
-  a = b + rotate_left_u(a + MD5Context::i(b, c, d) + input[0] + 0xf4292244, 6)
-  d = a + rotate_left_u(d + MD5Context::i(a, b, c) + input[7] + 0x432aff97, 10)
-  c = d + rotate_left_u(c + MD5Context::i(d, a, b) + input[14] + 0xab9423a7, 15)
-  b = c + rotate_left_u(b + MD5Context::i(c, d, a) + input[5] + 0xfc93a039, 21)
-  a = b + rotate_left_u(a + MD5Context::i(b, c, d) + input[12] + 0x655b59c3, 6)
-  d = a + rotate_left_u(d + MD5Context::i(a, b, c) + input[3] + 0x8f0ccc92, 10)
-  c = d + rotate_left_u(c + MD5Context::i(d, a, b) + input[10] + 0xffeff47d, 15)
-  b = c + rotate_left_u(b + MD5Context::i(c, d, a) + input[1] + 0x85845dd1, 21)
-  a = b + rotate_left_u(a + MD5Context::i(b, c, d) + input[8] + 0x6fa87e4f, 6)
-  d = a + rotate_left_u(d + MD5Context::i(a, b, c) + input[15] + 0xfe2ce6e0, 10)
-  c = d + rotate_left_u(c + MD5Context::i(d, a, b) + input[6] + 0xa3014314, 15)
-  b = c + rotate_left_u(b + MD5Context::i(c, d, a) + input[13] + 0x4e0811a1, 21)
-  a = b + rotate_left_u(a + MD5Context::i(b, c, d) + input[4] + 0xf7537e82, 6)
-  d = a + rotate_left_u(d + MD5Context::i(a, b, c) + input[11] + 0xbd3af235, 10)
-  c = d + rotate_left_u(c + MD5Context::i(d, a, b) + input[2] + 0x2ad7d2bb, 15)
-  b = c + rotate_left_u(b + MD5Context::i(c, d, a) + input[9] + 0xeb86d391, 21)
+  a = b + rotate_left_u(a + MD5::i(b, c, d) + input[0] + 0xf4292244, 6)
+  d = a + rotate_left_u(d + MD5::i(a, b, c) + input[7] + 0x432aff97, 10)
+  c = d + rotate_left_u(c + MD5::i(d, a, b) + input[14] + 0xab9423a7, 15)
+  b = c + rotate_left_u(b + MD5::i(c, d, a) + input[5] + 0xfc93a039, 21)
+  a = b + rotate_left_u(a + MD5::i(b, c, d) + input[12] + 0x655b59c3, 6)
+  d = a + rotate_left_u(d + MD5::i(a, b, c) + input[3] + 0x8f0ccc92, 10)
+  c = d + rotate_left_u(c + MD5::i(d, a, b) + input[10] + 0xffeff47d, 15)
+  b = c + rotate_left_u(b + MD5::i(c, d, a) + input[1] + 0x85845dd1, 21)
+  a = b + rotate_left_u(a + MD5::i(b, c, d) + input[8] + 0x6fa87e4f, 6)
+  d = a + rotate_left_u(d + MD5::i(a, b, c) + input[15] + 0xfe2ce6e0, 10)
+  c = d + rotate_left_u(c + MD5::i(d, a, b) + input[6] + 0xa3014314, 15)
+  b = c + rotate_left_u(b + MD5::i(c, d, a) + input[13] + 0x4e0811a1, 21)
+  a = b + rotate_left_u(a + MD5::i(b, c, d) + input[4] + 0xf7537e82, 6)
+  d = a + rotate_left_u(d + MD5::i(a, b, c) + input[11] + 0xbd3af235, 10)
+  c = d + rotate_left_u(c + MD5::i(d, a, b) + input[2] + 0x2ad7d2bb, 15)
+  b = c + rotate_left_u(b + MD5::i(c, d, a) + input[9] + 0xeb86d391, 21)
   state[0] += a
   state[1] += b
   state[2] += c
@@ -229,7 +247,7 @@ fn md5_transform(state : FixedArray[UInt], input : FixedArray[UInt]) -> Unit {
 /// - Note that MD5 is considered _cryptographically broken_.
 /// Unless mandated, more secure alternatives should be preferred.
 pub fn md5(data : FixedArray[Byte]) -> FixedArray[Byte] {
-  let ctx = MD5Context::new()
+  let ctx = MD5::new()
   md5_update(ctx, data)
   ctx.md5_compute()
 }
@@ -247,12 +265,12 @@ test "md5_wb" {
 
 ///|
 test {
-  let ctx = MD5Context::new()
+  let ctx = MD5::new()
   md5_update(ctx, b"\x61".to_fixedarray())
   md5_update(ctx, b"\x62".to_fixedarray())
   md5_update(ctx, b"\x63".to_fixedarray())
   let res1 = bytes_to_hex_string(ctx.md5_compute())
-  let ctx = MD5Context::new()
+  let ctx = MD5::new()
   md5_update(ctx, b"\x61\x62\x63".to_fixedarray())
   let res2 = bytes_to_hex_string(ctx.md5_compute())
   assert_eq!(res1, res2)

--- a/crypto/sha224.mbt
+++ b/crypto/sha224.mbt
@@ -14,7 +14,7 @@
 
 ///|
 pub fn sha224(data : FixedArray[Byte]) -> FixedArray[Byte] {
-  let ctx = Sha256Context::new(reg=[
+  let ctx = SHA256::new(reg=[
     0xc1059ed8, 0x367cd507, 0x3070dd17, 0xf70e5939, 0xffc00b31, 0x68581511, 0x64f98fa7,
     0xbefa4fa4,
   ])
@@ -24,7 +24,7 @@ pub fn sha224(data : FixedArray[Byte]) -> FixedArray[Byte] {
 
 ///|
 pub fn sha224_from_iter(data : Iter[Byte]) -> FixedArray[Byte] {
-  let ctx = Sha256Context::new(reg=[
+  let ctx = SHA256::new(reg=[
     0xc1059ed8, 0x367cd507, 0x3070dd17, 0xf70e5939, 0xffc00b31, 0x68581511, 0x64f98fa7,
     0xbefa4fa4,
   ])

--- a/crypto/sha256.mbt
+++ b/crypto/sha256.mbt
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 ///|
-struct Sha256Context {
-  reg : FixedArray[UInt] // register A B C D E F G H. i.e. digest
+struct SHA256 {
+  mut reg : FixedArray[UInt] // register A B C D E F G H. i.e. digest
   mut len : UInt64
   mut buf : FixedArray[Byte]
   mut buf_index : Int
@@ -22,12 +22,12 @@ struct Sha256Context {
 
 ///| Instantiate a Sha256 context
 /// `reg` is the initial hash value. Defaults to Sha256's.
-pub fn Sha256Context::new(
+pub fn SHA256::new(
   reg~ : FixedArray[UInt] = [
     0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab,
     0x5be0cd19,
   ]
-) -> Sha256Context {
+) -> SHA256 {
   { reg, len: 0, buf: FixedArray::make(64, Byte::default()), buf_index: 0 }
 }
 
@@ -46,7 +46,7 @@ let sha256_t : FixedArray[UInt] = [ // pre calculated
 ]
 
 ///|
-fn pad(self : Sha256Context) -> FixedArray[Byte] {
+fn pad(self : SHA256) -> FixedArray[Byte] {
   let mut cnt = self.buf_index
   self.len += 8UL * cnt.to_uint64()
   self.buf[cnt] = b'\x80'
@@ -73,7 +73,7 @@ fn pad(self : Sha256Context) -> FixedArray[Byte] {
 
 ///|
 fn transform(
-  self : Sha256Context,
+  self : SHA256,
   data : FixedArray[Byte],
   offset~ : Int = 0
 ) -> FixedArray[UInt] {
@@ -102,15 +102,11 @@ fn transform(
     let big_sigma_1 = rotate_right_u(e, 6) ^
       rotate_right_u(e, 11) ^
       rotate_right_u(e, 25)
-    let t_1 = h +
-      big_sigma_1 +
-      SM3Context::gg_1(e, f, g) +
-      sha256_t[index] +
-      w[index]
+    let t_1 = h + big_sigma_1 + SM3::gg_1(e, f, g) + sha256_t[index] + w[index]
     let big_sigma_0 = rotate_right_u(a, 2) ^
       rotate_right_u(a, 13) ^
       rotate_right_u(a, 22)
-    let t_2 = big_sigma_0 + SM3Context::ff_1(a, b, c)
+    let t_2 = big_sigma_0 + SM3::ff_1(a, b, c)
     h = g
     g = f
     f = e
@@ -132,7 +128,7 @@ fn transform(
 }
 
 ///|
-pub fn update_from_iter(self : Sha256Context, data : Iter[Byte]) -> Unit {
+pub fn SHA256::update_from_iter(self : SHA256, data : Iter[Byte]) -> Unit {
   data.each(fn(b) {
     self.buf[self.buf_index] = b
     self.buf_index += 1
@@ -146,7 +142,10 @@ pub fn update_from_iter(self : Sha256Context, data : Iter[Byte]) -> Unit {
 }
 
 ///| update the state of given context from new `data` 
-pub fn update(self : Sha256Context, data : FixedArray[Byte]) -> Unit {
+pub impl CryptoHasher for SHA256 with update(
+  self : SHA256,
+  data : FixedArray[Byte]
+) -> Unit {
   let mut offset = 0
   while offset < data.length() {
     let min_len = if 64 - self.buf_index >= data.length() - offset {
@@ -173,7 +172,7 @@ pub fn update(self : Sha256Context, data : FixedArray[Byte]) -> Unit {
 
 ///|
 fn sha256_compute(
-  self : Sha256Context,
+  self : SHA256,
   data~ : Iter[Byte] = Iter::empty()
 ) -> FixedArray[UInt] {
   self.update_from_iter(data)
@@ -186,21 +185,44 @@ fn sha256_compute(
   }
 }
 
+///|
+pub impl CryptoHasher for SHA256 with size(_self : SHA256) -> Int {
+  32
+}
+
+///|
+pub impl CryptoHasher for SHA256 with block_size(_self : SHA256) -> Int {
+  64
+}
+
+///|
+pub impl CryptoHasher for SHA256 with reset(self : SHA256) -> Unit {
+  self.reg = [
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab,
+    0x5be0cd19,
+  ]
+  self.len = 0
+  self.buf = FixedArray::make(64, Byte::default())
+  self.buf_index = 0
+}
+
 ///| Compute the Sha256 digest from given Sha256Context
-pub fn finalize(self : Sha256Context) -> FixedArray[Byte] {
+pub impl CryptoHasher for SHA256 with finalize(self : SHA256) -> FixedArray[
+  Byte,
+] {
   arr_u32_to_u8be(self.sha256_compute().iter(), 256)
 }
 
 ///| Compute the Sha256 digest in `Bytes` of some `data`. Note that Sha256 is big-endian.
 pub fn sha256(data : FixedArray[Byte]) -> FixedArray[Byte] {
-  let ctx = Sha256Context::new()
+  let ctx = SHA256::new()
   let _ = ctx.update(data)
   arr_u32_to_u8be(ctx.sha256_compute().iter(), 256)
 }
 
 ///|
 pub fn sha256_from_iter(data : Iter[Byte]) -> FixedArray[Byte] {
-  let ctx = Sha256Context::new()
+  let ctx = SHA256::new()
   let _ = ctx.update_from_iter(data)
   arr_u32_to_u8be(ctx.sha256_compute().iter(), 256)
 }
@@ -209,7 +231,7 @@ pub fn sha256_from_iter(data : Iter[Byte]) -> FixedArray[Byte] {
 test {
   // Sha256
   fn sha256_u32(data : FixedArray[Byte]) -> FixedArray[UInt] {
-    let ctx = Sha256Context::new()
+    let ctx = SHA256::new()
     let _ = ctx.update(data)
     ctx.sha256_compute()
   }
@@ -236,12 +258,12 @@ test {
     uints_to_hex_string(sha256_u32(b"\x61\x62\x63".to_fixedarray()).iter()),
   )
   let hash1 = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
-  let ctx = Sha256Context::new()
+  let ctx = SHA256::new()
   ctx.update(b"\x61".to_fixedarray())
   ctx.update(b"\x62".to_fixedarray())
   ctx.update(b"\x63".to_fixedarray())
   assert_eq!(hash1, bytes_to_hex_string(ctx.finalize()))
-  let ctx = Sha256Context::new()
+  let ctx = SHA256::new()
   let data = b"\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64"
   for i = 0; i < data.length(); i = i + 1 {
     ctx.update(FixedArray::make(1, data[i]))
@@ -250,7 +272,7 @@ test {
     bytes_to_hex_string(ctx.finalize()),
     "625b41490b883891943c5fa54ad45d7c900b9b6e91e159334e320b1f5215a209",
   )
-  let ctx = Sha256Context::new()
+  let ctx = SHA256::new()
   for i = 0; i < data.length(); i = i + 4 {
     ctx.update_from_iter(b"\x61\x62\x63\x64".iter())
   }

--- a/crypto/sm3.mbt
+++ b/crypto/sm3.mbt
@@ -17,15 +17,15 @@
 // SM3 is as secure as SHA256, providing similar performance. https://doi.org/10.3390/electronics8091033
 
 ///|
-struct SM3Context {
-  reg : FixedArray[UInt] // register A B C D E F G H. i.e. digest
+struct SM3 {
+  mut reg : FixedArray[UInt] // register A B C D E F G H. i.e. digest
   mut len : UInt64
   mut buf : FixedArray[Byte]
   mut buf_index : Int
 }
 
 ///| Instantiate a SM3 context
-pub fn SM3Context::new() -> SM3Context {
+pub fn SM3::new() -> SM3 {
   {
     reg: [
       0x7380166F, 0x4914B2B9, 0x172442D7, 0xDA8A0600, 0xA96F30BC, 0x163138AA, 0xE38DEE4D,
@@ -55,41 +55,41 @@ let t : FixedArray[UInt] = [ // pre calculated
 // FF_j = | X xor Y xor Z                       where 0 <= j <= 15
 //        | (X and Y) or (X and Z) or (Y and Z) where 16 <= j <=63
 ///|
-fn SM3Context::ff_0(x : UInt, y : UInt, z : UInt) -> UInt {
+fn SM3::ff_0(x : UInt, y : UInt, z : UInt) -> UInt {
   x ^ y ^ z
 }
 
 ///|
-fn SM3Context::ff_1(x : UInt, y : UInt, z : UInt) -> UInt {
+fn SM3::ff_1(x : UInt, y : UInt, z : UInt) -> UInt {
   (x & y) | (x & z) | (y & z)
 }
 
 // GG_j = | X xor Y xor Z           where 0 <= j <= 15
 //        | (X and Y) or (~X and Z) where 16 <= j <= 63
 ///|
-fn SM3Context::gg_0(x : UInt, y : UInt, z : UInt) -> UInt {
+fn SM3::gg_0(x : UInt, y : UInt, z : UInt) -> UInt {
   x ^ y ^ z
 }
 
 ///|
-fn SM3Context::gg_1(x : UInt, y : UInt, z : UInt) -> UInt {
+fn SM3::gg_1(x : UInt, y : UInt, z : UInt) -> UInt {
   ((y ^ z) & x) ^ z // equivalent of (x & y) | (x.lnot() & z), but faster
 }
 
 // P_0 = X xor (X <<< 9) xor (X <<< 17)
 // P_1 = X xor (X <<< 15) xor (X <<< 23)
 ///|
-fn SM3Context::p_0(x : UInt) -> UInt {
+fn SM3::p_0(x : UInt) -> UInt {
   x ^ rotate_left_u(x, 9) ^ rotate_left_u(x, 17)
 }
 
 ///|
-fn SM3Context::p_1(x : UInt) -> UInt {
+fn SM3::p_1(x : UInt) -> UInt {
   x ^ rotate_left_u(x, 15) ^ rotate_left_u(x, 23)
 }
 
 ///|
-fn SM3Context::pad(self : SM3Context) -> FixedArray[Byte] {
+fn SM3::pad(self : SM3) -> FixedArray[Byte] {
   let mut cnt = self.buf_index
   self.len += 8UL * cnt.to_uint64()
   self.buf[cnt] = b'\x80'
@@ -115,8 +115,8 @@ fn SM3Context::pad(self : SM3Context) -> FixedArray[Byte] {
 }
 
 ///|
-fn SM3Context::transform(
-  self : SM3Context,
+fn SM3::transform(
+  self : SM3,
   data : FixedArray[Byte],
   offset~ : Int = 0
 ) -> FixedArray[UInt] {
@@ -134,7 +134,7 @@ fn SM3Context::transform(
     w_0[index] = bytes_u8_to_u32be(data, i=4 * index + offset)
   }
   for index = 16; index < 68; index = index + 1 {
-    w_0[index] = SM3Context::p_1(
+    w_0[index] = SM3::p_1(
         w_0[index - 16] ^ w_0[index - 9] ^ rotate_left_u(w_0[index - 3], 15),
       ) ^
       rotate_left_u(w_0[index - 13], 7) ^
@@ -154,8 +154,8 @@ fn SM3Context::transform(
   for index = 0; index < 16; index = index + 1 {
     let ss_1 = rotate_left_u(rotate_left_u(a1, 12) + e1 + t[index], 7)
     let ss_2 = ss_1 ^ rotate_left_u(a1, 12)
-    let tt_1 = SM3Context::ff_0(a1, b1, c1) + d1 + ss_2 + w_1[index]
-    let tt_2 = SM3Context::gg_0(e1, f1, g1) + h1 + ss_1 + w_0[index]
+    let tt_1 = SM3::ff_0(a1, b1, c1) + d1 + ss_2 + w_1[index]
+    let tt_2 = SM3::gg_0(e1, f1, g1) + h1 + ss_1 + w_0[index]
     d1 = c1
     c1 = rotate_left_u(b1, 9)
     b1 = a1
@@ -163,13 +163,13 @@ fn SM3Context::transform(
     h1 = g1
     g1 = rotate_left_u(f1, 19)
     f1 = e1
-    e1 = SM3Context::p_0(tt_2)
+    e1 = SM3::p_0(tt_2)
   }
   for index = 16; index < 64; index = index + 1 {
     let ss_1 = rotate_left_u(rotate_left_u(a1, 12) + e1 + t[index], 7)
     let ss_2 = ss_1 ^ rotate_left_u(a1, 12)
-    let tt_1 = SM3Context::ff_1(a1, b1, c1) + d1 + ss_2 + w_1[index]
-    let tt_2 = SM3Context::gg_1(e1, f1, g1) + h1 + ss_1 + w_0[index]
+    let tt_1 = SM3::ff_1(a1, b1, c1) + d1 + ss_2 + w_1[index]
+    let tt_2 = SM3::gg_1(e1, f1, g1) + h1 + ss_1 + w_0[index]
     d1 = c1
     c1 = rotate_left_u(b1, 9)
     b1 = a1
@@ -177,7 +177,7 @@ fn SM3Context::transform(
     h1 = g1
     g1 = rotate_left_u(f1, 19)
     f1 = e1
-    e1 = SM3Context::p_0(tt_2)
+    e1 = SM3::p_0(tt_2)
   }
   a = a ^ a1
   b = b ^ b1
@@ -195,10 +195,7 @@ fn SM3Context::transform(
 }
 
 ///|
-pub fn SM3Context::update_from_iter(
-  self : SM3Context,
-  data : Iter[Byte]
-) -> Unit {
+pub fn SM3::update_from_iter(self : SM3, data : Iter[Byte]) -> Unit {
   data.each(fn(b) {
     self.buf[self.buf_index] = b
     self.buf_index += 1
@@ -212,7 +209,7 @@ pub fn SM3Context::update_from_iter(
 }
 
 ///| update the state of given context from new `data` 
-pub fn SM3Context::update(self : SM3Context, data : FixedArray[Byte]) -> Unit {
+pub impl CryptoHasher for SM3 with update(self : SM3, data : FixedArray[Byte]) -> Unit {
   let mut offset = 0
   while offset < data.length() {
     let min_len = if 64 - self.buf_index >= data.length() - offset {
@@ -239,7 +236,7 @@ pub fn SM3Context::update(self : SM3Context, data : FixedArray[Byte]) -> Unit {
 
 ///|
 fn sm3_compute(
-  self : SM3Context,
+  self : SM3,
   data~ : Iter[Byte] = Iter::empty()
 ) -> FixedArray[UInt] {
   self.update_from_iter(data)
@@ -252,21 +249,42 @@ fn sm3_compute(
   }
 }
 
+///|
+pub impl CryptoHasher for SM3 with size(_self : SM3) -> Int {
+  32
+}
+
+///|
+pub impl CryptoHasher for SM3 with block_size(_self : SM3) -> Int {
+  64
+}
+
+///|
+pub impl CryptoHasher for SM3 with reset(self : SM3) -> Unit {
+  self.reg = [
+    0x7380166F, 0x4914B2B9, 0x172442D7, 0xDA8A0600, 0xA96F30BC, 0x163138AA, 0xE38DEE4D,
+    0xB0FB0E4E,
+  ]
+  self.len = 0
+  self.buf = FixedArray::make(64, 0)
+  self.buf_index = 0
+}
+
 ///| Compute the SM3 digest from given SM3Context
-pub fn SM3Context::finalize(self : SM3Context) -> FixedArray[Byte] {
+pub impl CryptoHasher for SM3 with finalize(self : SM3) -> FixedArray[Byte] {
   arr_u32_to_u8be(self.sm3_compute().iter(), 256)
 }
 
 ///| Compute the SM3 digest in `FixedArray[Byte]` of some `data`. Note that SM3 is big-endian.
 pub fn sm3(data : FixedArray[Byte]) -> FixedArray[Byte] {
-  let ctx = SM3Context::new()
+  let ctx = SM3::new()
   let _ = ctx.update(data)
   arr_u32_to_u8be(ctx.sm3_compute().iter(), 256)
 }
 
 ///|
 pub fn sm3_from_iter(data : Iter[Byte]) -> FixedArray[Byte] {
-  let ctx = SM3Context::new()
+  let ctx = SM3::new()
   let _ = ctx.update_from_iter(data)
   arr_u32_to_u8be(ctx.sm3_compute().iter(), 256)
 }
@@ -274,7 +292,7 @@ pub fn sm3_from_iter(data : Iter[Byte]) -> FixedArray[Byte] {
 ///|
 test {
   fn sm3_u32(data : FixedArray[Byte]) -> FixedArray[UInt] {
-    let ctx = SM3Context::new()
+    let ctx = SM3::new()
     let _ = ctx.update(data)
     ctx.sm3_compute()
   }
@@ -301,12 +319,12 @@ test {
     uints_to_hex_string(sm3_u32(b"\x61\x62\x63".to_fixedarray()).iter()),
   )
   let hash1 = "66c7f0f462eeedd9d1f2d46bdc10e4e24167c4875cf2f7a2297da02b8f4ba8e0"
-  let ctx = SM3Context::new()
+  let ctx = SM3::new()
   ctx.update(b"\x61".to_fixedarray())
   ctx.update(b"\x62".to_fixedarray())
   ctx.update(b"\x63".to_fixedarray())
   assert_eq!(hash1, bytes_to_hex_string(ctx.finalize()))
-  let ctx = SM3Context::new()
+  let ctx = SM3::new()
   let data = b"\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64"
   for i = 0; i < data.length(); i = i + 1 {
     ctx.update(FixedArray::make(1, data[i]))
@@ -315,7 +333,7 @@ test {
     bytes_to_hex_string(ctx.finalize()),
     "debe9ff92275b8a138604889c18e5a4d6fdb70e5387e5765293dcba39c0c5732",
   )
-  let ctx = SM3Context::new()
+  let ctx = SM3::new()
   for i = 0; i < data.length(); i = i + 4 {
     ctx.update_from_iter(b"\x61\x62\x63\x64".iter())
   }

--- a/crypto/traits.mbt
+++ b/crypto/traits.mbt
@@ -1,0 +1,27 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+trait CryptoHasher {
+  /// Returns the byte-length of hash output
+  size(Self) -> Int
+  /// Returns the underlying block size of the hasher
+  block_size(Self) -> Int
+  /// Resets to initial state
+  reset(Self) -> Unit
+  /// Updates hash state with new data
+  update(Self, FixedArray[Byte]) -> Unit
+  /// Returns the hash output
+  finalize(Self) -> FixedArray[Byte]
+}


### PR DESCRIPTION
Part of #29 

This PR adds a CryptoHasher trait to provide a unified interface for cryptographic hashers and implements the HMAC algorithm described in [RFC 2104](https://datatracker.ietf.org/doc/html/rfc2104).