### PR TITLE
[codex] fix fs JS import annotations

### DIFF
--- a/fs/fs_js.mbt
+++ b/fs/fs_js.mbt
@@ -26,7 +26,7 @@ priv type FsBytesResult
 
 ///|
 extern "js" fn FsBytesResult::is_ok(self : Self) -> Bool =
-  #| (res) => res.tag === "ok"
+  #| (res) => res.ok
 
 ///|
 extern "js" fn FsBytesResult::content(self : Self) -> Bytes =
@@ -42,7 +42,7 @@ priv type FsStringArrayResult
 
 ///|
 extern "js" fn FsStringArrayResult::is_ok(self : Self) -> Bool =
-  #| (res) => res.tag === "ok"
+  #| (res) => res.ok
 
 ///|
 extern "js" fn FsStringArrayResult::content(self : Self) -> Array[String] =
@@ -58,7 +58,7 @@ priv type FsBoolResult
 
 ///|
 extern "js" fn FsBoolResult::is_ok(self : Self) -> Bool =
-  #| (res) => res.tag === "ok"
+  #| (res) => res.ok
 
 ///|
 extern "js" fn FsBoolResult::content(self : Self) -> Bool =
@@ -74,7 +74,7 @@ priv type FsUnitResult
 
 ///|
 extern "js" fn FsUnitResult::is_ok(self : Self) -> Bool =
-  #| (res) => res.tag === "ok"
+  #| (res) => res.ok
 
 ///|
 extern "js" fn FsUnitResult::error_message(self : Self) -> String =
