### PR TITLE
perf(encoding): UTF-8 encoder walks code units inline instead of for char in src

### DIFF
--- a/crypto/pkg.generated.mbti
+++ b/crypto/pkg.generated.mbti
@@ -74,10 +74,10 @@ pub impl ByteSource for Bytes
 pub impl ByteSource for BytesView
 
 pub(open) trait CryptoHasher {
-  size(Self) -> Int
-  block_size(Self) -> Int
-  reset(Self) -> Unit
-  update(Self, BytesView) -> Unit
-  finalize_into(Self, FixedArray[Byte], offset~ : Int) -> Unit
+  fn size(Self) -> Int
+  fn block_size(Self) -> Int
+  fn reset(Self) -> Unit
+  fn update(Self, BytesView) -> Unit
+  fn finalize_into(Self, FixedArray[Byte], offset~ : Int) -> Unit
 }
 

--- a/encoding/encoding.mbt
+++ b/encoding/encoding.mbt
@@ -54,9 +54,28 @@ pub fn encode(encoding : Encoding, src : String) -> Bytes {
     UTF16BE => write_utf16be_char
     _ => abort("unreachable")
   }
-  for char in src {
-    // SAFETY: Assume String are always valid UTF16LE
-    write(new_buf, char)
+  // Walk by UTF-16 code unit and assemble surrogate pairs inline. This
+  // avoids `for char in src`, which goes through String::iter +
+  // Iter::next per char (~30% of self time on an ASCII-heavy 64 KiB
+  // bench even though the inner body is small).
+  let len = src.length()
+  let mut i = 0
+  while i < len {
+    let cu = src.unsafe_get(i).to_int()
+    i += 1
+    let cp = if cu >= 0xD800 && cu <= 0xDBFF && i < len {
+      let cu2 = src.unsafe_get(i).to_int()
+      if cu2 >= 0xDC00 && cu2 <= 0xDFFF {
+        i += 1
+        ((cu - 0xD800) * 0x400) + (cu2 - 0xDC00) + 0x10000
+      } else {
+        cu
+      }
+    } else {
+      cu
+    }
+    // SAFETY: Assume String contains valid UTF-16
+    write(new_buf, cp.unsafe_to_char())
   }
   new_buf.to_bytes()
 }

--- a/encoding/encoding.mbt
+++ b/encoding/encoding.mbt
@@ -67,7 +67,7 @@ pub fn encode(encoding : Encoding, src : String) -> Bytes {
       let cu2 = src.unsafe_get(i).to_int()
       if cu2 >= 0xDC00 && cu2 <= 0xDFFF {
         i += 1
-        ((cu - 0xD800) * 0x400) + (cu2 - 0xDC00) + 0x10000
+        (cu - 0xD800) * 0x400 + (cu2 - 0xDC00) + 0x10000
       } else {
         cu
       }

--- a/num/pkg.generated.mbti
+++ b/num/pkg.generated.mbti
@@ -12,13 +12,13 @@ package "moonbitlang/x/num"
 // Traits
 #deprecated
 pub trait Num {
-  from_int(Int) -> Self
-  op_add(Self, Self) -> Self
-  op_sub(Self, Self) -> Self
-  op_mul(Self, Self) -> Self
-  op_div(Self, Self) -> Self
-  op_neg(Self) -> Self
-  abs(Self) -> Self
-  signum(Self) -> Self
+  fn from_int(Int) -> Self
+  fn op_add(Self, Self) -> Self
+  fn op_sub(Self, Self) -> Self
+  fn op_mul(Self, Self) -> Self
+  fn op_div(Self, Self) -> Self
+  fn op_neg(Self) -> Self
+  fn abs(Self) -> Self
+  fn signum(Self) -> Self
 }
 


### PR DESCRIPTION
## Summary

`encoding::encode(UTF8 | UTF16BE, ...)` walks the source string with `for char in src`. That goes through `String::iter` + `Iter::next<Char>` per code point, plus surrogate-pair decoding inside `Iter::next`. On an ASCII-heavy 64 KiB payload the iterator path is **~30% of self time** (`String::iter` 19.6% + `Iter::next<Char>` 10.2%) — more than the actual UTF-8 emission.

Replace with an explicit UTF-16 code-unit walk that handles surrogate pairs inline:

```moonbit
let len = src.length()
let mut i = 0
while i < len {
  let cu = src.unsafe_get(i).to_int()
  i += 1
  let cp = if cu >= 0xD800 && cu <= 0xDBFF && i < len {
    let cu2 = src.unsafe_get(i).to_int()
    if cu2 >= 0xDC00 && cu2 <= 0xDFFF {
      i += 1
      ((cu - 0xD800) * 0x400) + (cu2 - 0xDC00) + 0x10000
    } else { cu }
  } else { cu }
  write(new_buf, cp.unsafe_to_char())
}
```

ASCII code points (`cu < 0xD800`) skip the surrogate-detection arm entirely, which matches the common case.

## Benchmark

Scenario: [`bench-x/cmd/encoding_utf8/main.mbt`](https://github.com/mizchi/pprof-mbt/blob/main/bench-x/cmd/encoding_utf8/main.mbt) — 4 KiB ASCII chunk × 64 = ~256 KiB payload, UTF-8 encoded 5000× per run. Native release, Linux x86_64, 3-run median wall time.

|                | baseline | patched | delta  |
|----------------|---------:|--------:|-------:|
| encoding_utf8  |  528 ms  | 408 ms  | **-22.7%** |

## Tests

```
moonbitlang/x/encoding    71 / 71 pass
```

## Background

Same iter-overhead pattern as the moonbitlang/async gzip `crc32_update` patch and the base64 patch in this series (both also -20% to -37% from the same root cause).
