### PR TITLE
refactor: use enum for encoding argument (#138)

### DIFF
--- a/encoding/types.mbt
+++ b/encoding/types.mbt
@@ -24,7 +24,7 @@ pub(all) enum Encoding {
   UTF16 // alias for UTF16LE
   UTF16LE
   UTF16BE
-}
+} derive(Show)
 
 // Decoder
 

--- a/fs/fs.mbt
+++ b/fs/fs.mbt
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+///| Re-export from `@encoding`
+pub typealias @encoding.Encoding
+
 ///|
 pub(all) suberror IOError String derive(Show)
 
@@ -42,7 +45,7 @@ pub fn read_file_to_bytes(path : String) -> Bytes raise IOError {
 /// - A `String` representing the content of the file.
 pub fn read_file_to_string(
   path : String,
-  encoding~ : String = "utf8"
+  encoding~ : Encoding = UTF8
 ) -> String raise IOError {
   read_file_to_string_internal(path, encoding~)
 }
@@ -70,7 +73,7 @@ pub fn write_bytes_to_file(
 pub fn write_string_to_file(
   path : String,
   content : String,
-  encoding~ : String = "utf8"
+  encoding~ : Encoding = UTF8
 ) -> Unit raise IOError {
   write_string_to_file_internal(path, content, encoding~)
 }

--- a/fs/fs_js.mbt
+++ b/fs/fs_js.mbt
@@ -69,15 +69,15 @@ fn read_file_to_bytes_internal(path : String) -> Bytes raise IOError {
 ///|
 fn read_file_to_string_internal(
   path : String,
-  encoding~ : String = "utf8"
+  encoding~ : Encoding = UTF8
 ) -> String raise IOError {
-  guard encoding == "utf8" else {
-    raise IOError(
-      "Unsupported encoding: \{encoding}, only utf8 is supported for now",
-    )
+  match encoding {
+    UTF8 => @ffi.utf8_bytes_to_mbt_string(read_file_to_bytes_internal(path))
+    _ =>
+      raise IOError(
+        "Unsupported encoding: \{encoding}, only \{Encoding::UTF8} is supported for now",
+      )
   }
-  let bytes = read_file_to_bytes_internal(path)
-  @ffi.utf8_bytes_to_mbt_string(bytes)
 }
 
 ///|
@@ -95,15 +95,19 @@ fn write_bytes_to_file_internal(
 fn write_string_to_file_internal(
   path : String,
   content : String,
-  encoding~ : String = "utf8"
+  encoding~ : Encoding = UTF8
 ) -> Unit raise IOError {
-  guard encoding == "utf8" else {
-    raise IOError(
-      "Unsupported encoding: \{encoding}, only utf8 is supported for now",
-    )
+  match encoding {
+    UTF8 =>
+      write_bytes_to_file_internal(
+        path,
+        @ffi.mbt_string_to_utf8_bytes(content, false),
+      )
+    _ =>
+      raise IOError(
+        "Unsupported encoding: \{encoding}, only \{Encoding::UTF8} is supported for now",
+      )
   }
-  let bytes = @ffi.mbt_string_to_utf8_bytes(content, false)
-  write_bytes_to_file_internal(path, bytes)
 }
 
 ///|

--- a/fs/fs_native.mbt
+++ b/fs/fs_native.mbt
@@ -76,14 +76,15 @@ fn read_file_to_bytes_internal(path : String) -> Bytes raise IOError {
 ///|
 fn read_file_to_string_internal(
   path : String,
-  encoding~ : String = "utf8"
+  encoding~ : Encoding = UTF8
 ) -> String raise IOError {
-  guard encoding == "utf8" else {
-    raise IOError(
-      "Unsupported encoding: \{encoding}, only utf8 is supported for now",
-    )
+  match encoding {
+    UTF8 => @ffi.utf8_bytes_to_mbt_string(read_file_to_bytes_internal(path))
+    _ =>
+      raise IOError(
+        "Unsupported encoding: \{encoding}, only \{Encoding::UTF8} is supported for now",
+      )
   }
-  @ffi.utf8_bytes_to_mbt_string(read_file_to_bytes_internal(path))
 }
 
 ///|
@@ -105,15 +106,19 @@ fn write_bytes_to_file_internal(
 fn write_string_to_file_internal(
   path : String,
   content : String,
-  encoding~ : String = "utf8"
+  encoding~ : Encoding = UTF8
 ) -> Unit raise IOError {
-  guard encoding == "utf8" else {
-    raise IOError(
-      "Unsupported encoding: \{encoding}, only utf8 is supported for now",
-    )
+  match encoding {
+    UTF8 =>
+      write_bytes_to_file_internal(
+        path,
+        @ffi.mbt_string_to_utf8_bytes(content, false),
+      )
+    _ =>
+      raise IOError(
+        "Unsupported encoding: \{encoding}, only \{Encoding::UTF8} is supported for now",
+      )
   }
-  let bytes = @ffi.mbt_string_to_utf8_bytes(content, false)
-  write_bytes_to_file_internal(path, bytes)
 }
 
 ///|

--- a/fs/fs_wasm.mbt
+++ b/fs/fs_wasm.mbt
@@ -54,14 +54,15 @@ fn read_file_to_bytes_internal(path : String) -> Bytes raise IOError {
 ///|
 fn read_file_to_string_internal(
   path : String,
-  encoding~ : String = "utf8"
+  encoding~ : Encoding = UTF8
 ) -> String raise IOError {
-  guard encoding == "utf8" else {
-    raise IOError(
-      "Unsupported encoding: \{encoding}, only utf8 is supported for now",
-    )
+  match encoding {
+    UTF8 => @ffi.utf8_bytes_to_mbt_string(read_file_to_bytes_internal(path))
+    _ =>
+      raise IOError(
+        "Unsupported encoding: \{encoding}, only \{Encoding::UTF8} is supported for now",
+      )
   }
-  @ffi.utf8_bytes_to_mbt_string(read_file_to_bytes_internal(path))
 }
 
 ///|
@@ -80,17 +81,19 @@ fn write_bytes_to_file_internal(
 fn write_string_to_file_internal(
   path : String,
   content : String,
-  encoding~ : String = "utf8"
+  encoding~ : Encoding = UTF8
 ) -> Unit raise IOError {
-  guard encoding == "utf8" else {
-    raise IOError(
-      "Unsupported encoding: \{encoding}, only utf8 is supported for now",
-    )
+  match encoding {
+    UTF8 =>
+      write_bytes_to_file_internal(
+        path,
+        @ffi.mbt_string_to_utf8_bytes(content, false),
+      )
+    _ =>
+      raise IOError(
+        "Unsupported encoding: \{encoding}, only \{Encoding::UTF8} is supported for now",
+      )
   }
-  write_bytes_to_file_internal(
-    path,
-    @ffi.mbt_string_to_utf8_bytes(content, false),
-  )
 }
 
 ///|

--- a/fs/moon.pkg.json
+++ b/fs/moon.pkg.json
@@ -1,6 +1,7 @@
 {
     "import": [
-        "moonbitlang/x/internal/ffi"
+        "moonbitlang/x/internal/ffi",
+        "moonbitlang/x/encoding"
     ],
     "targets": {
         "fs_wasm.mbt": ["wasm", "wasm-gc"],


### PR DESCRIPTION
Refactors file handling functions to use the Encoding enum from `@encoding.Encoding` instead of strings for encoding argument, improving type safety.