### PR TITLE
[codex] Add Debug support for common types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [0.4.45]
+
+### Added
+
+- Added `Debug` implementations for common value types in `@decimal`,
+  `@encoding`, `@json5`, `@path`, `@stack`, `@time`, and `@uuid` (#250)
+
 ## [0.4.44]
 
 ### Added

--- a/decimal/decimal.mbt
+++ b/decimal/decimal.mbt
@@ -48,7 +48,7 @@
 pub struct Decimal {
   coefficient : @bigint.BigInt
   scale : Int
-}
+} derive(Debug)
 
 ///|
 /// Maximum number of decimal places (scale) allowed.

--- a/decimal/decimal_test.mbt
+++ b/decimal/decimal_test.mbt
@@ -77,6 +77,7 @@ test "decimal_string_conversion" {
     None => fail("Failed to parse")
   }
   inspect(d1.to_string(), content="123.45")
+  debug_inspect(d1, content="{ coefficient: 12345, scale: 2 }")
   let d2 = match @decimal.Decimal::from_string("0.001") {
     Some(d) => d
     None => fail("Failed to parse")

--- a/decimal/pkg.generated.mbti
+++ b/decimal/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "moonbitlang/x/decimal"
 
 import {
   "moonbitlang/core/bigint",
+  "moonbitlang/core/debug",
   "moonbitlang/core/json",
   "moonbitlang/core/quickcheck",
   "moonbitlang/core/quickcheck/splitmix",
@@ -23,7 +24,7 @@ pub fn zero() -> Decimal
 pub struct Decimal {
   coefficient : @bigint.BigInt
   scale : Int
-}
+} derive(@debug.Debug)
 pub fn Decimal::abs(Self) -> Self
 pub fn Decimal::coefficient(Self) -> @bigint.BigInt
 pub fn Decimal::from_bigint(@bigint.BigInt) -> Self

--- a/encoding/encoding_test.mbt
+++ b/encoding/encoding_test.mbt
@@ -25,6 +25,12 @@ test "encoding String to UTF8" {
 }
 
 ///|
+test "debug encoding" {
+  let encodings : Array[@encoding.Encoding] = [UTF8, UTF16, UTF16LE, UTF16BE]
+  debug_inspect(encodings, content="[UTF8, UTF16, UTF16LE, UTF16BE]")
+}
+
+///|
 test "encode_to/UTF8" {
   let src = "你好👀"
   let buf = Buffer(size_hint=10)

--- a/encoding/pkg.generated.mbti
+++ b/encoding/pkg.generated.mbti
@@ -58,7 +58,7 @@ pub(all) enum Encoding {
   UTF16
   UTF16LE
   UTF16BE
-}
+} derive(@debug.Debug)
 
 // Type aliases
 

--- a/encoding/types.mbt
+++ b/encoding/types.mbt
@@ -28,7 +28,7 @@ pub(all) enum Encoding {
   UTF16 // alias for UTF16LE
   UTF16LE
   UTF16BE
-}
+} derive(Debug)
 
 // Decoder
 

--- a/json5/parse_error_test.mbt
+++ b/json5/parse_error_test.mbt
@@ -27,6 +27,13 @@ test "throws on documents with only comments" {
 }
 
 ///|
