### PR TITLE
perf(json5): pass StringView to parse_double, materialize owned String only on error

### DIFF
--- a/json5/lex_number.mbt
+++ b/json5/lex_number.mbt
@@ -56,7 +56,7 @@ fn lex_number_end(
   @string.parse_double(view) catch {
     _ =>
       parse_error(
-        InvalidNumber(offset_to_position(ctx.input, start), view.to_string()),
+        InvalidNumber(offset_to_position(ctx.input, start), view.to_owned()),
       )
   }
 }

--- a/json5/lex_number.mbt
+++ b/json5/lex_number.mbt
@@ -49,8 +49,14 @@ fn lex_number_end(
   start : Int,
   end : Int,
 ) -> Double raise ParseError {
-  let s = ctx.input[start:end].to_owned()
-  @string.parse_double(s) catch {
-    _ => parse_error(InvalidNumber(offset_to_position(ctx.input, start), s))
+  // parse_double already accepts a StringView; only materialize an
+  // owned String for the error payload (the cold path). Saves one
+  // allocation + memcpy per number on the happy path.
+  let view = ctx.input[start:end]
+  @string.parse_double(view) catch {
+    _ =>
+      parse_error(
+        InvalidNumber(offset_to_position(ctx.input, start), view.to_string()),
+      )
   }
 }

--- a/json5/parse_error_test.mbt
+++ b/json5/parse_error_test.mbt
@@ -96,6 +96,12 @@ test "throws on invalid characters following an exponent sign" {
 }
 
 ///|
+test "throws on number parse failures" {
+  let res = try? @json5.parse("1e999999")
+  debug_inspect(res, content="Err(Invalid number 1e999999 at line 1, column 0)")
+}
+
+///|
 test "throws on invalid characters following a hexadecimal indicator" {
   let res = try? @json5.parse("0xg")
   debug_inspect(res, content="Err(Invalid character g at line 1, column 2)")


### PR DESCRIPTION
## Summary

`lex_number_end` currently does:

```moonbit
let s = ctx.input[start:end].to_owned()
@string.parse_double(s) catch {
  _ => parse_error(InvalidNumber(..., s))
}
```

`@string.parse_double` already accepts `StringView`. The `.to_owned()` materializes a fresh `String` for every parsed number — but the only consumer that actually needs an owned string is the *error* `parse_error` call, which is the cold path. Push the `to_owned` / `to_string` inside the `catch` arm and pass the `StringView` directly on the happy path.

## Benchmark

Scenario: [`bench-x/cmd/json5_parse/main.mbt`](https://github.com/mizchi/pprof-mbt/blob/main/bench-x/cmd/json5_parse/main.mbt) — 1000-element JSON5 object arrays (unquoted keys, trailing commas, single-quoted strings) × 50 iters. Native release, Linux x86_64, 3-run median wall time.

|           | baseline | patched | delta  |
|-----------|---------:|--------:|-------:|
| native    | 231 ms   | 219 ms  | **-5.2%** |

The patched payload contains 8 numbers per object × 1000 objects × 50 iters = 400 000 number parses; that's exactly the number of `to_owned`/`to_string` allocations skipped.

Callgrind profile before this change (top 10 of 2.63 G Ir for the same workload):

```
10.27% read_char
 7.83% moonbit_drop_object
 7.67% String::offset_of_nth_char_forward
 7.61% free
 7.36% lex_value
 4.10% strconv::fold_digits
 3.50% _mi_page_malloc_zero
 3.22% strconv::check_underscore
 3.22% malloc
 2.78% String::sub
```

The malloc/free + drop_object band (~26%) is partly the `to_owned` churn this patch removes.

## Tests

```
moonbitlang/x/json5    74 / 74 pass
```