@@ -92,9 +92,9 @@ extern "js" fn read_file_ffi(
   #| function(readFile, path) {
   #|   try {
   #|     const content = readFile(path);
-  #|     return { tag: "ok", content };
+  #|     return { ok: true, content };
   #|   } catch (error) {
-  #|     return { tag: "err", content: error.message };
+  #|     return { ok: false, content: error.message };
   #|   }
   #| }
 
@@ -111,9 +111,9 @@ extern "js" fn write_file_ffi(
   #| function(writeFile, path, content) {
   #|   try {
   #|     writeFile(path, Buffer.from(content));
-  #|     return { tag: "ok", content: "" };
+  #|     return { ok: true, content: "" };
   #|   } catch (error) {
-  #|     return { tag: "err", content: error.message };
+  #|     return { ok: false, content: error.message };
   #|   }
   #| }
 
@@ -187,9 +187,9 @@ extern "js" fn read_dir_ffi(
   #| function(readDir, path) {
   #|  try {
   #|    const files = readDir(path);
-  #|    return { tag: "ok", content: files };
+  #|    return { ok: true, content: files };
   #|  } catch (error) {
-  #|    return { tag: "err", content: error.message };
+  #|    return { ok: false, content: error.message };
   #|  }
   #| }
 
@@ -214,9 +214,9 @@ extern "js" fn create_dir_ffi(
   #| function(createDir, path) {
   #|  try {
   #|    createDir(path, { recursive: true });
-  #|    return { tag: "ok", content: "" };
+  #|    return { ok: true, content: "" };
   #|  } catch (error) {
-  #|    return { tag: "err", content: error.message };
+  #|    return { ok: false, content: error.message };
   #|  }
   #| }
 
@@ -240,9 +240,9 @@ extern "js" fn is_dir_ffi(
   #| function(stat, path) {
   #|  try {
   #|    const stats = stat(path);
-  #|    return { tag: "ok", content: stats.isDirectory() };
+  #|    return { ok: true, content: stats.isDirectory() };
   #|  } catch (error) {
-  #|    return { tag: "err", content: error.message };
+  #|    return { ok: false, content: error.message };
   #|  }
   #| }
 
@@ -263,9 +263,9 @@ extern "js" fn is_file_ffi(
   #| function(stat, path) {
   #|  try {
   #|    const stats = stat(path);
-  #|    return { tag: "ok", content: stats.isFile() };
+  #|    return { ok: true, content: stats.isFile() };
   #|  } catch (error) {
-  #|    return { tag: "err", content: error.message };
+  #|    return { ok: false, content: error.message };
   #|  }
   #| }
 
@@ -290,9 +290,9 @@ extern "js" fn remove_dir_ffi(
   #| function(removeDir, path) {
   #|  try {
   #|    removeDir(path, { recursive: true });
-  #|    return { tag: "ok", content: "" };
+  #|    return { ok: true, content: "" };
   #|  } catch (error) {
-  #|    return { tag: "err", content: error.message };
+  #|    return { ok: false, content: error.message };
   #|  }
   #| }
 
@@ -316,9 +316,9 @@ extern "js" fn remove_file_ffi(
   #| function(removeFile, path) {
   #|  try {
   #|    removeFile(path);
-  #|    return { tag: "ok", content: "" };
+  #|    return { ok: true, content: "" };
   #|  } catch (error) {
-  #|    return { tag: "err", content: error.message };
+  #|    return { ok: false, content: error.message };
   #|  }
   #| }
 

--- a/fs/fs_js.mbt
+++ b/fs/fs_js.mbt
@@ -81,7 +81,7 @@ extern "js" fn FsUnitResult::error_message(self : Self) -> String =
   #| (res) => res.content
 
 ///|
-#module("fs")
+#module("node:fs")
 extern "js" fn read_file_sync(path : String) -> Bytes = "readFileSync"
 
 ///|
@@ -99,7 +99,7 @@ extern "js" fn read_file_ffi(
   #| }
 
 ///|
-#module("fs")
+#module("node:fs")
 extern "js" fn write_file_sync(path : String, content : Bytes) -> Unit = "writeFileSync"
 
 ///|
@@ -167,7 +167,7 @@ fn write_string_to_file_internal(
 }
 
 ///|
-#module("fs")
+#module("node:fs")
 extern "js" fn path_exists_ffi(path : String) -> Bool = "existsSync"
 
 ///|
@@ -176,7 +176,7 @@ pub fn path_exists_internal(path : String) -> Bool {
 }
 
 ///|
-#module("fs")
+#module("node:fs")
 extern "js" fn read_dir_sync(path : String) -> Array[String] = "readdirSync"
 
 ///|
@@ -203,7 +203,7 @@ fn read_dir_internal(path : String) -> Array[String] raise IOError {
 }
 
 ///|
-#module("fs")
+#module("node:fs")
 extern "js" fn create_dir_sync(path : String, options : FsOptions) -> Unit = "mkdirSync"
 
 ///|
@@ -229,7 +229,7 @@ fn create_dir_internal(path : String) -> Unit raise IOError {
 }
 
 ///|
-#module("fs")
+#module("node:fs")
 extern "js" fn stat_sync(path : String) -> FsStats = "statSync"
 
 ///|
@@ -279,7 +279,7 @@ fn is_file_internal(path : String) -> Bool raise IOError {
 }
 
 ///|
-#module("fs")
+#module("node:fs")
 extern "js" fn remove_dir_sync(path : String, options : FsOptions) -> Unit = "rmSync"
 
 ///|
@@ -305,7 +305,7 @@ fn remove_dir_internal(path : String) -> Unit raise IOError {
 }
 
 ///|
-#module("fs")
+#module("node:fs")
 extern "js" fn remove_file_sync(path : String) -> Unit = "unlinkSync"
 
 ///|

--- a/fs/fs_js.mbt
+++ b/fs/fs_js.mbt
@@ -13,11 +13,25 @@
 // limitations under the License.
 
 ///|
-extern "js" fn read_file_ffi(path : String) -> Int =
-  #| function(path) {
-  #|   var fs = require('fs');
+#external
+priv type FsStats
+
+///|
+#external
+priv type FsOptions
+
+///|
+#module("fs")
+extern "js" fn read_file_sync(path : String) -> Bytes = "readFileSync"
+
+///|
+extern "js" fn read_file_ffi(
+  read_file : (String) -> Bytes,
+  path : String,
+) -> Int =
+  #| function(readFile, path) {
   #|   try {
-  #|     const content = fs.readFileSync(path);
+  #|     const content = readFile(path);
   #|     globalThis.fileContent = content;
   #|     return 0;
   #|   } catch (error) {
@@ -27,11 +41,18 @@ extern "js" fn read_file_ffi(path : String) -> Int =
   #| }
 
 ///|
-extern "js" fn write_file_ffi(path : String, content : Bytes) -> Int =
-  #| function(path, content) {
-  #|   var fs = require('fs');
+#module("fs")
+extern "js" fn write_file_sync(path : String, content : Bytes) -> Unit = "writeFileSync"
+
+///|
+extern "js" fn write_file_ffi(
+  write_file : (String, Bytes) -> Unit,
+  path : String,
+  content : Bytes,
+) -> Int =
+  #| function(writeFile, path, content) {
   #|   try {
-  #|     fs.writeFileSync(path, Buffer.from(content));
+  #|     writeFile(path, Buffer.from(content));
   #|     return 0;
   #|   } catch (error) {
   #|     globalThis.errorMessage = error.message;
@@ -59,7 +80,7 @@ extern "js" fn get_error_message_ffi() -> String =
 
 ///|
 fn read_file_to_bytes_internal(path : String) -> Bytes raise IOError {
-  let res = read_file_ffi(path)
+  let res = read_file_ffi(read_file_sync, path)
   if res == -1 {
     raise IOError(get_error_message_ffi())
   }
@@ -85,7 +106,7 @@ fn write_bytes_to_file_internal(
   path : String,
   content : Bytes,
 ) -> Unit raise IOError {
-  let res = write_file_ffi(path, content)
+  let res = write_file_ffi(write_file_sync, path, content)
   if res == -1 {
     raise IOError(get_error_message_ffi())
   }
@@ -107,11 +128,8 @@ fn write_string_to_file_internal(
 }
 
 ///|
-extern "js" fn path_exists_ffi(path : String) -> Bool =
-  #| function(path) {
-  #|  var fs = require('fs');
-  #|  return fs.existsSync(path);
-  #| }
+#module("fs")
+extern "js" fn path_exists_ffi(path : String) -> Bool = "existsSync"
 
 ///|
 pub fn path_exists_internal(path : String) -> Bool {
@@ -119,11 +137,17 @@ pub fn path_exists_internal(path : String) -> Bool {
 }
 
 ///|
-extern "js" fn read_dir_ffi(path : String) -> Int =
-  #| function(path) {
-  #|  var fs = require('fs');
+#module("fs")
+extern "js" fn read_dir_sync(path : String) -> Array[String] = "readdirSync"
+
+///|
+extern "js" fn read_dir_ffi(
+  read_dir : (String) -> Array[String],
+  path : String,
+) -> Int =
+  #| function(readDir, path) {
   #|  try {
-  #|    const files = fs.readdirSync(path);
+  #|    const files = readDir(path);
   #|    globalThis.files = files;
   #|    return 0;
   #|  } catch (error) {
@@ -134,7 +158,7 @@ extern "js" fn read_dir_ffi(path : String) -> Int =
 
 ///|
 fn read_dir_internal(path : String) -> Array[String] raise IOError {
-  let res = read_dir_ffi(path)
+  let res = read_dir_ffi(read_dir_sync, path)
   if res == -1 {
     raise IOError(get_error_message_ffi())
   }
@@ -142,11 +166,17 @@ fn read_dir_internal(path : String) -> Array[String] raise IOError {
 }
 
 ///|
-extern "js" fn create_dir_ffi(path : String) -> Int =
-  #| function(path) {
-  #|  var fs = require('fs');
+#module("fs")
+extern "js" fn create_dir_sync(path : String, options : FsOptions) -> Unit = "mkdirSync"
+
+///|
+extern "js" fn create_dir_ffi(
+  create_dir : (String, FsOptions) -> Unit,
+  path : String,
+) -> Int =
+  #| function(createDir, path) {
   #|  try {
-  #|    fs.mkdirSync(path, { recursive: true });
+  #|    createDir(path, { recursive: true });
   #|    return 0;
   #|  } catch (error) {
   #|    globalThis.errorMessage = error.message;
@@ -156,18 +186,21 @@ extern "js" fn create_dir_ffi(path : String) -> Int =
 
 ///|
 fn create_dir_internal(path : String) -> Unit raise IOError {
-  let res = create_dir_ffi(path)
+  let res = create_dir_ffi(create_dir_sync, path)
   if res == -1 {
     raise IOError(get_error_message_ffi())
   }
 }
 
 ///|
-extern "js" fn is_dir_ffi(path : String) -> Int =
-  #| function(path) {
-  #|  var fs = require('fs');
+#module("fs")
+extern "js" fn stat_sync(path : String) -> FsStats = "statSync"
+
+///|
+extern "js" fn is_dir_ffi(stat : (String) -> FsStats, path : String) -> Int =
+  #| function(stat, path) {
   #|  try {
-  #|    const stats = fs.statSync(path);
+  #|    const stats = stat(path);
   #|    return stats.isDirectory() ? 1 : 0;
   #|  } catch (error) {
   #|    globalThis.errorMessage = error.message;
@@ -177,7 +210,7 @@ extern "js" fn is_dir_ffi(path : String) -> Int =
 
 ///|
 fn is_dir_internal(path : String) -> Bool raise IOError {
-  let res = is_dir_ffi(path)
+  let res = is_dir_ffi(stat_sync, path)
   if res == -1 {
     raise IOError(get_error_message_ffi())
   }
@@ -185,11 +218,10 @@ fn is_dir_internal(path : String) -> Bool raise IOError {
 }
 
 ///|
-extern "js" fn is_file_ffi(path : String) -> Int =
-  #| function(path) {
-  #|  var fs = require('fs');
+extern "js" fn is_file_ffi(stat : (String) -> FsStats, path : String) -> Int =
+  #| function(stat, path) {
   #|  try {
-  #|    const stats = fs.statSync(path);
+  #|    const stats = stat(path);
   #|    return stats.isFile() ? 1 : 0;
   #|  } catch (error) {
   #|    globalThis.errorMessage = error.message;
@@ -199,7 +231,7 @@ extern "js" fn is_file_ffi(path : String) -> Int =
 
 ///|
 fn is_file_internal(path : String) -> Bool raise IOError {
-  let res = is_file_ffi(path)
+  let res = is_file_ffi(stat_sync, path)
   if res == -1 {
     raise IOError(get_error_message_ffi())
   }
@@ -207,11 +239,17 @@ fn is_file_internal(path : String) -> Bool raise IOError {
 }
 
 ///|
-extern "js" fn remove_dir_ffi(path : String) -> Int =
-  #| function(path) {
-  #|  var fs = require('fs');
+#module("fs")
+extern "js" fn remove_dir_sync(path : String, options : FsOptions) -> Unit = "rmSync"
+
+///|
+extern "js" fn remove_dir_ffi(
+  remove_dir : (String, FsOptions) -> Unit,
+  path : String,
+) -> Int =
+  #| function(removeDir, path) {
   #|  try {
-  #|    fs.rmSync(path, { recursive: true });
+  #|    removeDir(path, { recursive: true });
   #|    return 0;
   #|  } catch (error) {
   #|    globalThis.errorMessage = error.message;
@@ -221,18 +259,24 @@ extern "js" fn remove_dir_ffi(path : String) -> Int =
 
 ///|
 fn remove_dir_internal(path : String) -> Unit raise IOError {
-  let res = remove_dir_ffi(path)
+  let res = remove_dir_ffi(remove_dir_sync, path)
   if res == -1 {
     raise IOError(get_error_message_ffi())
   }
 }
 
 ///|
-extern "js" fn remove_file_ffi(path : String) -> Int =
-  #| function(path) {
-  #|  var fs = require('fs');
+#module("fs")
+extern "js" fn remove_file_sync(path : String) -> Unit = "unlinkSync"
+
+///|
+extern "js" fn remove_file_ffi(
+  remove_file : (String) -> Unit,
+  path : String,
+) -> Int =
+  #| function(removeFile, path) {
   #|  try {
-  #|    fs.unlinkSync(path);
+  #|    removeFile(path);
   #|    return 0;
   #|  } catch (error) {
   #|    globalThis.errorMessage = error.message;
@@ -242,7 +286,7 @@ extern "js" fn remove_file_ffi(path : String) -> Int =
 
 ///|
 fn remove_file_internal(path : String) -> Unit raise IOError {
-  let res = remove_file_ffi(path)
+  let res = remove_file_ffi(remove_file_sync, path)
   if res == -1 {
     raise IOError(get_error_message_ffi())
   }

--- a/fs/fs_js.mbt
+++ b/fs/fs_js.mbt
@@ -21,6 +21,66 @@ priv type FsStats
 priv type FsOptions
 
 ///|
+#external
+priv type FsBytesResult
+
+///|
+extern "js" fn FsBytesResult::is_ok(self : Self) -> Bool =
+  #| (res) => res.tag === "ok"
+
+///|
+extern "js" fn FsBytesResult::content(self : Self) -> Bytes =
+  #| (res) => res.content
+
+///|
+extern "js" fn FsBytesResult::error_message(self : Self) -> String =
+  #| (res) => res.content
+
+///|
+#external
+priv type FsStringArrayResult
+
+///|
+extern "js" fn FsStringArrayResult::is_ok(self : Self) -> Bool =
+  #| (res) => res.tag === "ok"
+
+///|
+extern "js" fn FsStringArrayResult::content(self : Self) -> Array[String] =
+  #| (res) => res.content
+
+///|
+extern "js" fn FsStringArrayResult::error_message(self : Self) -> String =
+  #| (res) => res.content
+
+///|
+#external
+priv type FsBoolResult
+
+///|
+extern "js" fn FsBoolResult::is_ok(self : Self) -> Bool =
+  #| (res) => res.tag === "ok"
+
+///|
+extern "js" fn FsBoolResult::content(self : Self) -> Bool =
+  #| (res) => res.content
+
+///|
+extern "js" fn FsBoolResult::error_message(self : Self) -> String =
+  #| (res) => res.content
+
+///|
+#external
+priv type FsUnitResult
+
+///|
+extern "js" fn FsUnitResult::is_ok(self : Self) -> Bool =
+  #| (res) => res.tag === "ok"
+
+///|
+extern "js" fn FsUnitResult::error_message(self : Self) -> String =
+  #| (res) => res.content
+
+///|
 #module("fs")
 extern "js" fn read_file_sync(path : String) -> Bytes = "readFileSync"
 
@@ -28,15 +88,13 @@ extern "js" fn read_file_sync(path : String) -> Bytes = "readFileSync"
 extern "js" fn read_file_ffi(
   read_file : (String) -> Bytes,
   path : String,
-) -> Int =
+) -> FsBytesResult =
   #| function(readFile, path) {
   #|   try {
   #|     const content = readFile(path);
-  #|     globalThis.fileContent = content;
-  #|     return 0;
+  #|     return { tag: "ok", content };
   #|   } catch (error) {
-  #|     globalThis.errorMessage = error.message;
-  #|     return -1;
+  #|     return { tag: "err", content: error.message };
   #|   }
   #| }
 
@@ -49,42 +107,23 @@ extern "js" fn write_file_ffi(
   write_file : (String, Bytes) -> Unit,
   path : String,
   content : Bytes,
-) -> Int =
+) -> FsUnitResult =
   #| function(writeFile, path, content) {
   #|   try {
   #|     writeFile(path, Buffer.from(content));
-  #|     return 0;
+  #|     return { tag: "ok", content: "" };
   #|   } catch (error) {
-  #|     globalThis.errorMessage = error.message;
-  #|     return -1;
+  #|     return { tag: "err", content: error.message };
   #|   }
-  #| }
-
-///|
-extern "js" fn get_file_content_ffi() -> Bytes =
-  #| function() {
-  #|   return globalThis.fileContent;
-  #| }
-
-///|
-extern "js" fn get_dir_files_ffi() -> Array[String] =
-  #| function() {
-  #|   return globalThis.files;
-  #| }
-
-///|
-extern "js" fn get_error_message_ffi() -> String =
-  #| function() {
-  #|   return globalThis.errorMessage || '';
   #| }
 
 ///|
 fn read_file_to_bytes_internal(path : String) -> Bytes raise IOError {
   let res = read_file_ffi(read_file_sync, path)
-  if res == -1 {
-    raise IOError(get_error_message_ffi())
+  if !res.is_ok() {
+    raise IOError(res.error_message())
   }
-  get_file_content_ffi()
+  res.content()
 }
 
 ///|
@@ -107,8 +146,8 @@ fn write_bytes_to_file_internal(
   content : Bytes,
 ) -> Unit raise IOError {
   let res = write_file_ffi(write_file_sync, path, content)
-  if res == -1 {
-    raise IOError(get_error_message_ffi())
+  if !res.is_ok() {
+    raise IOError(res.error_message())
   }
 }
 
@@ -144,25 +183,23 @@ extern "js" fn read_dir_sync(path : String) -> Array[String] = "readdirSync"
 extern "js" fn read_dir_ffi(
   read_dir : (String) -> Array[String],
   path : String,
-) -> Int =
+) -> FsStringArrayResult =
   #| function(readDir, path) {
   #|  try {
   #|    const files = readDir(path);
-  #|    globalThis.files = files;
-  #|    return 0;
+  #|    return { tag: "ok", content: files };
   #|  } catch (error) {
-  #|    globalThis.errorMessage = error.message;
-  #|    return -1;
+  #|    return { tag: "err", content: error.message };
   #|  }
   #| }
 
 ///|
 fn read_dir_internal(path : String) -> Array[String] raise IOError {
   let res = read_dir_ffi(read_dir_sync, path)
-  if res == -1 {
-    raise IOError(get_error_message_ffi())
+  if !res.is_ok() {
+    raise IOError(res.error_message())
   }
-  get_dir_files_ffi()
+  res.content()
 }
 
 ///|
@@ -173,22 +210,21 @@ extern "js" fn create_dir_sync(path : String, options : FsOptions) -> Unit = "mk
 extern "js" fn create_dir_ffi(
   create_dir : (String, FsOptions) -> Unit,
   path : String,
-) -> Int =
+) -> FsUnitResult =
   #| function(createDir, path) {
   #|  try {
   #|    createDir(path, { recursive: true });
-  #|    return 0;
+  #|    return { tag: "ok", content: "" };
   #|  } catch (error) {
-  #|    globalThis.errorMessage = error.message;
-  #|    return -1;
+  #|    return { tag: "err", content: error.message };
   #|  }
   #| }
 
 ///|
 fn create_dir_internal(path : String) -> Unit raise IOError {
   let res = create_dir_ffi(create_dir_sync, path)
-  if res == -1 {
-    raise IOError(get_error_message_ffi())
+  if !res.is_ok() {
+    raise IOError(res.error_message())
   }
 }
 
@@ -197,45 +233,49 @@ fn create_dir_internal(path : String) -> Unit raise IOError {
 extern "js" fn stat_sync(path : String) -> FsStats = "statSync"
 
 ///|
-extern "js" fn is_dir_ffi(stat : (String) -> FsStats, path : String) -> Int =
+extern "js" fn is_dir_ffi(
+  stat : (String) -> FsStats,
+  path : String,
+) -> FsBoolResult =
   #| function(stat, path) {
   #|  try {
   #|    const stats = stat(path);
-  #|    return stats.isDirectory() ? 1 : 0;
+  #|    return { tag: "ok", content: stats.isDirectory() };
   #|  } catch (error) {
-  #|    globalThis.errorMessage = error.message;
-  #|    return -1;
+  #|    return { tag: "err", content: error.message };
   #|  }
   #| }
 
 ///|
 fn is_dir_internal(path : String) -> Bool raise IOError {
   let res = is_dir_ffi(stat_sync, path)
-  if res == -1 {
-    raise IOError(get_error_message_ffi())
+  if !res.is_ok() {
+    raise IOError(res.error_message())
   }
-  res == 1
+  res.content()
 }
 
 ///|
-extern "js" fn is_file_ffi(stat : (String) -> FsStats, path : String) -> Int =
+extern "js" fn is_file_ffi(
+  stat : (String) -> FsStats,
+  path : String,
+) -> FsBoolResult =
   #| function(stat, path) {
   #|  try {
   #|    const stats = stat(path);
-  #|    return stats.isFile() ? 1 : 0;
+  #|    return { tag: "ok", content: stats.isFile() };
   #|  } catch (error) {
-  #|    globalThis.errorMessage = error.message;
-  #|    return -1;
+  #|    return { tag: "err", content: error.message };
   #|  }
   #| }
 
 ///|
 fn is_file_internal(path : String) -> Bool raise IOError {
   let res = is_file_ffi(stat_sync, path)
-  if res == -1 {
-    raise IOError(get_error_message_ffi())
+  if !res.is_ok() {
+    raise IOError(res.error_message())
   }
-  res == 1
+  res.content()
 }
 
 ///|
@@ -246,22 +286,21 @@ extern "js" fn remove_dir_sync(path : String, options : FsOptions) -> Unit = "rm
 extern "js" fn remove_dir_ffi(
   remove_dir : (String, FsOptions) -> Unit,
   path : String,
-) -> Int =
+) -> FsUnitResult =
   #| function(removeDir, path) {
   #|  try {
   #|    removeDir(path, { recursive: true });
-  #|    return 0;
+  #|    return { tag: "ok", content: "" };
   #|  } catch (error) {
-  #|    globalThis.errorMessage = error.message;
-  #|    return -1;
+  #|    return { tag: "err", content: error.message };
   #|  }
   #| }
 
 ///|
 fn remove_dir_internal(path : String) -> Unit raise IOError {
   let res = remove_dir_ffi(remove_dir_sync, path)
-  if res == -1 {
-    raise IOError(get_error_message_ffi())
+  if !res.is_ok() {
+    raise IOError(res.error_message())
   }
 }
 
@@ -273,21 +312,20 @@ extern "js" fn remove_file_sync(path : String) -> Unit = "unlinkSync"
 extern "js" fn remove_file_ffi(
   remove_file : (String) -> Unit,
   path : String,
-) -> Int =
+) -> FsUnitResult =
   #| function(removeFile, path) {
   #|  try {
   #|    removeFile(path);
-  #|    return 0;
+  #|    return { tag: "ok", content: "" };
   #|  } catch (error) {
-  #|    globalThis.errorMessage = error.message;
-  #|    return -1;
+  #|    return { tag: "err", content: error.message };
   #|  }
   #| }
 
 ///|
 fn remove_file_internal(path : String) -> Unit raise IOError {
   let res = remove_file_ffi(remove_file_sync, path)
-  if res == -1 {
-    raise IOError(get_error_message_ffi())
+  if !res.is_ok() {
+    raise IOError(res.error_message())
   }
 }


### PR DESCRIPTION
## Summary

Use MoonBit JS import annotations for the `fs` package's Node `fs` bindings instead of hardcoding `require("fs")` inside inline JS FFI bodies.

This lets MoonBit generate the final module import according to the selected JS output format. CJS builds emit `require("fs")`, while ESM builds emit `import { ... } from "fs"`.

## Root Cause

The JS implementation was written before import annotations were available, so each inline FFI body loaded Node's `fs` module directly with CommonJS syntax. That made the generated package format-sensitive and incompatible with ESM output.

## Validation

- `moon check fs --target all`
- `moon test fs --target js`
- `moon test fs --target native`
- `moon test fs --target wasm`
- `moon test fs --target wasm-gc`
- `moon fmt --check fs/fs_js.mbt`
- `git diff --check`
- Built a temporary consumer with `link.js.format = "esm"` and verified the output imports from `"fs"`
- Built the same temporary consumer with `link.js.format = "cjs"` and verified the output uses `require("fs")`