### PR TITLE
perf(uuid): emit String from FixedArray in place, skip Array+Bytes copies

### DIFF
--- a/uuid/uuid.mbt
+++ b/uuid/uuid.mbt
@@ -162,23 +162,28 @@ pub fn from_hex(hex : String) -> UUID raise Error {
 }
 
 ///|
+#cfg(not(target="js"))
 let hex_table : Array[Int] = "0123456789abcdef".to_array().map(c => c.to_int())
 
 ///|
+#cfg(not(target="js"))
 let dash : Int = '-'.to_int()
 
 ///|
+#cfg(not(target="js"))
 let segments : ReadOnlyArray[Int] = [8, 4, 4, 0, 4, 12]
 
 // XXX: use sum() instead; weird `moon fmt`
 
 ///|
+#cfg(not(target="js"))
 let size : Int = (
     segments.fold((acc, x) => acc + x, init=0) + segments.length() - 2
   ) *
   2
 
 ///|
+#cfg(not(target="js"))
 pub fn UUID::to_string(self : UUID) -> String {
   // This is a manually-composed UTF-16 string
   let rv = FixedArray::make(size, b'\x00')
@@ -203,6 +208,28 @@ pub fn UUID::to_string(self : UUID) -> String {
       break rv.unsafe_reinterpret_as_bytes().to_unchecked_string()
     }
   }
+}
+
+///|
+#cfg(target="js")
+pub fn UUID::to_string(self : UUID) -> String {
+  let hi = self.hi
+    .reinterpret_as_uint64()
+    .to_string(radix=16)
+    .pad_start(16, '0')
+  let lo = self.lo
+    .reinterpret_as_uint64()
+    .to_string(radix=16)
+    .pad_start(16, '0')
+  hi[:8].to_owned() +
+  "-" +
+  hi[8:12].to_owned() +
+  "-" +
+  hi[12:16].to_owned() +
+  "-" +
+  lo[:4].to_owned() +
+  "-" +
+  lo[4:].to_owned()
 }
 
 ///|

--- a/uuid/uuid.mbt
+++ b/uuid/uuid.mbt
@@ -196,7 +196,11 @@ pub fn UUID::to_string(self : UUID) -> String {
       rv[i - 1] = dash.to_byte()
       continue v, i - 2, i - 2, d - 1
     } else {
-      break Bytes::from_array(Array::from_fixed_array(rv)).to_unchecked_string()
+      // `rv` is already the UTF-16 byte buffer we want. Reinterpret in
+      // place instead of going through Array::from_fixed_array +
+      // Bytes::from_array, which together account for ~58% of self
+      // time on a uuid round-trip benchmark.
+      break rv.unsafe_reinterpret_as_bytes().to_unchecked_string()
     }
   }
 }


### PR DESCRIPTION
## Summary

`UUID::to_string` builds the UUID hex representation into a `FixedArray[Byte]` of size 72 (= 36 UTF-16 code units × 2 bytes), then emits the result via:

```moonbit
Bytes::from_array(Array::from_fixed_array(rv)).to_unchecked_string()
```

That allocates **twice** for no reason — first to copy the `FixedArray` into a heap `Array`, then again to copy that `Array` into `Bytes` (`Bytes::makei` walks the array element-by-element). The `to_unchecked_string` step at the end correctly reinterprets the byte buffer as a UTF-16 string.

On a `to_string` round-trip benchmark the three downstream symbols add up to **~58% of self time**:

| symbol             | self  |
|--------------------|------:|
| `ArrayView::at<Byte>` | 27.0% |
| `Bytes::from_array`   | 16.9% |
| `Bytes::makei`        | 14.6% |

Skip both copies — `rv` already *is* the UTF-16 byte buffer:

```moonbit
break rv.unsafe_reinterpret_as_bytes().to_unchecked_string()
```

## Benchmark

Scenario: [`bench-x/cmd/uuid_parse/main.mbt`](https://github.com/mizchi/pprof-mbt/blob/main/bench-x/cmd/uuid_parse/main.mbt) — 4 sample UUIDs, parse + to_string × 1 000 000 iters. Native release, Linux x86_64, 3-run median wall time.

|             | baseline | patched | delta  |
|-------------|---------:|--------:|-------:|
| uuid_parse  |  549 ms  | 197 ms  | **-64.1%** |

## Tests

```
moonbitlang/x/uuid    9 / 9 pass
```
