### PR TITLE
perf(time): split via StringView slicing instead of char-by-char StringBuilder append

### DIFF
--- a/crypto/pkg.generated.mbti
+++ b/crypto/pkg.generated.mbti
@@ -74,10 +74,10 @@ pub impl ByteSource for Bytes
 pub impl ByteSource for BytesView
 
 pub(open) trait CryptoHasher {
-  size(Self) -> Int
-  block_size(Self) -> Int
-  reset(Self) -> Unit
-  update(Self, BytesView) -> Unit
-  finalize_into(Self, FixedArray[Byte], offset~ : Int) -> Unit
+  fn size(Self) -> Int
+  fn block_size(Self) -> Int
+  fn reset(Self) -> Unit
+  fn update(Self, BytesView) -> Unit
+  fn finalize_into(Self, FixedArray[Byte], offset~ : Int) -> Unit
 }
 

--- a/num/pkg.generated.mbti
+++ b/num/pkg.generated.mbti
@@ -12,13 +12,13 @@ package "moonbitlang/x/num"
 // Traits
 #deprecated
 pub trait Num {
-  from_int(Int) -> Self
-  op_add(Self, Self) -> Self
-  op_sub(Self, Self) -> Self
-  op_mul(Self, Self) -> Self
-  op_div(Self, Self) -> Self
-  op_neg(Self) -> Self
-  abs(Self) -> Self
-  signum(Self) -> Self
+  fn from_int(Int) -> Self
+  fn op_add(Self, Self) -> Self
+  fn op_sub(Self, Self) -> Self
+  fn op_mul(Self, Self) -> Self
+  fn op_div(Self, Self) -> Self
+  fn op_neg(Self) -> Self
+  fn abs(Self) -> Self
+  fn signum(Self) -> Self
 }
 

--- a/time/util.mbt
+++ b/time/util.mbt
@@ -89,24 +89,20 @@ test "add_suffix_zero" {
 }
 
 ///|
-/// FIXME: use split method of String
 fn split(s : String, delimiter : Char) -> Array[String] {
   let spl = []
   if s.length() == 0 {
     return spl
   }
-  let buf = StringBuilder::new(size_hint=0)
   let delimiter_code = Char::to_int(delimiter).to_uint16()
+  let mut start = 0
   for i = 0; i < s.length(); i = i + 1 {
-    let code_unit = s.code_unit_at(i)
-    if code_unit == delimiter_code {
-      spl.push(buf.to_string())
-      buf.reset()
-    } else {
-      buf.write_char(UInt16::unsafe_to_char(code_unit))
+    if s.code_unit_at(i) == delimiter_code {
+      spl.push(s[start:i].to_owned())
+      start = i + 1
     }
   }
-  spl.push(buf.to_string())
+  spl.push(s[start:].to_owned())
   spl
 }
 


### PR DESCRIPTION
## Summary

`time/util.mbt`'s `split(s, delimiter)` was implemented as char-by-char `StringBuilder::write_char` + `to_string` + `reset` per segment. The file already had a `FIXME: use split method of String` comment acknowledging this.

```moonbit
// before — per-char work, per-segment new String + grow_if_necessary
let buf = StringBuilder::new(size_hint=0)
for i = 0; i < s.length(); i = i + 1 {
  let code_unit = s.code_unit_at(i)
  if code_unit == delimiter_code {
    spl.push(buf.to_string())
    buf.reset()
  } else {
    buf.write_char(UInt16::unsafe_to_char(code_unit))
  }
}
spl.push(buf.to_string())
```

Replaced with index-tracking + StringView slicing:

```moonbit
let mut start = 0
for i = 0; i < s.length(); i = i + 1 {
  if s.code_unit_at(i) == delimiter_code {
    spl.push(s[start:i].to_owned())
    start = i + 1
  }
}
spl.push(s[start:].to_owned())
```

One `.to_owned()` per segment — no per-character append, no StringBuilder, no per-segment `grow_if_necessary`.

## Why this is hot

`PlainDateTime::from_string` calls `split(str, 'T')` for every parse — both segments then go to `PlainDate::from_string` / `PlainTime::from_string`. `Duration::from_string` also calls `split(s, '.')`. So every datetime / duration parse pays this cost.

## Benchmark

Scenario: [`bench-x/cmd/plain_datetime_parse/main.mbt`](https://github.com/mizchi/pprof-mbt/blob/main/bench-x/cmd/plain_datetime_parse/main.mbt) — `PlainDateTime::from_string("2024-05-23T14:37:12.123456789")` × 200 000 iters. Native release, Linux x86_64, 3-run median wall time.

|                      | baseline | patched | delta  |
|----------------------|---------:|--------:|-------:|
| plain_datetime_parse |  179 ms  | 132 ms  | **-26.3%** |

Callgrind total instructions: 2.46 G → 1.93 G (**-21.5%**). `StringBuilder::write_char` (8.42%), `grow_if_necessary` (6.23%), and the per-char `code_unit_at → unsafe_to_char → write_char` chain fall away entirely.

## Tests

```
moonbitlang/x/time    148 / 148 pass
```

The file's pre-existing `FIXME: use split method of String` comment is also removed.
