### PR TITLE
feat(crypto): add byte source to accept bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,19 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add `ByteSource` trait for `@crypto` such that it accepts `FixedArray[Byte]`
+  `Bytes` `@bytes.View` at the same time.
+
 ### Fixed
 
 - Updated the READMEs by switching to `.mbt.md` format (#164)
 
 ### Changed
 
-- Deprecated `Num` trait since it has never been open and no one can implement it (#164)
+- Deprecated `Num` trait since it has never been open and no one can implement
+  it (#164)
 - Deprecated `Stack::peek_exn` and replace it with `Stack::unsafe_peek` (#164)
 
 ## [0.4.31]

--- a/crypto/README.mbt.md
+++ b/crypto/README.mbt.md
@@ -14,7 +14,7 @@ A collection of cryptographic hash functions and utilities.
 test {
   let input = "The quick brown fox jumps over the lazy dog"
   inspect(
-    bytes_to_hex_string(sha1(input.to_bytes().to_fixedarray())),
+    bytes_to_hex_string(sha1(input.to_bytes())),
     content="bd136cb58899c93173c33a90dde95ead0d0cf6df",
   )
 }
@@ -26,15 +26,15 @@ test {
 test {
   let input = "The quick brown fox jumps over the lazy dog"
   inspect(
-    bytes_to_hex_string(md5(input.to_bytes().to_fixedarray())),
+    bytes_to_hex_string(md5(input.to_bytes())),
     content="b0986ae6ee1eefee8a4a399090126837",
   )
 
   // buffered
   let ctx = MD5Context::new()
-  ctx.update(b"a".to_fixedarray())
-  ctx.update(b"b".to_fixedarray())
-  ctx.update(b"c".to_fixedarray())
+  ctx.update(b"a")
+  ctx.update(b"b")
+  ctx.update(b"c")
   inspect(
     bytes_to_hex_string(ctx.finalize()),
     content="900150983cd24fb0d6963f7d28e17f72",
@@ -48,7 +48,7 @@ test {
 test {
   let input = "The quick brown fox jumps over the lazy dog"
   inspect(
-    bytes_to_hex_string(sm3(input.to_bytes().to_fixedarray())),
+    bytes_to_hex_string(sm3(input.to_bytes())),
     content="fc2b31896629e88652ca1e3be449ec7ec93f7e5e29769f273fb973bc1858c66d",
   )
 

--- a/crypto/byte_source.mbt
+++ b/crypto/byte_source.mbt
@@ -1,3 +1,17 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 ///|
 trait ByteSource {
   op_get(Self, index : Int) -> Byte

--- a/crypto/byte_source.mbt
+++ b/crypto/byte_source.mbt
@@ -1,0 +1,75 @@
+///|
+trait ByteSource {
+  op_get(Self, index : Int) -> Byte
+  length(Self) -> Int
+  blit_to(
+    Self,
+    dst : FixedArray[Byte],
+    len~ : Int,
+    src_offset~ : Int,
+    dst_offset~ : Int,
+  ) -> Unit
+}
+
+///|
+pub impl ByteSource for FixedArray[Byte] with op_get(self, index) {
+  self[index]
+}
+
+///|
+pub impl ByteSource for FixedArray[Byte] with length(self) {
+  self.length()
+}
+
+///|
+pub impl ByteSource for FixedArray[Byte] with blit_to(
+  self,
+  dst,
+  len~,
+  src_offset~,
+  dst_offset~,
+) {
+  self.blit_to(dst, len~, src_offset~, dst_offset~)
+}
+
+///|
+pub impl ByteSource for @bytes.View with op_get(self, index) {
+  self[index]
+}
+
+///|
+pub impl ByteSource for @bytes.View with length(self) {
+  self.length()
+}
+
+///|
+pub impl ByteSource for @bytes.View with blit_to(
+  self,
+  dst,
+  len~,
+  src_offset~,
+  dst_offset~,
+) {
+  dst.blit_from_bytesview(dst_offset, self[src_offset:src_offset + len])
+}
+
+///|
+pub impl ByteSource for Bytes with op_get(self, index) {
+  self[index]
+}
+
+///|
+pub impl ByteSource for Bytes with length(self) {
+  self.length()
+}
+
+///|
+pub impl ByteSource for Bytes with blit_to(
+  self,
+  dst,
+  len~,
+  src_offset~,
+  dst_offset~,
+) {
+  dst.blit_from_bytes(dst_offset, self, src_offset, len)
+}

--- a/crypto/chacha.mbt
+++ b/crypto/chacha.mbt
@@ -305,10 +305,10 @@ test "stateToBytes" {
 /// - [block] is the block of data to be encrypted.
 /// - [nonce] is default to 0
 /// - Returns the encrypted block of data.
-pub fn chacha8(
+pub fn[Data : ByteSource] chacha8(
   key : FixedArray[UInt],
   counter : UInt,
-  block : FixedArray[Byte],
+  block : Data,
   nonce~ : UInt = 0,
 ) -> FixedArray[Byte] raise Error {
   if key.length() != 8 {
@@ -323,10 +323,10 @@ pub fn chacha8(
 /// - [block] is the block of data to be encrypted.
 /// - [nonce] is default to 0
 /// - Returns the encrypted block of data.
-pub fn chacha12(
+pub fn[Data : ByteSource] chacha12(
   key : FixedArray[UInt],
   counter : UInt,
-  block : FixedArray[Byte],
+  block : Data,
   nonce~ : UInt = 0,
 ) -> FixedArray[Byte] raise Error {
   if key.length() != 8 {
@@ -341,10 +341,10 @@ pub fn chacha12(
 /// - [block] is the block of data to be encrypted.
 /// - [nonce] is default to 0
 /// - Returns the encrypted block of data.
-pub fn chacha20(
+pub fn[Data : ByteSource] chacha20(
   key : FixedArray[UInt],
   counter : UInt,
-  block : FixedArray[Byte],
+  block : Data,
   nonce~ : UInt = 0,
 ) -> FixedArray[Byte] raise Error {
   if key.length() != 8 {
@@ -354,21 +354,19 @@ pub fn chacha20(
 }
 
 ///|
-fn chacha(
+fn[Data : ByteSource] chacha(
   key : FixedArray[UInt],
   counter : UInt,
-  block : FixedArray[Byte],
+  block : Data,
   round : UInt,
   nonce : UInt,
 ) -> FixedArray[Byte] {
   if block.length() == 0 {
     return FixedArray::make(0, Byte::default())
   }
-  fn takeToFixedArray(b : FixedArray[Byte], len : Int) -> FixedArray[Byte] {
+  fn takeToFixedArray(b : &ByteSource, len : Int) -> FixedArray[Byte] {
     let result = FixedArray::make(len, Byte::default())
-    for i = 0; i < len; i = i + 1 {
-      result[i] = b[i]
-    }
+    b.blit_to(result, len~, src_offset=0, dst_offset=0)
     result
   }
 
@@ -384,11 +382,9 @@ fn chacha(
     result
   }
 
-  fn dropBytes(b : FixedArray[Byte], len : Int) -> FixedArray[Byte] {
+  fn dropBytes(b : &ByteSource, len : Int) -> FixedArray[Byte] {
     let result = FixedArray::make(b.length() - len, Byte::default())
-    for i = 0; i < b.length() - len; i = i + 1 {
-      result[i] = b[len + i]
-    }
+    b.blit_to(result, len=b.length() - len, src_offset=len, dst_offset=0)
     result
   }
 

--- a/crypto/crypto.mbti
+++ b/crypto/crypto.mbti
@@ -1,28 +1,32 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/x/crypto"
 
+import(
+  "moonbitlang/core/bytes"
+)
+
 // Values
 fn bytes_to_hex_string(FixedArray[Byte]) -> String
 
-fn chacha12(FixedArray[UInt], UInt, FixedArray[Byte], nonce~ : UInt = ..) -> FixedArray[Byte] raise
+fn[Data : ByteSource] chacha12(FixedArray[UInt], UInt, Data, nonce~ : UInt = ..) -> FixedArray[Byte] raise
 
-fn chacha20(FixedArray[UInt], UInt, FixedArray[Byte], nonce~ : UInt = ..) -> FixedArray[Byte] raise
+fn[Data : ByteSource] chacha20(FixedArray[UInt], UInt, Data, nonce~ : UInt = ..) -> FixedArray[Byte] raise
 
-fn chacha8(FixedArray[UInt], UInt, FixedArray[Byte], nonce~ : UInt = ..) -> FixedArray[Byte] raise
+fn[Data : ByteSource] chacha8(FixedArray[UInt], UInt, Data, nonce~ : UInt = ..) -> FixedArray[Byte] raise
 
-fn md5(FixedArray[Byte]) -> FixedArray[Byte]
+fn[Data : ByteSource] md5(Data) -> FixedArray[Byte]
 
-fn sha1(FixedArray[Byte]) -> FixedArray[Byte]
+fn[Data : ByteSource] sha1(Data) -> FixedArray[Byte]
 
-fn sha224(FixedArray[Byte]) -> FixedArray[Byte]
+fn[Data : ByteSource] sha224(Data) -> FixedArray[Byte]
 
 fn sha224_from_iter(Iter[Byte]) -> FixedArray[Byte]
 
-fn sha256(FixedArray[Byte]) -> FixedArray[Byte]
+fn[Data : ByteSource] sha256(Data) -> FixedArray[Byte]
 
 fn sha256_from_iter(Iter[Byte]) -> FixedArray[Byte]
 
-fn sm3(FixedArray[Byte]) -> FixedArray[Byte]
+fn[Data : ByteSource] sm3(Data) -> FixedArray[Byte]
 
 fn sm3_from_iter(Iter[Byte]) -> FixedArray[Byte]
 
@@ -32,21 +36,25 @@ fn uints_to_hex_string(Iter[UInt]) -> String
 type MD5Context
 fn MD5Context::finalize(Self) -> FixedArray[Byte]
 fn MD5Context::new() -> Self
-fn MD5Context::update(Self, FixedArray[Byte]) -> Unit
+fn[Data : ByteSource] MD5Context::update(Self, Data) -> Unit
 
 type SM3Context
 fn SM3Context::finalize(Self) -> FixedArray[Byte]
 fn SM3Context::new() -> Self
-fn SM3Context::update(Self, FixedArray[Byte]) -> Unit
+fn[Data : ByteSource] SM3Context::update(Self, Data) -> Unit
 fn SM3Context::update_from_iter(Self, Iter[Byte]) -> Unit
 
 type Sha256Context
 fn Sha256Context::finalize(Self) -> FixedArray[Byte]
 fn Sha256Context::new(reg~ : FixedArray[UInt] = ..) -> Self
-fn Sha256Context::update(Self, FixedArray[Byte]) -> Unit
+fn[Data : ByteSource] Sha256Context::update(Self, Data) -> Unit
 fn Sha256Context::update_from_iter(Self, Iter[Byte]) -> Unit
 
 // Type aliases
 
 // Traits
+trait ByteSource
+impl ByteSource for FixedArray[Byte]
+impl ByteSource for Bytes
+impl ByteSource for @bytes.View
 

--- a/crypto/md5.mbt
+++ b/crypto/md5.mbt
@@ -28,7 +28,10 @@ struct MD5Context {
 let padding : FixedArray[Byte] = FixedArray::make(64, Byte::default())
 
 ///| update the state of given context from new `data` 
-pub fn MD5Context::update(self : MD5Context, data : FixedArray[Byte]) -> Unit {
+pub fn[Data : ByteSource] MD5Context::update(
+  self : MD5Context,
+  data : Data,
+) -> Unit {
   md5_update(self, data)
 }
 
@@ -114,7 +117,7 @@ fn MD5Context::i(x : UInt, y : UInt, z : UInt) -> UInt {
 }
 
 ///|
-fn md5_update(ctx : MD5Context, data : FixedArray[Byte]) -> Unit {
+fn[Data : ByteSource] md5_update(ctx : MD5Context, data : Data) -> Unit {
   let input = FixedArray::make(16, 0U)
   let mut idx = ((ctx.count[0] >> 3) & 0x3f).reinterpret_as_int()
   let length = data.length()
@@ -230,7 +233,7 @@ fn md5_transform(state : FixedArray[UInt], input : FixedArray[UInt]) -> Unit {
 ///| Compute the MD5 digest of some `data` based on [RFC1321](https://www.ietf.org/rfc/rfc1321.txt).
 /// - Note that MD5 is considered _cryptographically broken_.
 /// Unless mandated, more secure alternatives should be preferred.
-pub fn md5(data : FixedArray[Byte]) -> FixedArray[Byte] {
+pub fn[Data : ByteSource] md5(data : Data) -> FixedArray[Byte] {
   let ctx = MD5Context::new()
   md5_update(ctx, data)
   ctx.md5_compute()

--- a/crypto/sha1.mbt
+++ b/crypto/sha1.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-pub fn sha1(input : FixedArray[Byte]) -> FixedArray[Byte] {
+pub fn[Data : ByteSource] sha1(input : Data) -> FixedArray[Byte] {
   // Padding
   let old_length = input.length()
   let bits = old_length.to_uint64() * 8
@@ -22,7 +22,7 @@ pub fn sha1(input : FixedArray[Byte]) -> FixedArray[Byte] {
     new_length += 64
   }
   let bytes = FixedArray::make(new_length, b'\x00')
-  input.blit_to(bytes, len=old_length)
+  input.blit_to(bytes, len=old_length, src_offset=0, dst_offset=0)
   bytes[old_length] = (0x80).to_byte()
   for i = new_length - 8; i < new_length; i = i + 1 {
     bytes[i] = (bits >> (56 - (i - (new_length - 8)) * 8)).to_byte()

--- a/crypto/sha224.mbt
+++ b/crypto/sha224.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-pub fn sha224(data : FixedArray[Byte]) -> FixedArray[Byte] {
+pub fn[Data : ByteSource] sha224(data : Data) -> FixedArray[Byte] {
   let ctx = Sha256Context::new(reg=[
     0xc1059ed8, 0x367cd507, 0x3070dd17, 0xf70e5939, 0xffc00b31, 0x68581511, 0x64f98fa7,
     0xbefa4fa4,

--- a/crypto/sha256.mbt
+++ b/crypto/sha256.mbt
@@ -146,7 +146,7 @@ pub fn update_from_iter(self : Sha256Context, data : Iter[Byte]) -> Unit {
 }
 
 ///| update the state of given context from new `data` 
-pub fn update(self : Sha256Context, data : FixedArray[Byte]) -> Unit {
+pub fn[Data : ByteSource] update(self : Sha256Context, data : Data) -> Unit {
   let mut offset = 0
   while offset < data.length() {
     let min_len = if 64 - self.buf_index >= data.length() - offset {
@@ -192,7 +192,7 @@ pub fn finalize(self : Sha256Context) -> FixedArray[Byte] {
 }
 
 ///| Compute the Sha256 digest in `Bytes` of some `data`. Note that Sha256 is big-endian.
-pub fn sha256(data : FixedArray[Byte]) -> FixedArray[Byte] {
+pub fn[Data : ByteSource] sha256(data : Data) -> FixedArray[Byte] {
   let ctx = Sha256Context::new()
   let _ = ctx.update(data)
   arr_u32_to_u8be(ctx.sha256_compute().iter(), 256)

--- a/crypto/sm3.mbt
+++ b/crypto/sm3.mbt
@@ -215,7 +215,10 @@ pub fn SM3Context::update_from_iter(
 }
 
 ///| update the state of given context from new `data` 
-pub fn SM3Context::update(self : SM3Context, data : FixedArray[Byte]) -> Unit {
+pub fn[Data : ByteSource] SM3Context::update(
+  self : SM3Context,
+  data : Data,
+) -> Unit {
   let mut offset = 0
   while offset < data.length() {
     let min_len = if 64 - self.buf_index >= data.length() - offset {
@@ -261,7 +264,7 @@ pub fn SM3Context::finalize(self : SM3Context) -> FixedArray[Byte] {
 }
 
 ///| Compute the SM3 digest in `FixedArray[Byte]` of some `data`. Note that SM3 is big-endian.
-pub fn sm3(data : FixedArray[Byte]) -> FixedArray[Byte] {
+pub fn[Data : ByteSource] sm3(data : Data) -> FixedArray[Byte] {
   let ctx = SM3Context::new()
   let _ = ctx.update(data)
   arr_u32_to_u8be(ctx.sm3_compute().iter(), 256)


### PR DESCRIPTION
Use a sealed trait to allow accepting `Bytes` `@bytes.View` and `FixedArray[Byte]` as data source.