+test "debug parse error data" {
+  let pos : @json5.Position = { line: 1, column: 2 }
+  let data : @json5.ParseErrorData = InvalidChar(pos, 'x')
+  debug_inspect(data, content="InvalidChar({ line: 1, column: 2 }, 'x')")
+}
+
+///|
 test "throws on incomplete single line comments" {
   let res = try? @json5.parse("/a")
   debug_inspect(res, content="Err(No valid token at line 1, column 1)")

--- a/json5/pkg.generated.mbti
+++ b/json5/pkg.generated.mbti
@@ -23,7 +23,7 @@ pub(all) enum ParseErrorData {
   InvalidEof
   InvalidNumber(Position, String)
   InvalidIdentEscape(Position)
-} derive(Eq)
+} derive(Eq, @debug.Debug)
 
 pub(all) struct Position {
   line : Int

--- a/json5/types.mbt
+++ b/json5/types.mbt
@@ -25,7 +25,7 @@ pub(all) enum ParseErrorData {
   InvalidEof
   InvalidNumber(Position, String)
   InvalidIdentEscape(Position)
-} derive(Eq)
+} derive(Eq, Debug)
 
 ///|
 pub(all) suberror ParseError {

--- a/moon.mod
+++ b/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbitlang/x"
 
-version = "0.4.44"
+version = "0.4.45"
 
 readme = "README.md"
 

--- a/path/path_test.mbt
+++ b/path/path_test.mbt
@@ -1,0 +1,19 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "debug" {
+  let path : @path.Path = "a/b"
+  debug_inspect(path, content="Path(\"a/b\")")
+}

--- a/path/posix/path.mbt
+++ b/path/posix/path.mbt
@@ -14,7 +14,7 @@
 
 ///|
 /// A newtype wrapper provide path operation methods.
-pub(all) struct Path(String) derive(Eq)
+pub(all) struct Path(String) derive(Eq, Debug)
 
 ///|
 pub impl Show for Path with fn output(path, logger) {

--- a/path/posix/path_test.mbt
+++ b/path/posix/path_test.mbt
@@ -21,6 +21,11 @@ test "basename/dirname" {
 }
 
 ///|
+test "debug" {
+  debug_inspect(Path::join("a", "b"), content="Path(\"a/b\")")
+}
+
+///|
 test "dirname/edge cases" {
   // Root paths
   inspect(Path::dirname("/"), content="/")

--- a/path/posix/pkg.generated.mbti
+++ b/path/posix/pkg.generated.mbti
@@ -1,6 +1,10 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/x/path/posix"
 
+import {
+  "moonbitlang/core/debug",
+}
+
 // Values
 pub let delimiter : Char
 
@@ -9,7 +13,7 @@ pub let sep : Char
 // Errors
 
 // Types and methods
-pub(all) struct Path(String) derive(Eq)
+pub(all) struct Path(String) derive(Eq, @debug.Debug)
 pub fn Path::basename(Self) -> StringView
 pub fn Path::dirname(Self) -> Self
 pub fn Path::extname(Self) -> StringView

--- a/path/win32/path.mbt
+++ b/path/win32/path.mbt
@@ -14,7 +14,7 @@
 
 ///|
 /// A newtype wrapper provide path operation methods.
-pub(all) struct Path(String) derive(Eq)
+pub(all) struct Path(String) derive(Eq, Debug)
 
 ///|
 pub impl Show for Path with fn output(path, logger) {

--- a/path/win32/path_test.mbt
+++ b/path/win32/path_test.mbt
@@ -21,6 +21,11 @@ test "basename/dirname" {
 }
 
 ///|
+test "debug" {
+  debug_inspect(Path::join("a", "b"), content="Path(\"a\\\\b\")")
+}
+
+///|
 test "dirname/edge cases" {
   inspect(Path::dirname("\\"), content="\\")
   inspect(Path::dirname("\\\\"), content="\\\\")

--- a/path/win32/pkg.generated.mbti
+++ b/path/win32/pkg.generated.mbti
@@ -1,6 +1,10 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/x/path/win32"
 
+import {
+  "moonbitlang/core/debug",
+}
+
 // Values
 pub let delimiter : Char
 
@@ -9,7 +13,7 @@ pub let sep : Char
 // Errors
 
 // Types and methods
-pub(all) struct Path(String) derive(Eq)
+pub(all) struct Path(String) derive(Eq, @debug.Debug)
 pub fn Path::basename(Self) -> StringView
 pub fn Path::dirname(Self) -> Self
 pub fn Path::extname(Self) -> StringView

--- a/stack/pkg.generated.mbti
+++ b/stack/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "moonbitlang/x/stack"
 
 import {
+  "moonbitlang/core/debug",
   "moonbitlang/core/list",
 }
 
@@ -46,6 +47,7 @@ pub fn[T] Stack::to_list(Self[T]) -> @list.List[T]
 pub fn[T] Stack::unsafe_peek(Self[T]) -> T
 pub fn[T] Stack::unsafe_pop(Self[T]) -> T
 pub impl[T : Show] Show for Stack[T]
+pub impl[T : @debug.Debug] @debug.Debug for Stack[T]
 
 // Type aliases
 

--- a/stack/stack.mbt
+++ b/stack/stack.mbt
@@ -103,6 +103,16 @@ pub impl[T : Show] Show for Stack[T] with fn output(self, logger : &Logger) -> U
 }
 
 ///|
+pub impl[T : Debug] Debug for Stack[T] with fn to_repr(self : Stack[T]) -> Repr {
+  Repr::ctor("Stack", [
+    (
+      None,
+      Repr::array(self.elements.iter().map(fn(t) { to_repr(t) }).collect()),
+    ),
+  ])
+}
+
+///|
 test "to_string" {
   let empty : Stack[Int] = new()
   inspect(empty, content="Stack::[]")

--- a/stack/stack_test.mbt
+++ b/stack/stack_test.mbt
@@ -1,0 +1,19 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "debug" {
+  debug_inspect(@stack.of([1, 2, 3]), content="Stack([1, 2, 3])")
+  debug_inspect(@stack.of(["a", "b"]), content="Stack([\"a\", \"b\"])")
+}

--- a/time/debug_test.mbt
+++ b/time/debug_test.mbt
@@ -1,0 +1,70 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "debug" {
+  debug_inspect(
+    @time.Duration::of(hours=1L, minutes=2L),
+    content="{ secs: 3720, nanos: 0 }",
+  )
+  debug_inspect(
+    @time.Period::of(years=1, months=2, days=3),
+    content="{ years: 1, months: 2, days: 3 }",
+  )
+  debug_inspect(
+    @time.PlainDate::of(2000, 1, 2),
+    content="{ year: 2000, month: 1, day: 2 }",
+  )
+  debug_inspect(
+    @time.PlainTime::of(3, 4, 5, 600),
+    content="{ hour: 3, minute: 4, second: 5, nanosecond: 600 }",
+  )
+  debug_inspect(
+    @time.PlainDateTime::of(2000, 1, 2, hour=3, minute=4, second=5),
+    content=(
+      #|{
+      #|  date: { year: 2000, month: 1, day: 2 },
+      #|  time: { hour: 3, minute: 4, second: 5, nanosecond: 0 },
+      #|}
+    ),
+  )
+  let zone = @time.fixed_zone("Asia/Shanghai", 8 * 60 * 60)
+  debug_inspect(
+    zone,
+    content=(
+      #|{
+      #|  id: "Asia/Shanghai",
+      #|  offsets: [{ id: "+08:00", abbrev: "", seconds: 28800, dst: false }],
+      #|  transitions: [],
+      #|}
+    ),
+  )
+  debug_inspect(
+    @time.ZonedDateTime::of(2000, 1, 2, hour=3, minute=4, second=5, zone~),
+    content=(
+      #|{
+      #|  datetime: {
+      #|    date: { year: 2000, month: 1, day: 2 },
+      #|    time: { hour: 3, minute: 4, second: 5, nanosecond: 0 },
+      #|  },
+      #|  zone: {
+      #|    id: "Asia/Shanghai",
+      #|    offsets: [{ id: "+08:00", abbrev: "", seconds: 28800, dst: false }],
+      #|    transitions: [],
+      #|  },
+      #|  offset: { id: "+08:00", abbrev: "", seconds: 28800, dst: false },
+      #|}
+    ),
+  )
+}

--- a/time/duration.mbt
+++ b/time/duration.mbt
@@ -17,7 +17,7 @@
 struct Duration {
   secs : Int64
   nanos : Int
-} derive(Eq, Compare)
+} derive(Eq, Compare, Debug)
 
 ///|
 /// Creates a Duration from hours, minutes, seconds and nanoseconds.

--- a/time/period.mbt
+++ b/time/period.mbt
@@ -18,7 +18,7 @@ struct Period {
   years : Int
   months : Int
   days : Int
-} derive(Eq, Compare)
+} derive(Eq, Compare, Debug)
 
 ///|
 /// Creates a Period from years, months, and days.

--- a/time/pkg.generated.mbti
+++ b/time/pkg.generated.mbti
@@ -20,7 +20,7 @@ pub let utc_zone : Zone
 // Errors
 
 // Types and methods
-type Duration derive(Compare, Eq)
+type Duration derive(Compare, Eq, @debug.Debug)
 pub fn Duration::add_duration(Self, Self) -> Self raise
 pub fn Duration::add_hours(Self, Int64) -> Self raise
 pub fn Duration::add_minutes(Self, Int64) -> Self raise
@@ -42,7 +42,7 @@ pub fn Duration::zero() -> Self
 pub impl Show for Duration
 pub impl @string.FromStr for Duration
 
-type Period derive(Compare, Eq)
+type Period derive(Compare, Eq, @debug.Debug)
 pub fn Period::add_days(Self, Int) -> Self raise
 pub fn Period::add_months(Self, Int) -> Self raise
 pub fn Period::add_period(Self, Self) -> Self raise
@@ -67,7 +67,7 @@ pub fn Period::years(Self) -> Int
 pub fn Period::zero() -> Self
 pub impl Show for Period
 
-type PlainDate
+type PlainDate derive(@debug.Debug)
 pub fn PlainDate::add_days(Self, Int64) -> Self raise
 pub fn PlainDate::add_months(Self, Int64) -> Self raise
 pub fn PlainDate::add_period(Self, Period) -> Self raise
@@ -102,7 +102,7 @@ pub impl Eq for PlainDate
 pub impl Show for PlainDate
 pub impl @string.FromStr for PlainDate
 
-type PlainDateTime derive(Compare, Eq)
+type PlainDateTime derive(Compare, Eq, @debug.Debug)
 pub fn PlainDateTime::add_days(Self, Int64) -> Self raise
 pub fn PlainDateTime::add_duration(Self, Duration) -> Self raise
 pub fn PlainDateTime::add_hours(Self, Int64) -> Self raise
@@ -148,7 +148,7 @@ pub fn PlainDateTime::year(Self) -> Int
 pub impl Show for PlainDateTime
 pub impl @string.FromStr for PlainDateTime
 
-type PlainTime derive(Compare, Eq)
+type PlainTime derive(Compare, Eq, @debug.Debug)
 pub fn PlainTime::add_duration(Self, Duration) -> Self raise
 pub fn PlainTime::add_hours(Self, Int64) -> Self raise
 pub fn PlainTime::add_minutes(Self, Int64) -> Self raise
@@ -186,7 +186,7 @@ pub(all) enum Weekday {
 } derive(Eq, @debug.Debug)
 pub impl Show for Weekday
 
-type Zone derive(Eq)
+type Zone derive(Eq, @debug.Debug)
 pub fn Zone::from_tzif2(String, FixedArray[Byte]) -> Self raise
 pub fn Zone::is_fixed(Self) -> Bool
 pub fn Zone::to_string(Self) -> String
@@ -204,7 +204,7 @@ pub impl Compare for ZoneOffset
 pub impl Eq for ZoneOffset
 pub impl Show for ZoneOffset
 
-type ZonedDateTime
+type ZonedDateTime derive(@debug.Debug)
 pub fn ZonedDateTime::add_days(Self, Int64) -> Self raise
 pub fn ZonedDateTime::add_hours(Self, Int64) -> Self raise
 pub fn ZonedDateTime::add_minutes(Self, Int64) -> Self raise

--- a/time/plain_date.mbt
+++ b/time/plain_date.mbt
@@ -18,7 +18,7 @@ struct PlainDate {
   year : Int
   month : Int
   day : Int
-}
+} derive(Debug)
 
 ///|
 /// Creates a PlainDate from the year, month and day.

--- a/time/plain_date_time.mbt
+++ b/time/plain_date_time.mbt
@@ -17,7 +17,7 @@
 struct PlainDateTime {
   date : PlainDate
   time : PlainTime
-} derive(Eq, Compare)
+} derive(Eq, Compare, Debug)
 
 ///|
 /// Creates a PlainDateTime from the year, month, day, hour, minute, second and nanosecond.

--- a/time/plain_time.mbt
+++ b/time/plain_time.mbt
@@ -19,7 +19,7 @@ struct PlainTime {
   minute : Int
   second : Int
   nanosecond : Int
-} derive(Eq, Compare)
+} derive(Eq, Compare, Debug)
 
 ///|
 /// Creates a PlainTime from the hour, minute, second and nanosecond.

