### PR TITLE
feat(fs): add file stat functionality across platforms

### DIFF
--- a/benchmark/internal/benchmark_ffi/pkg.generated.mbti
+++ b/benchmark/internal/benchmark_ffi/pkg.generated.mbti
@@ -2,14 +2,14 @@
 package "moonbitlang/x/benchmark/internal/benchmark_ffi"
 
 // Values
-fn instant_elapsed_as_secs_f64(Instant) -> Double
+fn instant_elapsed_as_secs_f64(Date) -> Double
 
-fn instant_now() -> Instant
+fn instant_now() -> Date
 
 // Errors
 
 // Types and methods
-type Instant
+type Date
 
 // Type aliases
 

--- a/fs/blackbox_test.mbt
+++ b/fs/blackbox_test.mbt
@@ -50,3 +50,38 @@ test "create_dir_and_remove_dir" {
   @fs.remove_dir(path)
   assert_false(@fs.path_exists(path))
 }
+
+///|
+test "stat" {
+  let path = "./fs/stat_test.txt"
+  // Ensure cleanup if previous run failed
+  if @fs.path_exists(path) {
+    @fs.remove_file(path)
+  }
+  let content = "12345"
+  @fs.write_string_to_file(path, content)
+  let stats = @fs.stats(path)
+  // println(stats)
+
+  // Basic Type and Size
+  inspect(stats.size, content="5")
+
+  // Time fields check (sanity check: should be non-zero)
+  assert_true(stats.atime_sec > 0L)
+  assert_true(stats.mtime_sec > 0L)
+  assert_true(stats.ctime_sec > 0L)
+
+  // Metadata checks
+  assert_true(stats.nlink >= 1UL)
+
+  // Mode check: Verify it's a regular file (S_IFREG is 0o100000)
+  // We mask with S_IFMT (0o170000) to get the file type bits
+  let is_reg = (stats.mode & 0o170000U) == 0o100000U
+  assert_true(is_reg)
+
+  // UID/GID should be readable (printing them to ensure they are valid numbers)
+  // Note: specific values depend on the environment, so we just check they exist
+  inspect(stats.uid >= 0U, content="true")
+  inspect(stats.gid >= 0U, content="true")
+  @fs.remove_file(path)
+}

--- a/fs/fs.mbt
+++ b/fs/fs.mbt
@@ -146,6 +146,103 @@ pub fn is_file(path : String) -> Bool raise IOError {
 }
 
 ///|
+pub struct Stats {
+  dev : UInt64
+  mode : UInt
+  nlink : UInt64
+  ino : UInt64
+  uid : UInt
+  gid : UInt
+  rdev : UInt64
+  atime_sec : Int64
+  atime_nsec : Int64
+  mtime_sec : Int64
+  mtime_nsec : Int64
+  ctime_sec : Int64
+  ctime_nsec : Int64
+  birthtime_sec : Int64
+  birthtime_nsec : Int64
+  size : Int64
+  blocks : UInt64
+  blksize : UInt
+  flags : UInt
+  gen : UInt
+  lspare : Int
+  qspare : (Int64, Int64)
+} derive(Show, Eq)
+
+///|
+fn decode_stat(b : Bytes) -> Stats raise IOError {
+  match b {
+    [
+      u64le(dev),
+      u32le(mode),
+      u32le(_),
+      u64le(nlink),
+      u64le(ino),
+      u32le(uid),
+      u32le(gid),
+      u64le(rdev),
+      i64le(atime_sec),
+      i64le(atime_nsec),
+      i64le(mtime_sec),
+      i64le(mtime_nsec),
+      i64le(ctime_sec),
+      i64le(ctime_nsec),
+      i64le(birthtime_sec),
+      i64le(birthtime_nsec),
+      i64le(size),
+      u64le(blocks),
+      u32le(blksize),
+      u32le(flags),
+      u32le(gen),
+      i32le(lspare),
+      i64le(qspare_0),
+      i64le(qspare_1),
+    ] =>
+      {
+        dev,
+        mode,
+        nlink,
+        ino,
+        uid,
+        gid,
+        rdev,
+        atime_sec,
+        atime_nsec,
+        mtime_sec,
+        mtime_nsec,
+        ctime_sec,
+        ctime_nsec,
+        birthtime_sec,
+        birthtime_nsec,
+        size,
+        blocks,
+        blksize,
+        flags,
+        gen,
+        lspare,
+        qspare: (qspare_0, qspare_1),
+      }
+    _ => raise IOError("invalid stat buffer")
+  }
+}
+
+///|
+/// Returns the statistics of the file specified by the given path.
+///
+/// # Parameters
+///
+/// - `path` : The path to the file.
+///
+/// # Returns
+///
+/// - A `Stats` structure containing file information.
+pub fn stats(path : String) -> Stats raise IOError {
+  stat_internal(path)
+}
+
+///|
 /// Removes a directory at the specified path.
 ///
 /// # Parameters

