### PR TITLE
fix(Path::join): ignore empty components correctly

### DIFF
--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,6 +1,6 @@
 {
   "name": "moonbitlang/x",
-  "version": "0.4.42",
+  "version": "0.4.43",
   "readme": "README.md",
   "repository": "https://github.com/moonbitlang/x",
   "license": "Apache-2.0",

--- a/path/path.mbt
+++ b/path/path.mbt
@@ -22,7 +22,7 @@ let is_windows : Bool = @ffi.is_windows()
 
 ///|
 /// A newtype wrapper provide path operation methods.
-pub(all) struct Path(String) derive(Eq)
+pub(all) struct Path(String) derive(Eq, Debug)
 
 ///|
 pub impl Show for Path with output(path, logger) {
@@ -114,9 +114,14 @@ pub fn Path::is_absolute(path : Path) -> Bool {
 ///  1. when lhs and rhs both are empty, return empty string
 ///  2. ignore empty string
 /// 
-/// ```moonbit skip nocheck
-/// let path : Path = "/usr/local"
-/// inspect(path.join("bin"), content="/usr/local/bin")
+/// ```moonbit nocheck
+/// test {
+///   assert_eq(Path::join("/usr/local", "bin"), "/usr/local/bin")
+///   assert_eq(Path::join("/usr/local", "/usr"), "/usr")
+///   assert_eq(Path::join("/usr/local", ""), "/usr/local")
+///   assert_eq(Path::join("", "local/bin"), "local/bin")
+///   assert_eq(Path::join("", ""), "")
+/// }
 /// ```
 pub fn Path::join(lhs : Path, rhs : Path) -> Path {
   if is_windows {

--- a/path/pkg.generated.mbti
+++ b/path/pkg.generated.mbti
@@ -1,6 +1,10 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/x/path"
 
+import {
+  "moonbitlang/core/debug",
+}
+
 // Values
 pub let delimiter : Char
 
@@ -9,7 +13,7 @@ pub let sep : Char
 // Errors
 
 // Types and methods
-pub(all) struct Path(String) derive(Eq)
+pub(all) struct Path(String) derive(Eq, @debug.Debug)
 pub fn Path::basename(Self) -> StringView
 pub fn Path::dirname(Self) -> Self
 pub fn Path::extname(Self) -> StringView

--- a/path/posix/path.mbt
+++ b/path/posix/path.mbt
@@ -137,22 +137,30 @@ pub fn Path::join(lhs : Path, rhs : Path) -> Path {
   let rhs = rhs.0
   if Path::is_absolute(rhs) {
     return rhs
-  } else {
-    match lhs {
-      [] => rhs
-      [.., '/'] as all => {
-        let builder = StringBuilder::new()
-        builder.write_stringview(all)
-        builder.write_stringview(rhs)
-        builder.to_string()
-      }
-      without_tailing_slashes => {
-        let builder = StringBuilder::new()
-        builder.write_stringview(without_tailing_slashes)
-        builder.write_char('/')
-        builder.write_stringview(rhs)
-        builder.to_string()
-      }
+  }
+  // ignore empty string
+  if lhs.is_empty() {
+    return rhs
+  }
+  // ignore empty string
+  if rhs.is_empty() {
+    return lhs
+  }
+
+  match lhs {
+    [] => rhs
+    [.., '/'] as all => {
+      let builder = StringBuilder::new()
+      builder.write_stringview(all)
+      builder.write_stringview(rhs)
+      builder.to_string()
+    }
+    without_tailing_slashes => {
+      let builder = StringBuilder::new()
+      builder.write_stringview(without_tailing_slashes)
+      builder.write_char('/')
+      builder.write_stringview(rhs)
+      builder.to_string()
     }
   }
 }

--- a/path/posix/path_test.mbt
+++ b/path/posix/path_test.mbt
@@ -221,7 +221,12 @@ test "is_absolute edge cases" {
 test "join edge cases" {
   // Empty strings
   inspect(Path::join("", ""), content="")
-  inspect(Path::join("a", ""), content="a/")
+  inspect(
+    Path::join("a", ""),
+    content=(
+      #|a
+    ),
+  )
   inspect(Path::join("", "b"), content="b")
 
   // Both paths are absolute

--- a/path/win32/path.mbt
+++ b/path/win32/path.mbt
@@ -248,6 +248,14 @@ fn join_rest(lhs : StringView, rhs : StringView) -> StringView? {
 pub fn Path::join(lhs : Path, rhs : Path) -> Path {
   let lhs = lhs.0
   let rhs = rhs.0
+  // ignore empty string
+  if lhs.is_empty() {
+    return rhs
+  }
+  // ignore empty string
+  if rhs.is_empty() {
+    return lhs
+  }
   match join_rest(lhs, rhs) {
     None => rhs
     Some(rhs) =>

--- a/path/win32/path_test.mbt
+++ b/path/win32/path_test.mbt
@@ -396,7 +396,12 @@ test "is_absolute advanced edge cases" {
 test "join edge cases" {
   // Empty strings
   inspect(Path::join("", ""), content="")
-  inspect(Path::join("a", ""), content="a\\")
+  inspect(
+    Path::join("a", ""),
+    content=(
+      #|a
+    ),
+  )
   inspect(Path::join("", "b"), content="b")
 
   // Both paths are absolute - second wins


### PR DESCRIPTION
The documentation for `Path::join()` says:

```
/// 1. string concatenation with OS platform specific path separator
/// 2. if rhs is absolute or on a different drive in Windows, return rhs.
/// 
/// edge cases:
///  1. when lhs and rhs both are empty, return empty string
///  2. ignore empty string
/// 
```

The actual behavior is:

```
assert_eq(Path::join("a/b", ""), "a/b/")
```

This contradicts the documentation, even though the current behavior is covered by a black-box test.

I don't think there is a single clearly correct behavior for `join` in a path library, both choices have reasonable arguments. The documentation and implementation should at least be consistent. I choose to update the implementation of `join` so that`Path::join("a/b", "") == "a/b"`.
