### PR TITLE
feat(fs): include native stub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ target/
 .mooncakes/
 .clangd
 benchlog/
+.cache/
+compile_commands.json

--- a/fs/blackbox_test.mbt
+++ b/fs/blackbox_test.mbt
@@ -34,7 +34,7 @@ test "read_dir" {
   inspect(
     files,
     content=(
-      #|["fs.mbt", "fs.mbti", "fs_js.mbt", "test_1.txt", "test_2.txt", "fs_wasm.mbt", "fs_native.mbt", "moon.pkg.json", "blackbox_test.mbt"]
+      #|["fs.mbt", "fs.mbti", "fs_js.mbt", "test_1.txt", "test_2.txt", "fs_native.c", "fs_wasm.mbt", "fs_native.mbt", "moon.pkg.json", "blackbox_test.mbt"]
     ),
   )
 }

--- a/fs/fs_native.c
+++ b/fs/fs_native.c
@@ -1,0 +1,253 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#ifdef _WIN32
+#include <direct.h>
+#include <windows.h>
+#else
+#include <dirent.h>
+#include <unistd.h>
+#endif
+
+#include "moonbit.h"
+
+MOONBIT_FFI_EXPORT FILE *moonbitlang_x_fs_fopen_ffi(moonbit_bytes_t path,
+                                                    moonbit_bytes_t mode) {
+  return fopen((const char *)path, (const char *)mode);
+}
+
+MOONBIT_FFI_EXPORT int moonbitlang_x_fs_is_null(void *ptr) {
+  return ptr == NULL;
+}
+
+MOONBIT_FFI_EXPORT size_t moonbitlang_x_fs_fread_ffi(moonbit_bytes_t ptr,
+                                                     int size, int nitems,
+                                                     FILE *stream) {
+  return fread(ptr, size, nitems, stream);
+}
+
+MOONBIT_FFI_EXPORT size_t moonbitlang_x_fs_fwrite_ffi(moonbit_bytes_t ptr,
+                                                      int size, int nitems,
+                                                      FILE *stream) {
+  return fwrite(ptr, size, nitems, stream);
+}
+
+MOONBIT_FFI_EXPORT int moonbitlang_x_fs_fseek_ffi(FILE *stream, long offset,
+                                                  int whence) {
+  return fseek(stream, offset, whence);
+}
+
+MOONBIT_FFI_EXPORT long moonbitlang_x_fs_ftell_ffi(FILE *stream) {
+  return ftell(stream);
+}
+
+MOONBIT_FFI_EXPORT int moonbitlang_x_fs_fflush_ffi(FILE *file) {
+  return fflush(file);
+}
+
+MOONBIT_FFI_EXPORT int moonbitlang_x_fs_fclose_ffi(FILE *stream) {
+  return fclose(stream);
+}
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t moonbitlang_x_fs_get_error_message(void) {
+  const char *err_str = strerror(errno);
+  size_t len = strlen(err_str);
+  moonbit_bytes_t bytes = moonbit_make_bytes(len, 0);
+  memcpy(bytes, err_str, len);
+  return bytes;
+}
+
+MOONBIT_FFI_EXPORT int moonbitlang_x_fs_stat_ffi(moonbit_bytes_t path) {
+  struct stat buffer;
+  int status = stat((const char *)path, &buffer);
+  return status;
+}
+
+MOONBIT_FFI_EXPORT int moonbitlang_x_fs_is_dir_ffi(moonbit_bytes_t path) {
+#ifdef _WIN32
+  DWORD attrs = GetFileAttributes((const char *)path);
+  if (attrs == INVALID_FILE_ATTRIBUTES) {
+    return -1;
+  }
+  if (attrs & FILE_ATTRIBUTE_DIRECTORY) {
+    return 1;
+  }
+  return 0;
+#else
+  struct stat buffer;
+  int status = stat((const char *)path, &buffer);
+  if (status == -1) {
+    return -1;
+  }
+  if (S_ISDIR(buffer.st_mode)) {
+    return 1;
+  }
+  return 0;
+#endif
+}
+
+MOONBIT_FFI_EXPORT int moonbitlang_x_fs_is_file_ffi(moonbit_bytes_t path) {
+#ifdef _WIN32
+  DWORD attrs = GetFileAttributes((const char *)path);
+  if (attrs == INVALID_FILE_ATTRIBUTES) {
+    return -1;
+  }
+  if (!(attrs & FILE_ATTRIBUTE_DIRECTORY)) {
+    return 1;
+  }
+  return 0;
+#else
+  struct stat buffer;
+  int status = stat((const char *)path, &buffer);
+  if (status == -1) {
+    return -1;
+  }
+  if (S_ISREG(buffer.st_mode)) {
+    return 1;
+  }
+  return 0;
+#endif
+}
+
+MOONBIT_FFI_EXPORT int moonbitlang_x_fs_remove_dir_ffi(moonbit_bytes_t path) {
+#ifdef _WIN32
+  return _rmdir((const char *)path);
+#else
+  return rmdir((const char *)path);
+#endif
+}
+
+MOONBIT_FFI_EXPORT int moonbitlang_x_fs_remove_file_ffi(moonbit_bytes_t path) {
+  return remove((const char *)path);
+}
+
+MOONBIT_FFI_EXPORT int moonbitlang_x_fs_create_dir_ffi(moonbit_bytes_t path) {
+#ifdef _WIN32
+  return _mkdir((const char *)path);
+#else
+  return mkdir((const char *)path, 0777);
+#endif
+}
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t *
+moonbitlang_x_fs_read_dir_ffi(moonbit_bytes_t path) {
+#ifdef _WIN32
+  WIN32_FIND_DATA find_data;
+  HANDLE dir;
+  moonbit_bytes_t *result = NULL;
+  int count = 0;
+
+  size_t path_len = strlen((const char *)path);
+  char *search_path = malloc(path_len + 3);
+  if (search_path == NULL) {
+    return NULL;
+  }
+
+  sprintf(search_path, "%s\\*", (const char *)path);
+  dir = FindFirstFile(search_path, &find_data);
+  if (dir == INVALID_HANDLE_VALUE) {
+    DWORD error = GetLastError();
+    fprintf(stderr, "Failed to open directory: error code %lu\n", error);
+    free(search_path);
+    return NULL;
+  }
+
+  do {
+    if (find_data.cFileName[0] != '.') {
+      count++;
+    }
+  } while (FindNextFile(dir, &find_data));
+
+  FindClose(dir);
+  dir = FindFirstFile(search_path, &find_data);
+  free(search_path);
+
+  result = (moonbit_bytes_t *)moonbit_make_ref_array(count, NULL);
+  if (result == NULL) {
+    FindClose(dir);
+    return NULL;
+  }
+
+  int index = 0;
+  do {
+    if (find_data.cFileName[0] != '.') {
+      size_t name_len = strlen(find_data.cFileName);
+      moonbit_bytes_t item = moonbit_make_bytes(name_len, 0);
+      memcpy(item, find_data.cFileName, name_len);
+      result[index++] = item;
+    }
+  } while (FindNextFile(dir, &find_data));
+
+  FindClose(dir);
+  return result;
+#else
+
+  DIR *dir;
+  struct dirent *entry;
+  moonbit_bytes_t *result = NULL;
+  int count = 0;
+
+  // open the directory
+  dir = opendir((const char *)path);
+  if (dir == NULL) {
+    perror("opendir");
+    return NULL;
+  }
+
+  // first traversal of the directory, calculate the number of items
+  while ((entry = readdir(dir)) != NULL) {
+    // ignore hidden files and current/parent directories
+    if (entry->d_name[0] != '.') {
+      count++;
+    }
+  }
+
+  // reset the directory stream
+  rewinddir(dir);
+
+  // create moonbit_ref_array to store the result
+  result = (moonbit_bytes_t *)moonbit_make_ref_array(count, NULL);
+  if (result == NULL) {
+    closedir(dir);
+    return NULL;
+  }
+
+  // second traversal of the directory, fill the array
+  int index = 0;
+  while ((entry = readdir(dir)) != NULL) {
+    if (entry->d_name[0] != '.') {
+      size_t name_len = strlen(entry->d_name);
+      moonbit_bytes_t item = moonbit_make_bytes(name_len, 0);
+      memcpy(item, entry->d_name, name_len);
+      result[index++] = item;
+    }
+  }
+
+  closedir(dir);
+  return result;
+#endif
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/fs/fs_native.mbt
+++ b/fs/fs_native.mbt
@@ -17,10 +17,10 @@
 priv type Handler
 
 ///|
-extern "C" fn fopen_ffi(path : Bytes, mode : Bytes) -> Handler = "moonbit_fopen_ffi"
+extern "C" fn fopen_ffi(path : Bytes, mode : Bytes) -> Handler = "moonbitlang_x_fs_fopen_ffi"
 
 ///|
-extern "C" fn is_null(ptr : Handler) -> Int = "moonbit_is_null"
+extern "C" fn is_null(ptr : Handler) -> Int = "moonbitlang_x_fs_is_null"
 
 ///|
 extern "C" fn fread_ffi(
@@ -28,7 +28,7 @@ extern "C" fn fread_ffi(
   size : Int,
   nitems : Int,
   stream : Handler,
-) -> Int = "moonbit_fread_ffi"
+) -> Int = "moonbitlang_x_fs_fread_ffi"
 
 ///|
 extern "C" fn fwrite_ffi(
@@ -36,22 +36,22 @@ extern "C" fn fwrite_ffi(
   size : Int,
   nitems : Int,
   stream : Handler,
-) -> Int = "moonbit_fwrite_ffi"
+) -> Int = "moonbitlang_x_fs_fwrite_ffi"
 
 ///|
-extern "C" fn get_error_message_ffi() -> Bytes = "moonbit_get_error_message"
+extern "C" fn get_error_message_ffi() -> Bytes = "moonbitlang_x_fs_get_error_message"
 
 ///|
-extern "C" fn fseek_ffi(file : Handler, offset : Int, whence : Int) -> Int = "moonbit_fseek_ffi"
+extern "C" fn fseek_ffi(file : Handler, offset : Int, whence : Int) -> Int = "moonbitlang_x_fs_fseek_ffi"
 
 ///|
-extern "C" fn ftell_ffi(file : Handler) -> Int = "moonbit_ftell_ffi"
+extern "C" fn ftell_ffi(file : Handler) -> Int = "moonbitlang_x_fs_ftell_ffi"
 
 ///|
-extern "C" fn fflush_ffi(stream : Handler) -> Int = "moonbit_fflush_ffi"
+extern "C" fn fflush_ffi(stream : Handler) -> Int = "moonbitlang_x_fs_fflush_ffi"
 
 ///|
-extern "C" fn fclose_ffi(file : Handler) -> Int = "moonbit_fclose_ffi"
+extern "C" fn fclose_ffi(file : Handler) -> Int = "moonbitlang_x_fs_fclose_ffi"
 
 ///|
 fn get_error_message() -> String {
@@ -117,7 +117,7 @@ fn write_string_to_file_internal(
 }
 
 ///|
-extern "C" fn stat_ffi(path : Bytes) -> Int = "moonbit_stat_ffi"
+extern "C" fn stat_ffi(path : Bytes) -> Int = "moonbitlang_x_fs_stat_ffi"
 
 ///|
 fn path_exists_internal(path : String) -> Bool {
@@ -125,7 +125,7 @@ fn path_exists_internal(path : String) -> Bool {
 }
 
 ///|
-extern "C" fn read_dir_ffi(path : Bytes) -> Handler = "moonbit_read_dir_ffi"
+extern "C" fn read_dir_ffi(path : Bytes) -> Handler = "moonbitlang_x_fs_read_dir_ffi"
 
 ///|
 fn handler_to_fixed_array(handler : Handler) -> FixedArray[Bytes] = "%identity"
@@ -139,7 +139,7 @@ fn read_dir_internal(path : String) -> Array[String] raise IOError {
 }
 
 ///|
-extern "C" fn create_dir_ffi(path : Bytes) -> Int = "moonbit_create_dir_ffi"
+extern "C" fn create_dir_ffi(path : Bytes) -> Int = "moonbitlang_x_fs_create_dir_ffi"
 
 ///|
 fn create_dir_internal(path : String) -> Unit raise IOError {
@@ -149,7 +149,7 @@ fn create_dir_internal(path : String) -> Unit raise IOError {
 }
 
 ///|
-extern "C" fn is_dir_ffi(path : Bytes) -> Int = "moonbit_is_dir_ffi"
+extern "C" fn is_dir_ffi(path : Bytes) -> Int = "moonbitlang_x_fs_is_dir_ffi"
 
 ///|
 fn is_dir_internal(path : String) -> Bool raise IOError {
@@ -159,7 +159,7 @@ fn is_dir_internal(path : String) -> Bool raise IOError {
 }
 
 ///|
-extern "C" fn is_file_ffi(path : Bytes) -> Int = "moonbit_is_file_ffi"
+extern "C" fn is_file_ffi(path : Bytes) -> Int = "moonbitlang_x_fs_is_file_ffi"
 
 ///|
 fn is_file_internal(path : String) -> Bool raise IOError {
@@ -169,7 +169,7 @@ fn is_file_internal(path : String) -> Bool raise IOError {
 }
 
 ///|
-extern "C" fn remove_dir_ffi(path : Bytes) -> Int = "moonbit_remove_dir_ffi"
+extern "C" fn remove_dir_ffi(path : Bytes) -> Int = "moonbitlang_x_fs_remove_dir_ffi"
 
 ///|
 fn remove_dir_internal(path : String) -> Unit raise IOError {
@@ -179,7 +179,7 @@ fn remove_dir_internal(path : String) -> Unit raise IOError {
 }
 
 ///|
-extern "C" fn remove_file_ffi(path : Bytes) -> Int = "moonbit_remove_file_ffi"
+extern "C" fn remove_file_ffi(path : Bytes) -> Int = "moonbitlang_x_fs_remove_file_ffi"
 
 ///|
 fn remove_file_internal(path : String) -> Unit raise IOError {

--- a/fs/moon.pkg.json
+++ b/fs/moon.pkg.json
@@ -6,5 +6,6 @@
         "fs_wasm.mbt": ["wasm", "wasm-gc"],
         "fs_js.mbt": ["js"],
         "fs_native.mbt": ["native", "llvm"]
-    }
+    },
+    "native-stub": ["fs_native.c"]
 }


### PR DESCRIPTION
Migrate the native stub for `x` to this library such that they are maintained side by side.