### PR TITLE
fix: lex_string flush bug ignores characters at start of input

### DIFF
--- a/json5/lex_string.mbt
+++ b/json5/lex_string.mbt
@@ -80,6 +80,18 @@ fn lex_string(ctx : ParseContext, quote : Char) -> String raise ParseError {
 }
 
 ///|
+test {
+  //If start < 0 && is not removed, the test has no input. After removing it, the output is correct.
+  // 1. 输入是 "hello" (不带起始引号)
+  let ctx = ParseContext::make("hello\"")
+
+  // 2. *不* 预先读取字符，直接调用 lex_string
+  //    此时 ctx.offset 是 0
+  let result = lex_string(ctx, '"')
+  println(result)
+}
+
+///|
 fn lex_hex_digits(ctx : ParseContext, n : Int) -> Int raise ParseError {
   let mut r = 0
   for i = 0; i < n; i = i + 1 {


### PR DESCRIPTION

# Bug: lex_string flush ignores characters at start of input

## Description

In `lex_string`, the `flush` function was originally written as:

```moonbit
if start > 0 && end > start {
    buf.write_substring(ctx.input, start, end - start)
}
```

When parsing a string literal that starts at the beginning of the input (`ctx.offset = 0`), the first call to `flush` does not add any characters to the buffer, causing the returned string to be empty. This issue only occurs when the string starts at the beginning of the input or when `start = 0` during the first flush.

## Fix

Remove the `start > 0` condition and use:

```moonbit
if end > start {
    buf.write_substring(ctx.input, start, end - start)
}
```

This ensures that characters at the start of the string are correctly added to the buffer.