--- a/fs/fs_js.mbt
+++ b/fs/fs_js.mbt
@@ -247,3 +247,65 @@ fn remove_file_internal(path : String) -> Unit raise IOError {
     raise IOError(get_error_message_ffi())
   }
 }
+
+///|
+
+///|
+extern "js" fn stat_details_ffi(path : String, out_buf : Bytes) -> Int =
+  #| function(path, out_buf) {
+  #|   var fs = require('fs');
+  #|   try {
+  #|     const s = fs.statSync(path, {bigint: true});
+  #|     const view = new DataView(out_buf.buffer, out_buf.byteOffset, out_buf.byteLength);
+  #|     
+  #|     view.setBigUint64(0, s.dev, true);
+  #|     view.setUint32(8, Number(s.mode), true);
+  #|     view.setUint32(12, 0, true); // padding
+  #|     view.setBigUint64(16, s.nlink, true);
+  #|     view.setBigUint64(24, s.ino, true);
+  #|     view.setUint32(32, Number(s.uid), true);
+  #|     view.setUint32(36, Number(s.gid), true);
+  #|     view.setBigUint64(40, s.rdev, true);
+  #|     
+  #|     const splitTime = (ns, offset) => {
+  #|       if (ns === undefined) {
+  #|         view.setBigInt64(offset, 0n, true);
+  #|         view.setBigInt64(offset + 8, 0n, true);
+  #|         return;
+  #|       }
+  #|       const sec = ns / 1000000000n;
+  #|       const nsec = ns % 1000000000n;
+  #|       view.setBigInt64(offset, sec, true);
+  #|       view.setBigInt64(offset + 8, nsec, true);
+  #|     };
+  #|
+  #|     splitTime(s.atimeNs, 48);
+  #|     splitTime(s.mtimeNs, 64);
+  #|     splitTime(s.ctimeNs, 80);
+  #|     splitTime(s.birthtimeNs, 96);
+  #|
+  #|     view.setBigInt64(112, s.size, true);
+  #|     view.setBigUint64(120, s.blocks || 0n, true);
+  #|     view.setUint32(128, Number(s.blksize || 0), true);
+  #|     view.setUint32(132, 0, true); // flags
+  #|     view.setUint32(136, 0, true); // gen
+  #|     view.setInt32(140, 0, true); // lspare
+  #|     view.setBigInt64(144, 0n, true); // qspare
+  #|     view.setBigInt64(152, 0n, true); // qspare
+  #|
+  #|     return 0;
+  #|   } catch (error) {
+  #|     globalThis.errorMessage = error.message;
+  #|     return -1;
+  #|   }
+  #| }
+
+///|
+fn stat_internal(path : String) -> Stats raise IOError {
+  let buf = Bytes::make(160, 0)
+  let res = stat_details_ffi(path, buf)
+  if res == -1 {
+    raise IOError(get_error_message_ffi())
+  }
+  decode_stat(buf)
+}

--- a/fs/fs_native.mbt
+++ b/fs/fs_native.mbt
@@ -197,3 +197,15 @@ fn remove_file_internal(path : String) -> Unit raise IOError {
     raise IOError(get_error_message())
   }
 }
+
+///|
+#borrow(path, out_buf)
+extern "C" fn stat_details_ffi(path : Bytes, out_buf : Bytes) -> Int = "moonbitlang_x_fs_stat_details_ffi"
+
+///|
+fn stat_internal(path : String) -> Stats raise IOError {
+  let buf = Bytes::make(160, 0)
+  let res = stat_details_ffi(@ffi.mbt_string_to_utf8_bytes(path, true), buf)
+  guard res == 0 else { raise IOError(get_error_message()) }
+  decode_stat(buf)
+}

--- a/fs/fs_wasm.mbt
+++ b/fs/fs_wasm.mbt
@@ -157,3 +157,17 @@ fn remove_dir_internal(path : String) -> Unit raise IOError {
   let res = remove_dir_ffi(@ffi.string_to_extern(path))
   guard res != -1 else { raise IOError(get_error_message()) }
 }