--- a/time/zone.mbt
+++ b/time/zone.mbt
@@ -18,7 +18,7 @@ struct Zone {
   id : String
   offsets : Array[ZoneOffset]
   transitions : Array[(Int64, Int)] // (timestamp, offset_index)
-} derive(Eq)
+} derive(Eq, Debug)
 
 ///|
 /// UTC time zone.

--- a/time/zoned_date_time.mbt
+++ b/time/zoned_date_time.mbt
@@ -18,7 +18,7 @@ struct ZonedDateTime {
   datetime : PlainDateTime
   zone : Zone
   offset : ZoneOffset
-}
+} derive(Debug)
 
 ///|
 /// Creates a ZonedDateTime from year, month, day, hour, minute, second and a time zone.

--- a/uuid/pkg.generated.mbti
+++ b/uuid/pkg.generated.mbti
@@ -21,6 +21,7 @@ pub fn UUID::to_string(Self) -> String
 pub fn UUID::variant(Self) -> Variant
 pub fn UUID::version(Self) -> Version?
 pub impl Show for UUID
+pub impl @debug.Debug for UUID
 
 pub(all) enum Variant {
   ReservedNCS

--- a/uuid/uuid.mbt
+++ b/uuid/uuid.mbt
@@ -236,3 +236,8 @@ pub fn UUID::to_string(self : UUID) -> String {
 pub impl Show for UUID with fn output(self : UUID, logger : &Logger) -> Unit {
   logger.write_string(self.to_string())
 }
+
+///|
+pub impl Debug for UUID with fn to_repr(self : UUID) -> Repr {
+  Repr::ctor("UUID", [(None, Repr::string(self.to_string()))])
+}

--- a/uuid/uuid_test.mbt
+++ b/uuid/uuid_test.mbt
@@ -16,6 +16,10 @@
 test "from_hex" {
   let hex = "13cb501c-1234-5678-9034-abcdef937e20"
   inspect(@uuid.from_hex(hex), content=hex)
+  debug_inspect(
+    @uuid.from_hex(hex),
+    content="UUID(\"13cb501c-1234-5678-9034-abcdef937e20\")",
+  )
   inspect(
     @uuid.from_hex("12345678-1234-1234-1234-ABCDEF098765"),
     content="12345678-1234-1234-1234-abcdef098765",


### PR DESCRIPTION
## Summary

- Add Debug support for common value types across uuid, stack, decimal, time, path, encoding, and json5.
- Use structural custom Debug representations for opaque/common value types so debug diffs preserve constructors, arrays, and labeled fields instead of plain formatted strings.
- Add blackbox debug_inspect coverage and regenerate pkg.generated.mbti interfaces.

## Validation

- moon fmt
- moon check
- moon info
- moon test (546 passed)
- git diff --check