### PR TITLE
perf(time): parse date-time strings through views

### DIFF
--- a/time/duration.mbt
+++ b/time/duration.mbt
@@ -54,7 +54,13 @@ pub fn Duration::zero() -> Duration {
 
 ///|
 /// Parses a ISO 8601 format string like `PT[n]H[n]M[n].[n]S`.
+#deprecated("Use `Duration::from_str` instead")
 pub fn Duration::from_string(str : String) -> Duration raise Error {
+  Duration::parse_str(str)
+}
+
+///|
+fn Duration::parse_str(str : StringView) -> Duration raise Error {
   guard str is [.. "PT", ..] else { fail(invalid_duration_err) }
   let mut hours = 0L
   let mut minutes = 0L
@@ -75,21 +81,31 @@ pub fn Duration::from_string(str : String) -> Duration raise Error {
       }
       'S' => {
         let s = buf.to_string()
-        let splits = split(s, '.')
-        if splits.is_empty() || splits.length() > 2 {
+        if s.is_empty() {
           fail(invalid_duration_err)
         }
-        if splits.length() > 0 && splits[0] != "" {
-          let secs_str = splits[0]
+        let splits = s.split(".")
+        let secs_str = match splits.next() {
+          Some(part) => part
+          None => fail(invalid_duration_err)
+        }
+        let nanos_str = splits.next()
+        match splits.next() {
+          Some(_) => fail(invalid_duration_err)
+          None => ()
+        }
+        if !secs_str.is_empty() {
           seconds = @string.from_str(secs_str)
         }
-        if splits.length() > 1 && splits[1] != "" {
-          let mut nanos_str = splits[1]
-          nanos_str = add_suffix_zero(nanos_str, 9)
-          if seconds < 0L {
-            nanos_str = "-" + nanos_str
+        match nanos_str {
+          Some(nanos) if !nanos.is_empty() => {
+            let mut nanos_str = add_suffix_zero(nanos, 9)
+            if seconds < 0L {
+              nanos_str = "-" + nanos_str
+            }
+            nanoseconds = @string.from_str(nanos_str)
           }
-          nanoseconds = @string.from_str(nanos_str)
+          _ => ()
         }
         break
       }
@@ -97,6 +113,11 @@ pub fn Duration::from_string(str : String) -> Duration raise Error {
     }
   }
   Duration::of(hours~, minutes~, seconds~, nanoseconds~)
+}
+
+///|
+pub impl @string.FromStr for Duration with fn from_str(str) {
+  Duration::parse_str(str)
 }
 
 ///|

--- a/time/duration_test.mbt
+++ b/time/duration_test.mbt
@@ -13,19 +13,19 @@
 // limitations under the License.
 
 ///|
-test "from_string" {
-  inspect(@time.Duration::from_string("PT0S"), content="PT0S")
+test "from_str" {
+  inspect(@time.Duration::from_str("PT0S"), content="PT0S")
   inspect(
-    @time.Duration::from_string("PT1H2M3.456789S"),
+    @time.Duration::from_str("PT1H2M3.456789S"),
     content="PT1H2M3.456789S",
   )
   inspect(
-    @time.Duration::from_string("PT-1H-2M-3.456789S"),
+    @time.Duration::from_str("PT-1H-2M-3.456789S"),
     content="PT-1H-2M-3.456789S",
   )
-  inspect(@time.Duration::from_string("PT0.45S"), content="PT0.45S")
-  assert_true((try? @time.Duration::from_string("PT0.000.45S")) is Err(_))
-  assert_true((try? @time.Duration::from_string("P1Y2M3DT4H5M6S")) is Err(_))
+  inspect(@time.Duration::from_str("PT0.45S"), content="PT0.45S")
+  assert_true((try? @time.Duration::from_str("PT0.000.45S")) is Err(_))
+  assert_true((try? @time.Duration::from_str("P1Y2M3DT4H5M6S")) is Err(_))
 }
 
 ///|

--- a/time/pkg.generated.mbti
+++ b/time/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "moonbitlang/x/time"
 
 import {
   "moonbitlang/core/debug",
+  "moonbitlang/core/string",
 }
 
 // Values
@@ -25,6 +26,7 @@ pub fn Duration::add_hours(Self, Int64) -> Self raise
 pub fn Duration::add_minutes(Self, Int64) -> Self raise
 pub fn Duration::add_nanoseconds(Self, Int64) -> Self raise
 pub fn Duration::add_seconds(Self, Int64) -> Self raise
+#deprecated
 pub fn Duration::from_string(String) -> Self raise
 pub fn Duration::is_neg(Self) -> Bool
 pub fn Duration::is_zero(Self) -> Bool
@@ -38,6 +40,7 @@ pub fn Duration::with_nanoseconds(Self, Int) -> Self raise
 pub fn Duration::with_seconds(Self, Int64) -> Self
 pub fn Duration::zero() -> Self
 pub impl Show for Duration
+pub impl @string.FromStr for Duration
 
 type Period derive(Compare, Eq)
 pub fn Period::add_days(Self, Int) -> Self raise
@@ -76,6 +79,7 @@ pub fn PlainDate::days_in_week(Self) -> Int
 pub fn PlainDate::days_in_year(Self) -> Int
 pub fn PlainDate::era(Self) -> String
 pub fn PlainDate::era_year(Self) -> Int
+#deprecated
 pub fn PlainDate::from_string(String) -> Self raise
 pub fn PlainDate::from_unix_day(Int64) -> Self raise
 pub fn PlainDate::from_year_ord(Int, Int) -> Self raise
@@ -96,6 +100,7 @@ pub fn PlainDate::year(Self) -> Int
 pub impl Compare for PlainDate
 pub impl Eq for PlainDate
 pub impl Show for PlainDate
+pub impl @string.FromStr for PlainDate
 
 type PlainDateTime derive(Compare, Eq)
 pub fn PlainDateTime::add_days(Self, Int64) -> Self raise
@@ -114,6 +119,7 @@ pub fn PlainDateTime::days_in_week(Self) -> Int
 pub fn PlainDateTime::days_in_year(Self) -> Int
 pub fn PlainDateTime::era(Self) -> String
 pub fn PlainDateTime::era_year(Self) -> Int
+#deprecated
 pub fn PlainDateTime::from_string(String) -> Self raise
 pub fn PlainDateTime::from_unix_second(Int64, Int, ZoneOffset) -> Self raise
 pub fn PlainDateTime::hour(Self) -> Int
@@ -140,6 +146,7 @@ pub fn PlainDateTime::with_second(Self, Int) -> Self raise
 pub fn PlainDateTime::with_year(Self, Int) -> Self raise
 pub fn PlainDateTime::year(Self) -> Int
 pub impl Show for PlainDateTime
+pub impl @string.FromStr for PlainDateTime
 
 type PlainTime derive(Compare, Eq)
 pub fn PlainTime::add_duration(Self, Duration) -> Self raise
@@ -150,6 +157,7 @@ pub fn PlainTime::add_seconds(Self, Int64) -> Self raise
 pub fn PlainTime::at_date(Self, PlainDate) -> PlainDateTime
 pub fn PlainTime::from_nanosecond_of_day(Int64) -> Self raise
 pub fn PlainTime::from_second_of_day(Int) -> Self raise
+#deprecated
 pub fn PlainTime::from_string(String) -> Self raise
 pub fn PlainTime::hour(Self) -> Int
 pub fn PlainTime::minute(Self) -> Int
@@ -165,6 +173,7 @@ pub fn PlainTime::with_minute(Self, Int) -> Self raise
 pub fn PlainTime::with_nanosecond(Self, Int) -> Self raise
 pub fn PlainTime::with_second(Self, Int) -> Self raise
 pub impl Show for PlainTime
+pub impl @string.FromStr for PlainTime
 
 pub(all) enum Weekday {
   Monday

--- a/time/plain_date.mbt
+++ b/time/plain_date.mbt
@@ -70,7 +70,13 @@ pub fn PlainDate::to_unix_day(self : PlainDate) -> Int64 {
 
 ///|
 /// Creates a PlainDate from a string, like "2008-08-08".
+#deprecated("Use `PlainDate::from_str` instead")
 pub fn PlainDate::from_string(str : String) -> PlainDate raise Error {
+  PlainDate::parse_str(str)
+}
+
+///|
+fn PlainDate::parse_str(str : StringView) -> PlainDate raise Error {
   lexmatch str with longest {
     (
       ("-?[0-9]{4}" as year_str)
@@ -86,6 +92,11 @@ pub fn PlainDate::from_string(str : String) -> PlainDate raise Error {
     }
     _ => fail(invalid_date_err)
   }
+}
+
+///|
+pub impl @string.FromStr for PlainDate with fn from_str(str) {
+  PlainDate::parse_str(str)
 }
 
 ///|

--- a/time/plain_date_test.mbt
+++ b/time/plain_date_test.mbt
@@ -42,16 +42,16 @@ test "from_year_ord" {
 }
 
 ///|
-test "from_string" {
-  inspect(@time.PlainDate::from_string("9999-01-01"), content="9999-01-01")
-  inspect(@time.PlainDate::from_string("0000-01-01"), content="0000-01-01")
-  inspect(@time.PlainDate::from_string("0001-01-01"), content="0001-01-01")
-  inspect(@time.PlainDate::from_string("-9999-01-01"), content="-9999-01-01")
-  assert_true((try? @time.PlainDate::from_string("10000-01-01")) is Err(_))
-  assert_true((try? @time.PlainDate::from_string("-10000-01-01")) is Err(_))
-  assert_true((try? @time.PlainDate::from_string("-01-01")) is Err(_))
-  assert_true((try? @time.PlainDate::from_string("12-31")) is Err(_))
-  assert_true((try? @time.PlainDate::from_string("-01")) is Err(_))
+test "from_str" {
+  inspect(@time.PlainDate::from_str("9999-01-01"), content="9999-01-01")
+  inspect(@time.PlainDate::from_str("0000-01-01"), content="0000-01-01")
+  inspect(@time.PlainDate::from_str("0001-01-01"), content="0001-01-01")
+  inspect(@time.PlainDate::from_str("-9999-01-01"), content="-9999-01-01")
+  assert_true((try? @time.PlainDate::from_str("10000-01-01")) is Err(_))
+  assert_true((try? @time.PlainDate::from_str("-10000-01-01")) is Err(_))
+  assert_true((try? @time.PlainDate::from_str("-01-01")) is Err(_))
+  assert_true((try? @time.PlainDate::from_str("12-31")) is Err(_))
+  assert_true((try? @time.PlainDate::from_str("-01")) is Err(_))
 }
 
 ///|

--- a/time/plain_date_time.mbt
+++ b/time/plain_date_time.mbt
@@ -65,15 +65,36 @@ pub fn PlainDateTime::to_unix_second(self : PlainDateTime) -> Int64 {
 
 ///|
 /// Creates a PlainTime from a string, like '2008-08-08T20:00:00'.
+#deprecated("Use `PlainDateTime::from_str` instead")
 pub fn PlainDateTime::from_string(str : String) -> PlainDateTime raise Error {
+  PlainDateTime::parse_str(str)
+}
+
+///|
+fn PlainDateTime::parse_str(str : StringView) -> PlainDateTime raise Error {
   // TODO: better parsing implementation
-  let split = split(str, 'T')
-  if split.length() != 2 {
-    fail(invalid_date_time_err)
+  let split = str.split("T")
+  let date_str = match split.next() {
+    Some(part) => part
+    None => fail(invalid_date_time_err)
   }
-  let date = PlainDate::from_string(split[0])
-  let time = PlainTime::from_string(split[1])
-  { date, time }
+  let time_str = match split.next() {
+    Some(part) => part
+    None => fail(invalid_date_time_err)
+  }
+  match split.next() {
+    Some(_) => fail(invalid_date_time_err)
+    None => {
+      let date = PlainDate::parse_str(date_str)
+      let time = PlainTime::parse_str(time_str)
+      { date, time }
+    }
+  }
+}
+
+///|
+pub impl @string.FromStr for PlainDateTime with fn from_str(str) {
+  PlainDateTime::parse_str(str)
 }
 
 ///|

--- a/time/plain_date_time_test.mbt
+++ b/time/plain_date_time_test.mbt
@@ -77,34 +77,34 @@ test "from_unix_second" {
 }
 
 ///|
-test "from_string" {
+test "from_str" {
   inspect(
-    @time.PlainDateTime::from_string("0000-01-01T00:00:00"),
+    @time.PlainDateTime::from_str("0000-01-01T00:00:00"),
     content="0000-01-01T00:00:00",
   )
   inspect(
-    @time.PlainDateTime::from_string("9999-12-31T23:59:59"),
+    @time.PlainDateTime::from_str("9999-12-31T23:59:59"),
     content="9999-12-31T23:59:59",
   )
   inspect(
-    @time.PlainDateTime::from_string("-9999-12-31T23:59:59"),
+    @time.PlainDateTime::from_str("-9999-12-31T23:59:59"),
     content="-9999-12-31T23:59:59",
   )
   inspect(
-    @time.PlainDateTime::from_string("2000-01-01T00:00:00.12345"),
+    @time.PlainDateTime::from_str("2000-01-01T00:00:00.12345"),
     content="2000-01-01T00:00:00.12345",
   )
   assert_true(
-    (try? @time.PlainDateTime::from_string("9999-12-31T23:59:60")) is Err(_),
+    (try? @time.PlainDateTime::from_str("9999-12-31T23:59:60")) is Err(_),
   )
   assert_true(
-    (try? @time.PlainDateTime::from_string("10000-12-31T23:59:60")) is Err(_),
+    (try? @time.PlainDateTime::from_str("10000-12-31T23:59:60")) is Err(_),
   )
   assert_true(
-    (try? @time.PlainDateTime::from_string("2000-01-01 00:00:00")) is Err(_),
+    (try? @time.PlainDateTime::from_str("2000-01-01 00:00:00")) is Err(_),
   )
-  assert_true((try? @time.PlainDateTime::from_string("2000-01-01")) is Err(_))
-  assert_true((try? @time.PlainDateTime::from_string("00:00:00")) is Err(_))
+  assert_true((try? @time.PlainDateTime::from_str("2000-01-01")) is Err(_))
+  assert_true((try? @time.PlainDateTime::from_str("00:00:00")) is Err(_))
 }
 
 ///|

--- a/time/plain_time.mbt
+++ b/time/plain_time.mbt
@@ -38,7 +38,13 @@ pub fn PlainTime::of(
 
 ///|
 /// Creates a PlainTime from a string, like '10:20:30.45678'.
+#deprecated("Use `PlainTime::from_str` instead")
 pub fn PlainTime::from_string(str : String) -> PlainTime raise Error {
+  PlainTime::parse_str(str)
+}
+
+///|
+fn PlainTime::parse_str(str : StringView) -> PlainTime raise Error {
   let (hour, minute, second, nanosecond) = lexmatch str with longest {
     (("[0-9]{2}" as hour_str) ":" ("[0-9]{2}" as minute_str)) =>
       (@string.parse_int(hour_str), @string.parse_int(minute_str), 0, 0)
@@ -68,11 +74,16 @@ pub fn PlainTime::from_string(str : String) -> PlainTime raise Error {
         @string.parse_int(hour_str),
         @string.parse_int(minute_str),
         @string.parse_int(second_str),
-        @string.parse_int(add_suffix_zero(nanosecond_str.to_owned(), 9)),
+        @string.parse_int(add_suffix_zero(nanosecond_str, 9)),
       )
     _ => fail(invalid_time_err)
   }
   PlainTime::of(hour, minute, second, nanosecond)
+}
+
+///|
+pub impl @string.FromStr for PlainTime with fn from_str(str) {
+  PlainTime::parse_str(str)
 }
 
 ///|

--- a/time/plain_time_test.mbt
+++ b/time/plain_time_test.mbt
@@ -25,22 +25,22 @@ test "of" {
 }
 
 ///|
-test "from_string" {
-  inspect(@time.PlainTime::from_string("00:00"), content="00:00:00")
-  inspect(@time.PlainTime::from_string("23:59"), content="23:59:00")
-  inspect(@time.PlainTime::from_string("24:00"), content="24:00:00")
-  inspect(@time.PlainTime::from_string("23:59:59"), content="23:59:59")
-  inspect(@time.PlainTime::from_string("01:00:00.123"), content="01:00:00.123")
+test "from_str" {
+  inspect(@time.PlainTime::from_str("00:00"), content="00:00:00")
+  inspect(@time.PlainTime::from_str("23:59"), content="23:59:00")
+  inspect(@time.PlainTime::from_str("24:00"), content="24:00:00")
+  inspect(@time.PlainTime::from_str("23:59:59"), content="23:59:59")
+  inspect(@time.PlainTime::from_str("01:00:00.123"), content="01:00:00.123")
   inspect(
-    @time.PlainTime::from_string("01:00:00.0000123"),
+    @time.PlainTime::from_str("01:00:00.0000123"),
     content="01:00:00.0000123",
   )
-  assert_true((try? @time.PlainTime::from_string("1:00")) is Err(_))
-  assert_true((try? @time.PlainTime::from_string("10:0")) is Err(_))
-  assert_true((try? @time.PlainTime::from_string("100000")) is Err(_))
-  assert_true((try? @time.PlainTime::from_string("123:00:00")) is Err(_))
-  assert_true((try? @time.PlainTime::from_string("10:00:00.123zzz")) is Err(_))
-  assert_true((try? @time.PlainTime::from_string("z1:00:00")) is Err(_))
+  assert_true((try? @time.PlainTime::from_str("1:00")) is Err(_))
+  assert_true((try? @time.PlainTime::from_str("10:0")) is Err(_))
+  assert_true((try? @time.PlainTime::from_str("100000")) is Err(_))
+  assert_true((try? @time.PlainTime::from_str("123:00:00")) is Err(_))
+  assert_true((try? @time.PlainTime::from_str("10:00:00.123zzz")) is Err(_))
+  assert_true((try? @time.PlainTime::from_str("z1:00:00")) is Err(_))
 }
 
 ///|

--- a/time/util.mbt
+++ b/time/util.mbt
@@ -71,9 +71,9 @@ test "remove_suffix_zero && format_nanos" {
 }
 
 ///|
-fn add_suffix_zero(s : String, len : Int) -> String {
+fn add_suffix_zero(s : StringView, len : Int) -> String {
   let buf = StringBuilder::new(size_hint=len)
-  buf.write_string(s)
+  buf.write_stringview(s)
   for i = s.length(); i < len; i = i + 1 {
     buf.write_char('0')
   }
@@ -86,69 +86,6 @@ test "add_suffix_zero" {
   inspect(add_suffix_zero("1", 1), content="1")
   inspect(add_suffix_zero("1", 2), content="10")
   inspect(add_suffix_zero("1", 3), content="100")
-}
-
-///|
-/// FIXME: use split method of String
-fn split(s : String, delimiter : Char) -> Array[String] {
-  let spl = []
-  if s.length() == 0 {
-    return spl
-  }
-  let buf = StringBuilder::new(size_hint=0)
-  let delimiter_code = Char::to_int(delimiter).to_uint16()
-  for i = 0; i < s.length(); i = i + 1 {
-    let code_unit = s.code_unit_at(i)
-    if code_unit == delimiter_code {
-      spl.push(buf.to_string())
-      buf.reset()
-    } else {
-      buf.write_char(UInt16::unsafe_to_char(code_unit))
-    }
-  }
-  spl.push(buf.to_string())
-  spl
-}
-
-///|
-test "split" {
-  debug_inspect(
-    split("2000-01-01", '-'),
-    content=(
-      #|["2000", "01", "01"]
-    ),
-  )
-  debug_inspect(
-    split("-01-01", '-'),
-    content=(
-      #|["", "01", "01"]
-    ),
-  )
-  debug_inspect(
-    split("12-31", '-'),
-    content=(
-      #|["12", "31"]
-    ),
-  )
-  debug_inspect(
-    split("-01", '-'),
-    content=(
-      #|["", "01"]
-    ),
-  )
-  debug_inspect(
-    split("-", '-'),
-    content=(
-      #|["", ""]
-    ),
-  )
-  debug_inspect(split("", '-'), content="[]")
-  debug_inspect(
-    split("0", '-'),
-    content=(
-      #|["0"]
-    ),
-  )
 }
 
 ///|


### PR DESCRIPTION
## Summary

- Keep the existing `from_string(String)` parsers for `Duration`, `PlainDate`, `PlainTime`, and `PlainDateTime`, but mark them deprecated in favor of `from_str`.
- Implement `@string.FromStr` for those four time types so callers can parse through `Type::from_str(StringView)` or generic `@string.from_str` without materializing owned strings.
- Replace the private char-by-char split helper with stdlib `StringView::split` iterator consumption in date-time parsing.
- Parse duration fractional seconds through `StringView` pieces and avoid materializing the fractional part before padding.

## Benchmark

Stable toolchain: `~/repos/moon-stable/bin/moon`, release builds, macOS arm64. Values are 3-run medians; first cold outlier retained in the run set but median reported.

| workload | target | base `origin/main` | this branch | delta |
|---|---|---:|---:|---:|
| `PlainDateTime::from_string` x5M | native | 2.84s | 1.88s | -33.8% |
| `Duration::from_string` x5M | native | 2.04s | 1.65s | -19.1% |
| `PlainDateTime::from_string` x1M | js/node v25.9.0 | 0.91s | 0.79s | -13.2% |
| `Duration::from_string` x1M | js/node v25.9.0 | 0.58s | 0.58s | flat |
| `PlainDateTime::from_string` x2M | wasm-gc/moonrun | 1.07s | 0.92s | -14.0% |
| `Duration::from_string` x2M | wasm-gc/moonrun | 0.70s | 0.65s | -7.1% |

## Tests

- `moon check --target all`
- `moon test time --target native`
- `moon test time --target js`
- `moon test time --target wasm`
- `moon test time --target wasm-gc`
- `moon info`