+
+///|
+fn stat_ffi(path : XExternString) -> Int = "__moonbit_fs_unstable" "stat"
+
+///|
+fn get_stat_content_ffi() -> XExternByteArray = "__moonbit_fs_unstable" "get_stat_content"
+
+///|
+fn stat_internal(path : String) -> Stats raise IOError {
+  let res = stat_ffi(@ffi.string_to_extern(path))
+  guard res != -1 else { raise IOError(get_error_message()) }
+  let buf = @ffi.byte_array_from_extern(get_stat_content_ffi())
+  decode_stat(buf)
+}

--- a/fs/pkg.generated.mbti
+++ b/fs/pkg.generated.mbti
@@ -10,6 +10,8 @@ fn is_file(String) -> Bool raise IOError
 
 fn path_exists(String) -> Bool
 
+fn path_exists_internal(String) -> Bool
+
 fn read_dir(String) -> Array[String] raise IOError
 
 fn read_file_to_bytes(String) -> Bytes raise IOError
@@ -20,6 +22,8 @@ fn remove_dir(String) -> Unit raise IOError
 
 fn remove_file(String) -> Unit raise IOError
 
+fn stats(String) -> Stats raise IOError
+
 fn write_bytes_to_file(String, Bytes) -> Unit raise IOError
 
 fn write_string_to_file(String, String, encoding? : String) -> Unit raise IOError
@@ -29,6 +33,32 @@ pub(all) suberror IOError String
 impl Show for IOError
 
 // Types and methods
+pub struct Stats {
+  dev : UInt64
+  mode : UInt
+  nlink : UInt64
+  ino : UInt64
+  uid : UInt
+  gid : UInt
+  rdev : UInt64
+  atime_sec : Int64
+  atime_nsec : Int64
+  mtime_sec : Int64
+  mtime_nsec : Int64
+  ctime_sec : Int64
+  ctime_nsec : Int64
+  birthtime_sec : Int64
+  birthtime_nsec : Int64
+  size : Int64
+  blocks : UInt64
+  blksize : UInt
+  flags : UInt
+  gen : UInt
+  lspare : Int
+  qspare : (Int64, Int64)
+}
+impl Eq for Stats
+impl Show for Stats
 
 // Type aliases
 

--- a/internal/ffi/pkg.generated.mbti
+++ b/internal/ffi/pkg.generated.mbti
@@ -2,46 +2,13 @@
 package "moonbitlang/x/internal/ffi"
 
 // Values
-fn byte_array_from_extern(XExternByteArray) -> Bytes
-
-fn byte_array_to_extern(Bytes) -> XExternByteArray
-
 fn mbt_string_to_utf8_bytes(String, Bool) -> Bytes
-
-fn string_array_from_extern(XExternStringArray) -> Array[String]
-
-fn string_from_extern(XExternString) -> String
-
-fn string_to_extern(String) -> XExternString
 
 fn utf8_bytes_to_mbt_string(Bytes) -> String
 
 // Errors
 
 // Types and methods
-#external
-pub(all) type XByteArrayCreateHandle
-
-#external
-pub(all) type XByteArrayReadHandle
-
-#external
-pub(all) type XExternByteArray
-
-#external
-pub(all) type XExternString
-
-#external
-pub(all) type XExternStringArray
-
-#external
-pub(all) type XStringArrayReadHandle
-
-#external
-pub(all) type XStringCreateHandle
-
-#external
-pub(all) type XStringReadHandle
 
 // Type aliases
 


### PR DESCRIPTION
Implement stat functionality to retrieve file metadata including size, timestamps, and permissions. Added native, wasm and JS implementations with tests. The Stats struct contains comprehensive file system information.

Add cross-platform support for stat details with proper handling of platform-specific fields. Includes tests to verify basic functionality and metadata correctness.
```moonbit
///|
pub struct Stats {
  dev : UInt64
  mode : UInt
  nlink : UInt64
  ino : UInt64
  uid : UInt
  gid : UInt
  rdev : UInt64
  atime_sec : Int64
  atime_nsec : Int64
  mtime_sec : Int64
  mtime_nsec : Int64
  ctime_sec : Int64
  ctime_nsec : Int64
  birthtime_sec : Int64
  birthtime_nsec : Int64
  size : Int64
  blocks : UInt64
  blksize : UInt
  flags : UInt
  gen : UInt
  lspare : Int
  qspare : (Int64, Int64)
} derive(Show, Eq)
```