### PR TITLE
perf: refactor chacha implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Updated the READMEs by switching to `.mbt.md` format (#164)
 - Fixed the overflow for rational's equality check (#167)
 - Updated MoonBit toolchain support to 0.6.22, updated info file (#169)
+- Refactored ChaCha series to make them faster (#170)
 
 ### Changed
 

--- a/crypto/chacha.mbt
+++ b/crypto/chacha.mbt
@@ -256,23 +256,15 @@ test "chachaBlock" {
 
 ///|
 fn stateToBytes(state : FixedArray[UInt]) -> FixedArray[Byte] {
-  fn from_array(arr : Array[UInt]) -> FixedArray[Byte] {
-    let rv = FixedArray::make(arr.length(), Byte::default())
-    for i = 0; i < arr.length(); i = i + 1 {
-      rv[i] = arr[i].to_byte()
-    }
-    rv
-  }
-
-  let result = Array::make(64, 0U)
+  let result = FixedArray::make(4 * state.length(), b'\x00')
   for i = 0; i < 16; i = i + 1 {
     let word = state[i]
-    result[i * 4 + 3] = word & 0xff
-    result[i * 4 + 2] = (word & 0xff00) >> 8
-    result[i * 4 + 1] = (word & 0xff0000) >> 16
-    result[i * 4 + 0] = (word & 0xff000000) >> 24
+    result[i * 4 + 3] = word.to_byte()
+    result[i * 4 + 2] = (word >> 8).to_byte()
+    result[i * 4 + 1] = (word >> 16).to_byte()
+    result[i * 4 + 0] = (word >> 24).to_byte()
   }
-  from_array(result)
+  result
 }
 
 ///|

--- a/crypto/chacha.mbt
+++ b/crypto/chacha.mbt
@@ -170,35 +170,6 @@ test "chachaBlockLoop" {
   )
 }
 
-///|
-fn zipWith(
-  op : (UInt, UInt) -> UInt,
-  state1 : FixedArray[UInt],
-  state2 : FixedArray[UInt],
-) -> FixedArray[UInt] {
-  let result = FixedArray::make(state1.length(), 0U)
-  for i = 0; i < state1.length(); i = i + 1 {
-    result[i] = op(state1[i], state2[i])
-  }
-  result
-}
-
-///|
-test "zipWith" {
-  let state1 = FixedArray::make(4, 0U)
-  state1[0] = 1
-  state1[1] = 2
-  state1[2] = 3
-  state1[3] = 4
-  let state2 = FixedArray::make(4, 0U)
-  state2[0] = 5
-  state2[1] = 6
-  state2[2] = 7
-  state2[3] = 8
-  let result = zipWith(UInt::op_add, state1, state2)
-  inspect(result, content="[6, 8, 10, 12]")
-}
-
 ///| - chacha8: round = 4
 /// - chacha12: round = 6
 /// - chacha20: round = 10

--- a/crypto/chacha.mbt
+++ b/crypto/chacha.mbt
@@ -36,24 +36,26 @@ fn FixedArray::quarterRound(
   y : Int,
   z : Int,
 ) -> Unit {
-  fn fullQuarterRound(
-    a : UInt,
-    b : UInt,
-    c : UInt,
-    d : UInt,
-  ) -> (UInt, UInt, UInt, UInt) {
-    (a, b, c, d)
-    |> quarterRound1
-    |> quarterRound2
-    |> quarterRound3
-    |> quarterRound4
-  }
-
-  let t = fullQuarterRound(state[w], state[x], state[y], state[z])
-  state[w] = t.0
-  state[x] = t.1
-  state[y] = t.2
-  state[z] = t.3
+  let mut a = state[w]
+  let mut b = state[x]
+  let mut c = state[y]
+  let mut d = state[z]
+  a += b
+  d = d ^ a
+  d = rotate_left_u(d, 16)
+  c += d
+  b = b ^ c
+  b = rotate_left_u(b, 12)
+  a += b
+  d = d ^ a
+  d = rotate_left_u(d, 8)
+  c += d
+  b = b ^ c
+  b = rotate_left_u(b, 7)
+  state[w] = a
+  state[x] = b
+  state[y] = c
+  state[z] = d
 }
 
 ///|
@@ -379,36 +381,4 @@ fn[Data : ByteSource] chacha(
     }
   }
   buffer
-}
-
-///|
-fn quarterRound1(t : (UInt, UInt, UInt, UInt)) -> (UInt, UInt, UInt, UInt) {
-  let aprime = t.0 + t.1
-  let dprime = t.3 ^ aprime
-  let dout = rotate_left_u(dprime, 16)
-  (aprime, t.1, t.2, dout)
-}
-
-///|
-fn quarterRound2(t : (UInt, UInt, UInt, UInt)) -> (UInt, UInt, UInt, UInt) {
-  let cprime = t.2 + t.3
-  let bprime = t.1 ^ cprime
-  let bout = rotate_left_u(bprime, 12)
-  (t.0, bout, cprime, t.3)
-}
-
-///|
-fn quarterRound3(t : (UInt, UInt, UInt, UInt)) -> (UInt, UInt, UInt, UInt) {
-  let aprime = t.0 + t.1
-  let dprime = t.3 ^ aprime
-  let dout = rotate_left_u(dprime, 8)
-  (aprime, t.1, t.2, dout)
-}
-
-///|
-fn quarterRound4(t : (UInt, UInt, UInt, UInt)) -> (UInt, UInt, UInt, UInt) {
-  let cprime = t.2 + t.3
-  let bprime = t.1 ^ cprime
-  let bout = rotate_left_u(bprime, 7)
-  (t.0, bout, cprime, t.3)
 }

--- a/crypto/chacha.mbt
+++ b/crypto/chacha.mbt
@@ -364,57 +364,21 @@ fn[Data : ByteSource] chacha(
   if block.length() == 0 {
     return FixedArray::make(0, Byte::default())
   }
-  fn takeToFixedArray(b : &ByteSource, len : Int) -> FixedArray[Byte] {
-    let result = FixedArray::make(len, Byte::default())
-    b.blit_to(result, len~, src_offset=0, dst_offset=0)
-    result
-  }
-
-  fn zipWith(
-    op : (Byte, Byte) -> Byte,
-    state1 : FixedArray[Byte],
-    state2 : FixedArray[Byte],
-  ) -> FixedArray[Byte] {
-    let result = FixedArray::make(state1.length(), Byte::default())
-    for i = 0; i < state1.length(); i = i + 1 {
-      result[i] = op(state1[i], state2[i])
+  let buffer = FixedArray::make(block.length(), Byte::default())
+  for i = 0; i < block.length(); i = i + 64 {
+    let keyStream = chachaBlock(
+      key,
+      counter + i.reinterpret_as_uint() / 64,
+      nonce,
+      round,
+    )
+    let pad = stateToBytes(keyStream)
+    let len = @cmp.minimum(block.length() - i, 64)
+    for j in 0..<len {
+      buffer[i + j] = pad[j] ^ block[i + j]
     }
-    result
   }
-
-  fn dropBytes(b : &ByteSource, len : Int) -> FixedArray[Byte] {
-    let result = FixedArray::make(b.length() - len, Byte::default())
-    b.blit_to(result, len=b.length() - len, src_offset=len, dst_offset=0)
-    result
-  }
-
-  fn concatBytes(
-    b1 : FixedArray[Byte],
-    b2 : FixedArray[Byte],
-  ) -> FixedArray[Byte] {
-    let result = FixedArray::make(b1.length() + b2.length(), Byte::default())
-    for i = 0; i < b1.length(); i = i + 1 {
-      result[i] = b1[i]
-    }
-    for i = 0; i < b2.length(); i = i + 1 {
-      result[b1.length() + i] = b2[i]
-    }
-    result
-  }
-
-  let keyStream = chachaBlock(key, counter, nonce, round)
-  let pad = stateToBytes(keyStream)
-  let len = if block.length() < 64 { block.length() } else { 64 }
-  let maskedBlock = zipWith(
-    Byte::lxor,
-    takeToFixedArray(pad, len),
-    takeToFixedArray(block, len),
-  )
-  let res = concatBytes(
-    maskedBlock,
-    chacha(key, counter + 1, dropBytes(block, len), round, nonce),
-  )
-  res
+  buffer
 }
 
 ///|

--- a/crypto/chacha.mbt
+++ b/crypto/chacha.mbt
@@ -29,20 +29,24 @@ test "flipWord" {
 }
 
 ///|
-fn quarterRound(
+fn FixedArray::quarterRound(
   state : FixedArray[UInt],
   w : Int,
   x : Int,
   y : Int,
   z : Int,
-) -> FixedArray[UInt] {
+) -> Unit {
   fn fullQuarterRound(
     a : UInt,
     b : UInt,
     c : UInt,
     d : UInt,
   ) -> (UInt, UInt, UInt, UInt) {
-    quarterRound4(quarterRound3(quarterRound2(quarterRound1((a, b, c, d)))))
+    (a, b, c, d)
+    |> quarterRound1
+    |> quarterRound2
+    |> quarterRound3
+    |> quarterRound4
   }
 
   let t = fullQuarterRound(state[w], state[x], state[y], state[z])
@@ -50,7 +54,6 @@ fn quarterRound(
   state[x] = t.1
   state[y] = t.2
   state[z] = t.3
-  state
 }
 
 ///|
@@ -72,24 +75,24 @@ test "quarterRound" {
   state[13] = 0x3d631689U
   state[14] = 0x2098d9d6U
   state[15] = 0x91dbd320U
-  let newState = quarterRound(state, 2, 7, 8, 13)
+  state.quarterRound(2, 7, 8, 13)
   inspect(
-    newState,
+    state,
     content="[2274701792, 3320640381, 3182986972, 3383111562, 1153568499, 865120127, 3657197835, 3484200914, 3832277632, 2953467441, 2538361882, 899586403, 1553404001, 3435166841, 546888150, 2447102752]",
   )
 }
 
 ///|
-fn chachaBlockRound(state : FixedArray[UInt]) -> FixedArray[UInt] {
-  let state1 = quarterRound(state, 0, 4, 8, 12)
-  let state2 = quarterRound(state1, 1, 5, 9, 13)
-  let state3 = quarterRound(state2, 2, 6, 10, 14)
-  let state4 = quarterRound(state3, 3, 7, 11, 15)
-  let state5 = quarterRound(state4, 0, 5, 10, 15)
-  let state6 = quarterRound(state5, 1, 6, 11, 12)
-  let state7 = quarterRound(state6, 2, 7, 8, 13)
-  let state8 = quarterRound(state7, 3, 4, 9, 14)
-  state8
+fn FixedArray::chachaBlockRound(state : FixedArray[UInt]) -> Unit {
+  state
+  ..quarterRound(0, 4, 8, 12)
+  ..quarterRound(1, 5, 9, 13)
+  ..quarterRound(2, 6, 10, 14)
+  ..quarterRound(3, 7, 11, 15)
+  ..quarterRound(0, 5, 10, 15)
+  ..quarterRound(1, 6, 11, 12)
+  ..quarterRound(2, 7, 8, 13)
+  ..quarterRound(3, 4, 9, 14)
 }
 
 ///|
@@ -111,18 +114,17 @@ test "chachaBlockRound" {
   state[13] = 0x00000000U
   state[14] = 0x00000000U
   state[15] = 0x00000000U
-  let newState = chachaBlockRound(state)
+  state.chachaBlockRound()
   inspect(
-    newState,
+    state,
     content="[986087425, 3489031050, 2890662805, 2683391196, 1720476390, 1116253759, 2262580386, 3212003942, 2202368212, 756352536, 496298475, 669838588, 567302638, 1860562437, 1434237441, 2097484794]",
   )
 }
 
 ///|
-fn chachaBlockLoop(state : FixedArray[UInt], n : UInt) -> FixedArray[UInt] {
-  match n {
-    0 => state.copy()
-    _ => chachaBlockLoop(chachaBlockRound(state.copy()), n - 1)
+fn FixedArray::chachaBlockLoop(state : FixedArray[UInt], n : UInt) -> Unit {
+  for i in 0U..<n {
+    state.chachaBlockRound()
   }
 }
 
@@ -159,16 +161,11 @@ test "chachaBlockLoop" {
     state,
     content="[1634760805, 857760878, 2036477234, 1797285236, 50462976, 117835012, 185207048, 252579084, 319951120, 387323156, 454695192, 522067228, 1, 0, 0, 0]",
   )
-  let newState = chachaBlockLoop(state, 4)
+  state.chachaBlockLoop(4)
   inspect(
-    newState,
+    state,
     content="[2919080465, 647515738, 898727107, 777299107, 3407982512, 2489307765, 745530666, 2053399858, 1994399329, 139328223, 3709168053, 3118545354, 4170274417, 867477305, 1393604261, 3769539545]",
   )
-}
-
-///|
-fn flipState(state : FixedArray[UInt]) -> FixedArray[UInt] {
-  state.map(flipWord)
 }
 
 ///|
@@ -229,9 +226,12 @@ fn chachaBlock(
   state[13] = nonce
   state[14] = nonce
   state[15] = nonce
-  let mixedState = chachaBlockLoop(state.copy(), round)
-  let combinedState = zipWith(UInt::op_add, state, mixedState)
-  flipState(combinedState)
+  let mixedState = state.copy()
+  mixedState.chachaBlockLoop(round)
+  for i in 0..<16 {
+    mixedState[i] = flipWord(mixedState[i] + state[i])
+  }
+  mixedState
 }
 
 ///|

--- a/crypto/chacha_test.mbt
+++ b/crypto/chacha_test.mbt
@@ -36,3 +36,24 @@ test "chachaEncrypt" {
   let expected = "17b882adc3f1"
   assert_eq(bytes_to_hex_string(encrypted), expected)
 }
+
+///|
+test (bench : @bench.T) {
+  let key = FixedArray::make(8, 0U)
+  key[0] = 0
+  key[1] = 0
+  key[2] = 0
+  key[3] = 0
+  key[4] = 0
+  key[5] = 0
+  key[6] = 0
+  key[7] = 0
+  let plaintext = "abc".repeat(100)
+  let block = plaintext.to_bytes().to_fixedarray()
+  bench.bench(fn() {
+    let _ = try! @crypto.chacha8(key, 0, block)
+    let _ = try! @crypto.chacha12(key, 0, block)
+    let _ = try! @crypto.chacha20(key, 0, block)
+
+  })
+}


### PR DESCRIPTION
Before:

```
bench moonbitlang/x/crypto/chacha_test.mbt::1
time (mean ± σ)         range (min … max) 
 294.84 µs ±  11.64 µs   279.83 µs … 308.53 µs  in 10 ×    363 runs
Total tests: 1, passed: 1, failed: 0. [wasm]
bench moonbitlang/x/crypto/chacha_test.mbt::1
time (mean ± σ)         range (min … max) 
  45.97 µs ±   0.52 µs    45.42 µs …  46.91 µs  in 10 ×   2109 runs
Total tests: 1, passed: 1, failed: 0. [wasm-gc]
bench moonbitlang/x/crypto/chacha_test.mbt::1
time (mean ± σ)         range (min … max) 
 216.62 µs ±   5.45 µs   212.35 µs … 226.38 µs  in 10 ×    464 runs
Total tests: 1, passed: 1, failed: 0. [js]
bench moonbitlang/x/crypto/chacha_test.mbt::1
time (mean ± σ)         range (min … max) 
  95.79 µs ±   0.87 µs    95.19 µs …  98.04 µs  in 10 ×   1049 runs
Total tests: 1, passed: 1, failed: 0. [native]
```

After:

```
bench moonbitlang/x/crypto/chacha_test.mbt::1
time (mean ± σ)         range (min … max) 
 184.69 µs ±   8.03 µs   173.31 µs … 196.76 µs  in 10 ×    494 runs
Total tests: 1, passed: 1, failed: 0. [wasm]
bench moonbitlang/x/crypto/chacha_test.mbt::1
time (mean ± σ)         range (min … max) 
   8.12 µs ±   0.02 µs     8.10 µs …   8.17 µs  in 10 ×  12304 runs
Total tests: 1, passed: 1, failed: 0. [wasm-gc]
bench moonbitlang/x/crypto/chacha_test.mbt::1
time (mean ± σ)         range (min … max) 
  33.05 µs ±   0.54 µs    32.70 µs …  34.23 µs  in 10 ×   3081 runs
Total tests: 1, passed: 1, failed: 0. [js]
bench moonbitlang/x/crypto/chacha_test.mbt::1
time (mean ± σ)         range (min … max) 
  37.05 µs ±   0.27 µs    36.80 µs …  37.65 µs  in 10 ×   2700 runs
Total tests: 1, passed: 1, failed: 0. [native]
```