### PR TITLE
[codex] fix deprecated try? warnings

### DIFF
--- a/codec/base64/base64_wbtest.mbt
+++ b/codec/base64/base64_wbtest.mbt
@@ -53,5 +53,12 @@ test "base64 decode" {
 
 ///|
 test "base64 decode with errors" {
-  debug_inspect(try? decode("中文"), content="Err(InvalidChar('中'))")
+  debug_inspect(
+    try decode("中文") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Err(InvalidChar('中'))",
+  )
 }

--- a/crypto/chacha_test.mbt
+++ b/crypto/chacha_test.mbt
@@ -48,11 +48,21 @@ test "chacha stream encrypt RFC8439" {
 ///|
 test "chacha with error" {
   inspect(
-    (try? @crypto.ChaCha::chacha8(b"", Bytes::make(12, b'\x00'))) is Err(_),
+    (try @crypto.ChaCha::chacha8(b"", Bytes::make(12, b'\x00')) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
     content="true",
   )
   inspect(
-    (try? @crypto.ChaCha::chacha8(Bytes::make(32, b'\x00'), b"")) is Err(_),
+    (try @crypto.ChaCha::chacha8(Bytes::make(32, b'\x00'), b"") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
     content="true",
   )
 }

--- a/encoding/decoding_test.mbt
+++ b/encoding/decoding_test.mbt
@@ -402,7 +402,11 @@ test "decoding UTF16LE encoded data with UTF8" {
   )
   let decoder = @encoding.decoder(UTF8)
   // NOTE: Expected to be malformed here
-  let chars = try? decoder.decode(buf.to_bytes())
+  let chars = try decoder.decode(buf.to_bytes()) catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   assert_true(chars is Err(_))
   debug_inspect(chars, content="Err(MalformedError(<Bytes: [0xd8, 0xc3]>))")
 }
@@ -417,7 +421,11 @@ test "decode_to/UTF16LE-UTF8/MalformedError" {
   let decoder = @encoding.decoder(UTF8)
   let acc = StringBuilder::new()
   debug_inspect(
-    try? decoder.decode_to(buf.to_bytes(), acc),
+    try decoder.decode_to(buf.to_bytes(), acc) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content="Err(MalformedError(<Bytes: [0xd8, 0xc3]>))",
   )
 }
@@ -433,7 +441,11 @@ test "decode_to/UTF16LE-UTF8/TruncatedError" {
   let bytes_view : Bytes = [..bytes[:bytes.length() - 1]]
   let decoder = @encoding.decoder(UTF16LE)
   let acc = StringBuilder::new()
-  let result = try? decoder.decode_to(bytes_view, acc)
+  let result = try decoder.decode_to(bytes_view, acc) catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     result,
     content="Err(TruncatedError(<Bytes: [0xca, 0x00, 0x00, 0x00]>))",
@@ -451,14 +463,20 @@ test "decode_to/UTF16LE-UTF8/stream" {
   let bytes_view : Bytes = [..bytes[:bytes.length() - 1]]
   let decoder = @encoding.decoder(UTF16LE)
   let acc = StringBuilder::new()
-  let result = try? decoder.decode_to(bytes_view, acc, stream=true)
+  let result = try decoder.decode_to(bytes_view, acc, stream=true) catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(result, content="Ok(())")
   inspect(acc.to_string(), content="跑步🏃游泳")
-  let result = try? decoder.decode_to(
-    [bytes[bytes.length() - 1]],
-    acc,
-    stream=true,
-  )
+  let result = try
+    decoder.decode_to([bytes[bytes.length() - 1]], acc, stream=true)
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(result, content="Ok(())")
   inspect(acc.to_string(), content="跑步🏃游泳🏊")
 }
@@ -520,7 +538,11 @@ test "decoding UTF16BE encoded data with UTF8" {
   )
   let decoder = @encoding.decoder(UTF8)
   // NOTE: Expected to be malformed here
-  let chars = try? decoder.decode(buf.to_bytes())
+  let chars = try decoder.decode(buf.to_bytes()) catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   assert_true(chars is Err(_))
   debug_inspect(chars, content="Err(MalformedError(<Bytes: [0x8d]>))")
 }
@@ -535,7 +557,11 @@ test "decode_to/UTF16BE-UTF8" {
   let decoder = @encoding.decoder(UTF8)
   let acc = StringBuilder::new()
   debug_inspect(
-    try? decoder.decode_to(buf.to_bytes(), acc),
+    try decoder.decode_to(buf.to_bytes(), acc) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content="Err(MalformedError(<Bytes: [0x8d]>))",
   )
 }
@@ -837,7 +863,11 @@ test "Not all UTF16LE is format-legal UTF16BE and vice versa" {
 
   // invalid in UTF16BE
   let decoder_utf16be = @encoding.decoder(UTF16BE)
-  let malformedError = try? decoder_utf16be.decode(bytes_le)
+  let malformedError = try decoder_utf16be.decode(bytes_le) catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   assert_true(malformedError is Err(_))
 
   // vice versa
@@ -850,6 +880,10 @@ test "Not all UTF16LE is format-legal UTF16BE and vice versa" {
 
   // invalid in UTF16LE
   let decoder_utf16le = @encoding.decoder(UTF16LE)
-  let malformedError = try? decoder_utf16le.decode(bytes_be)
+  let malformedError = try decoder_utf16le.decode(bytes_be) catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   assert_true(malformedError is Err(_))
 }

--- a/encoding/internal/benchmark/lib.mbt
+++ b/encoding/internal/benchmark/lib.mbt
@@ -67,7 +67,12 @@ pub fn bench_decoding_streaming(
   let test_data_group = test_data.to_array().chunks(1000).map(Bytes::from_array)
   let decoder = @encoding.decoder(encoding)
   for td in test_data_group {
-    guard (try? decoder.consume(td)) is Ok(_)
+    guard (try decoder.consume(td) catch {
+        err => Err(err)
+      } noraise {
+        value => Ok(value)
+      })
+      is Ok(_)
   }
   println("decoded data \{test_data.length()}")
 }
@@ -85,6 +90,11 @@ pub fn bench_decoding_batch(
   let rand = @random.Rand::chacha8(seed~)
   let test_data = random(rand, 1024000)
   let decoder = @encoding.decoder(encoding)
-  guard (try? decoder.decode(test_data)) is Ok(_)
+  guard (try decoder.decode(test_data) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Ok(_)
   println("decoded data \{test_data.length()}")
 }

--- a/json5/parse_error_test.mbt
+++ b/json5/parse_error_test.mbt
@@ -16,13 +16,21 @@
 
 ///|
 test "throws on empty documents" {
-  let res = try? @json5.parse("")
+  let res = try @json5.parse("") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(Unexpected end of file)")
 }
 
 ///|
 test "throws on documents with only comments" {
-  let res = try? @json5.parse("//a")
+  let res = try @json5.parse("//a") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(Unexpected end of file)")
 }
 
@@ -35,43 +43,71 @@ test "debug parse error data" {
 
 ///|
 test "throws on incomplete single line comments" {
-  let res = try? @json5.parse("/a")
+  let res = try @json5.parse("/a") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(No valid token at line 1, column 1)")
 }
 
 ///|
 test "throws on unterminated multiline comments" {
-  let res = try? @json5.parse("/*")
+  let res = try @json5.parse("/*") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(Unexpected end of file)")
 }
 
 ///|
 test "throws on unterminated multiline comment closings" {
-  let res = try? @json5.parse("/**")
+  let res = try @json5.parse("/**") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(Unexpected end of file)")
 }
 
 ///|
 test "throws on invalid characters in values" {
-  let res = try? @json5.parse("a")
+  let res = try @json5.parse("a") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(No valid token at line 1, column 1)")
 }
 
 ///|
 test "throws on invalid characters in identifier start escapes" {
-  let res = try? @json5.parse("{\\a:1}")
+  let res = try @json5.parse("{\\a:1}") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(Invalid character a at line 1, column 2)")
 }
 
 ///|
 test "throws on invalid characters in identifier continue escapes" {
-  let res = try? @json5.parse("{a\\a:1}")
+  let res = try @json5.parse("{a\\a:1}") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(Invalid character a at line 1, column 3)")
 }
 
 ///|
 test "throws on invalid identifier continue characters" {
-  let res = try? @json5.parse("{a\\u0021:1}")
+  let res = try @json5.parse("{a\\u0021:1}") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     res,
     content="Err(Invalid escape sequence in identifier at line 1, column 2)",
@@ -80,43 +116,71 @@ test "throws on invalid identifier continue characters" {
 
 ///|
 test "throws on invalid characters following a sign" {
-  let res = try? @json5.parse("-a")
+  let res = try @json5.parse("-a") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(No valid token at line 1, column 1)")
 }
 
 ///|
 test "throws on invalid characters following a leading decimal point" {
-  let res = try? @json5.parse(".a")
+  let res = try @json5.parse(".a") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(No valid token at line 1, column 1)")
 }
 
 ///|
 test "throws on invalid characters following an exponent indicator" {
-  let res = try? @json5.parse("1ea")
+  let res = try @json5.parse("1ea") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(Invalid character e at line 1, column 1)")
 }
 
 ///|
 test "throws on invalid characters following an exponent sign" {
-  let res = try? @json5.parse("1e-a")
+  let res = try @json5.parse("1e-a") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(Invalid character e at line 1, column 1)")
 }
 
 ///|
 test "throws on number parse failures" {
-  let res = try? @json5.parse("1e999999")
+  let res = try @json5.parse("1e999999") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(Invalid number 1e999999 at line 1, column 0)")
 }
 
 ///|
 test "throws on invalid characters following a hexadecimal indicator" {
-  let res = try? @json5.parse("0xg")
+  let res = try @json5.parse("0xg") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(Invalid character g at line 1, column 2)")
 }
 
 ///|
 test "throws on invalid new lines in strings" {
-  let res = try? @json5.parse("\"\n\"")
+  let res = try @json5.parse("\"\n\"") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     res,
     content=(
@@ -128,121 +192,201 @@ test "throws on invalid new lines in strings" {
 
 ///|
 test "throws on unterminated strings" {
-  let res = try? @json5.parse("\"")
+  let res = try @json5.parse("\"") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(Unexpected end of file)")
 }
 
 ///|
 test "throws on invalid identifier start characters in property names" {
-  let res = try? @json5.parse("{!:1}")
+  let res = try @json5.parse("{!:1}") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(Invalid character ! at line 1, column 1)")
 }
 
 ///|
 test "throws on invalid characters following a property name" {
-  let res = try? @json5.parse("{a!1}")
+  let res = try @json5.parse("{a!1}") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(Invalid character ! at line 1, column 2)")
 }
 
 ///|
 test "throws on invalid characters following a property value" {
-  let res = try? @json5.parse("{a:1!}")
+  let res = try @json5.parse("{a:1!}") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(Invalid character ! at line 1, column 4)")
 }
 
 ///|
 test "throws on invalid characters following an array value" {
-  let res = try? @json5.parse("[1!]")
+  let res = try @json5.parse("[1!]") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(Invalid character ! at line 1, column 2)")
 }
 
 ///|
 test "throws on invalid characters in literals" {
-  let res = try? @json5.parse("tru!")
+  let res = try @json5.parse("tru!") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(No valid token at line 1, column 1)")
 }
 
 ///|
 test "throws on unterminated escapes" {
-  let res = try? @json5.parse("\"\\")
+  let res = try @json5.parse("\"\\") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(Unexpected end of file)")
 }
 
 ///|
 test "throws on invalid first digits in hexadecimal escapes" {
-  let res = try? @json5.parse("\"\\xg\"")
+  let res = try @json5.parse("\"\\xg\"") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(Invalid character g at line 1, column 3)")
 }
 
 ///|
 test "throws on invalid second digits in hexadecimal escapes" {
-  let res = try? @json5.parse("\"\\x0g\"")
+  let res = try @json5.parse("\"\\x0g\"") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(Invalid character g at line 1, column 4)")
 }
 
 ///|
 test "throws on invalid unicode escapes" {
-  let res = try? @json5.parse("\"\\u000g\"")
+  let res = try @json5.parse("\"\\u000g\"") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(Invalid character g at line 1, column 6)")
 }
 
 ///|
 test "throws on escaped digits" {
-  let res = try? @json5.parse("\"\\1\"")
+  let res = try @json5.parse("\"\\1\"") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(Invalid character 1 at line 1, column 2)")
 }
 
 ///|
 test "throws on octal escapes" {
-  let res = try? @json5.parse("\"\\01\"")
+  let res = try @json5.parse("\"\\01\"") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(Invalid character 1 at line 1, column 3)")
 }
 
 ///|
 test "throws on multiple values" {
-  let res = try? @json5.parse("1 2")
+  let res = try @json5.parse("1 2") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(Invalid character 2 at line 1, column 2)")
 }
 
 ///|
 test "throws with control characters escaped in the message" {
-  let res = try? @json5.parse("\u{01}")
+  let res = try @json5.parse("\u{01}") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(No valid token at line 1, column 1)")
 }
 
 ///|
 test "throws on unclosed objects before property names" {
-  let res = try? @json5.parse("{")
+  let res = try @json5.parse("{") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(Unexpected end of file)")
 }
 
 ///|
 test "throws on unclosed objects after property names" {
-  let res = try? @json5.parse("{a")
+  let res = try @json5.parse("{a") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(Unexpected end of file)")
 }
 
 ///|
 test "throws on unclosed objects before property values" {
-  let res = try? @json5.parse("{a:")
+  let res = try @json5.parse("{a:") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(Unexpected end of file)")
 }
 
 ///|
 test "throws on unclosed objects after property values" {
-  let res = try? @json5.parse("{a:1")
+  let res = try @json5.parse("{a:1") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(Unexpected end of file)")
 }
 
 ///|
 test "throws on unclosed arrays before values" {
-  let res = try? @json5.parse("[")
+  let res = try @json5.parse("[") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(Unexpected end of file)")
 }
 
 ///|
 test "throws on unclosed arrays after values" {
-  let res = try? @json5.parse("[1")
+  let res = try @json5.parse("[1") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(res, content="Err(Unexpected end of file)")
 }
 //endregion

--- a/json5/parse_test.mbt
+++ b/json5/parse_test.mbt
@@ -15,7 +15,11 @@
 ///|
 #callsite(autofill(loc))
 fn test_parse(input : String, loc~ : SourceLoc) -> Json raise Error {
-  let v = try? @json5.parse(input)
+  let v = try @json5.parse(input) catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   match v {
     Ok(v) => v
     Err(err) => fail("Parse failed, \{loc}, \{err}")

--- a/rational/rational.mbt
+++ b/rational/rational.mbt
@@ -1068,12 +1068,20 @@ test "eq and compare" {
 
 ///|
 test "from_double normal case" {
-  let result = try? from_double(0.5)
+  let result = try from_double(0.5) catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   @debug.assert_eq(result, Ok(new_unchecked(1L, 2L)))
 }
 
 ///|
 test "from_double edge case" {
-  let result = try? from_double(9_223_372_036_800_000_000.0)
+  let result = try from_double(9_223_372_036_800_000_000.0) catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   @debug.assert_eq(result, Ok(new_unchecked(9_223_372_036_800_000_000L, 1L)))
 }

--- a/rational/rational_test.mbt
+++ b/rational/rational_test.mbt
@@ -57,12 +57,20 @@ test "division" {
 
 ///|
 test "from_double overflow" {
-  let result = try? @rational.from_double(10.0e200)
+  let result = try @rational.from_double(10.0e200) catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   @debug.assert_eq(
     result,
     Err(RationalError("Rational::from_double: overflow")),
   )
-  let result = try? @rational.from_double(-10.0e200)
+  let result = try @rational.from_double(-10.0e200) catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   @debug.assert_eq(
     result,
     Err(RationalError("Rational::from_double: overflow")),
@@ -71,7 +79,11 @@ test "from_double overflow" {
 
 ///|
 test "from_double NaN" {
-  let result = try? @rational.from_double(@double.not_a_number)
+  let result = try @rational.from_double(@double.not_a_number) catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   @debug.assert_eq(
     result,
     Err(RationalError("Rational::from_double: cannot convert NaN")),
@@ -80,12 +92,20 @@ test "from_double NaN" {
 
 ///|
 test "from_double overflow edge case" {
-  let result = try? @rational.from_double(9_223_372_036_854_775_807.1)
+  let result = try @rational.from_double(9_223_372_036_854_775_807.1) catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   @debug.assert_eq(
     result,
     Err(RationalError("Rational::from_double: overflow")),
   )
-  let result = try? @rational.from_double(-9_223_372_036_854_775_807.1)
+  let result = try @rational.from_double(-9_223_372_036_854_775_807.1) catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   @debug.assert_eq(
     result,
     Err(RationalError("Rational::from_double: overflow")),
@@ -94,12 +114,20 @@ test "from_double overflow edge case" {
 
 ///|
 test "from_double infinity" {
-  let result = try? @rational.from_double(@double.infinity)
+  let result = try @rational.from_double(@double.infinity) catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   @debug.assert_eq(
     result,
     Err(RationalError("Rational::from_double: overflow")),
   )
-  let result = try? @rational.from_double(@double.neg_infinity)
+  let result = try @rational.from_double(@double.neg_infinity) catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   @debug.assert_eq(
     result,
     Err(RationalError("Rational::from_double: overflow")),

--- a/time/duration_test.mbt
+++ b/time/duration_test.mbt
@@ -24,8 +24,22 @@ test "from_str" {
     content="PT-1H-2M-3.456789S",
   )
   inspect(@time.Duration::from_str("PT0.45S"), content="PT0.45S")
-  assert_true((try? @time.Duration::from_str("PT0.000.45S")) is Err(_))
-  assert_true((try? @time.Duration::from_str("P1Y2M3DT4H5M6S")) is Err(_))
+  assert_true(
+    (try @time.Duration::from_str("PT0.000.45S") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.Duration::from_str("P1Y2M3DT4H5M6S") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -71,11 +85,19 @@ test "add_seconds" {
     content="PT-2562047788015215H-30M-8S",
   )
   assert_true(
-    (try? @time.Duration::of(seconds=1L).add_seconds(@int64.MAX_VALUE))
+    (try @time.Duration::of(seconds=1L).add_seconds(@int64.MAX_VALUE) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
     is Err(_),
   )
   assert_true(
-    (try? @time.Duration::of(seconds=-1L).add_seconds(@int64.MIN_VALUE))
+    (try @time.Duration::of(seconds=-1L).add_seconds(@int64.MIN_VALUE) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
     is Err(_),
   )
 }
@@ -92,5 +114,12 @@ test "with_nanoseconds" {
   let d = @time.Duration::of(nanoseconds=1000L)
   inspect(d.with_nanoseconds(1000), content="PT0.000001S")
   inspect(d.with_nanoseconds(2000), content="PT0.000002S")
-  assert_true((try? d.with_nanoseconds(1_000_000_000)) is Err(_))
+  assert_true(
+    (try d.with_nanoseconds(1_000_000_000) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }

--- a/time/duration_wbtest.mbt
+++ b/time/duration_wbtest.mbt
@@ -47,8 +47,22 @@ test "add_hours" {
     Duration::zero().add_hours(@int64.MIN_VALUE / seconds_per_hour),
     content="PT-2562047788015215H",
   )
-  assert_true((try? Duration::zero().add_hours(@int64.MAX_VALUE)) is Err(_))
-  assert_true((try? Duration::zero().add_hours(@int64.MIN_VALUE)) is Err(_))
+  assert_true(
+    (try Duration::zero().add_hours(@int64.MAX_VALUE) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try Duration::zero().add_hours(@int64.MIN_VALUE) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -64,8 +78,22 @@ test "add_minutes" {
     Duration::zero().add_minutes(@int64.MIN_VALUE / seconds_per_minute),
     content="PT-2562047788015215H-30M",
   )
-  assert_true((try? Duration::zero().add_minutes(@int64.MAX_VALUE)) is Err(_))
-  assert_true((try? Duration::zero().add_minutes(@int64.MIN_VALUE)) is Err(_))
+  assert_true(
+    (try Duration::zero().add_minutes(@int64.MAX_VALUE) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try Duration::zero().add_minutes(@int64.MIN_VALUE) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -106,15 +134,23 @@ test "add_nanoseconds" {
     content="PT-2562047H-47M-16.854775808S",
   )
   assert_true(
-    (try? Duration::of(seconds=@int64.MAX_VALUE).add_nanoseconds(
-      @int64.MAX_VALUE,
-    ))
+    (try
+      Duration::of(seconds=@int64.MAX_VALUE).add_nanoseconds(@int64.MAX_VALUE)
+    catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
     is Err(_),
   )
   assert_true(
-    (try? Duration::of(seconds=@int64.MIN_VALUE).add_nanoseconds(
-      @int64.MIN_VALUE,
-    ))
+    (try
+      Duration::of(seconds=@int64.MIN_VALUE).add_nanoseconds(@int64.MIN_VALUE)
+    catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
     is Err(_),
   )
 }
@@ -132,6 +168,20 @@ test "op_add" {
   inspect(p1.op_add(p2), content="PT0S")
   inspect(p1.op_add(p1), content="PT2H2M2.000002S")
   inspect(p2.op_add(p2), content="PT-2H-2M-2.000002S")
-  assert_true((try? p1.op_add(p3)) is Err(_))
-  assert_true((try? p2.op_add(p4)) is Err(_))
+  assert_true(
+    (try p1.op_add(p3) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try p2.op_add(p4) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }

--- a/time/period_test.mbt
+++ b/time/period_test.mbt
@@ -25,10 +25,38 @@ test "from_string" {
   inspect(@time.Period::from_string("P10Y2M3D"), content="P10Y2M3D")
   inspect(@time.Period::from_string("P-10Y-2M-3D"), content="P-10Y-2M-3D")
   inspect(@time.Period::from_string("P2M3D10Y"), content="P2M3D")
-  assert_true((try? @time.Period::from_string("10Y")) is Err(_))
-  assert_true((try? @time.Period::from_string("10Y0M")) is Err(_))
-  assert_true((try? @time.Period::from_string("P10YT3H")) is Err(_))
-  assert_true((try? @time.Period::from_string("P2.5Y")) is Err(_))
+  assert_true(
+    (try @time.Period::from_string("10Y") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.Period::from_string("10Y0M") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.Period::from_string("P10YT3H") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.Period::from_string("P2.5Y") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -127,8 +155,22 @@ test "op_add" {
   inspect(p1.op_add(p2), content="P0D")
   inspect(p1.op_add(p1), content="P2Y4M6D")
   inspect(p2.op_add(p2), content="P-2Y-4M-6D")
-  assert_true((try? p1.op_add(p3)) is Err(_))
-  assert_true((try? p2.op_add(p4)) is Err(_))
+  assert_true(
+    (try p1.op_add(p3) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try p2.op_add(p4) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -148,8 +190,22 @@ test "op_sub" {
   inspect(p1.op_sub(p1), content="P0D")
   inspect(p1.op_sub(p2), content="P2Y4M6D")
   inspect(p2.op_sub(p1), content="P-2Y-4M-6D")
-  assert_true((try? p3.op_sub(p2)) is Err(_))
-  assert_true((try? p4.op_sub(p1)) is Err(_))
+  assert_true(
+    (try p3.op_sub(p2) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try p4.op_sub(p1) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -159,8 +215,22 @@ test "multiply" {
   inspect(p.multiply(1), content="P1Y2M3D")
   inspect(p.multiply(-1), content="P-1Y-2M-3D")
   inspect(p.multiply(2), content="P2Y4M6D")
-  assert_true((try? p.multiply(@int.MAX_VALUE)) is Err(_))
-  assert_true((try? p.multiply(@int.MIN_VALUE)) is Err(_))
+  assert_true(
+    (try p.multiply(@int.MAX_VALUE) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try p.multiply(@int.MIN_VALUE) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -180,5 +250,12 @@ test "negated" {
     months=@int.MIN_VALUE,
     days=@int.MIN_VALUE,
   )
-  assert_true((try? p.negated()) is Err(_))
+  assert_true(
+    (try p.negated() catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }

--- a/time/plain_date_test.mbt
+++ b/time/plain_date_test.mbt
@@ -21,9 +21,30 @@ test "of" {
   inspect(@time.PlainDate::of(-1, 1, 1), content="-0001-01-01")
   inspect(@time.PlainDate::of(-2000, 2, 29), content="-2000-02-29")
   inspect(@time.PlainDate::of(-9999, 1, 1), content="-9999-01-01")
-  assert_true((try? @time.PlainDate::of(2001, 2, 29)) is Err(_))
-  assert_true((try? @time.PlainDate::of(2001, 1, 32)) is Err(_))
-  assert_true((try? @time.PlainDate::of(10000, 1, 1)) is Err(_))
+  assert_true(
+    (try @time.PlainDate::of(2001, 2, 29) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.PlainDate::of(2001, 1, 32) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.PlainDate::of(10000, 1, 1) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -35,10 +56,38 @@ test "from_year_ord" {
   inspect(@time.PlainDate::from_year_ord(-2000, 366), content="-2000-12-31")
   inspect(@time.PlainDate::from_year_ord(9999, 365), content="9999-12-31")
   inspect(@time.PlainDate::from_year_ord(-9999, 365), content="-9999-12-31")
-  assert_true((try? @time.PlainDate::from_year_ord(2001, 366)) is Err(_))
-  assert_true((try? @time.PlainDate::from_year_ord(-2001, 366)) is Err(_))
-  assert_true((try? @time.PlainDate::from_year_ord(10000, 365)) is Err(_))
-  assert_true((try? @time.PlainDate::from_year_ord(-10000, 365)) is Err(_))
+  assert_true(
+    (try @time.PlainDate::from_year_ord(2001, 366) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.PlainDate::from_year_ord(-2001, 366) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.PlainDate::from_year_ord(10000, 365) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.PlainDate::from_year_ord(-10000, 365) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -47,11 +96,46 @@ test "from_str" {
   inspect(@time.PlainDate::from_str("0000-01-01"), content="0000-01-01")
   inspect(@time.PlainDate::from_str("0001-01-01"), content="0001-01-01")
   inspect(@time.PlainDate::from_str("-9999-01-01"), content="-9999-01-01")
-  assert_true((try? @time.PlainDate::from_str("10000-01-01")) is Err(_))
-  assert_true((try? @time.PlainDate::from_str("-10000-01-01")) is Err(_))
-  assert_true((try? @time.PlainDate::from_str("-01-01")) is Err(_))
-  assert_true((try? @time.PlainDate::from_str("12-31")) is Err(_))
-  assert_true((try? @time.PlainDate::from_str("-01")) is Err(_))
+  assert_true(
+    (try @time.PlainDate::from_str("10000-01-01") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.PlainDate::from_str("-10000-01-01") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.PlainDate::from_str("-01-01") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.PlainDate::from_str("12-31") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.PlainDate::from_str("-01") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -193,8 +277,22 @@ test "add_years" {
   inspect(d.add_years(7999L), content="9999-02-28")
   inspect(d.add_years(-2001L), content="-0001-02-28")
   inspect(d.add_years(-9999L), content="-7999-02-28")
-  assert_true((try? d.add_years(8000L)) is Err(_))
-  assert_true((try? d.add_years(@int64.MAX_VALUE)) is Err(_))
+  assert_true(
+    (try d.add_years(8000L) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try d.add_years(@int64.MAX_VALUE) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
   inspect(d.add_years(@int64.MIN_VALUE), content="2000-02-29")
 }
 
@@ -208,9 +306,30 @@ test "add_months" {
   inspect(d.add_months(12L), content="2001-02-28")
   inspect(d.add_months(24L), content="2002-02-28")
   inspect(d.add_months(12L * -2000L), content="0000-02-29")
-  assert_true((try? d.add_months(12L * 8000L)) is Err(_))
-  assert_true((try? d.add_months(@int64.MAX_VALUE)) is Err(_))
-  assert_true((try? d.add_months(@int64.MIN_VALUE)) is Err(_))
+  assert_true(
+    (try d.add_months(12L * 8000L) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try d.add_months(@int64.MAX_VALUE) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try d.add_months(@int64.MIN_VALUE) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
   let d = @time.PlainDate::of(-2000, 2, 29)
   inspect(d.add_months(0L), content="-2000-02-29")
   inspect(d.add_months(1L), content="-2000-03-29")
@@ -219,9 +338,30 @@ test "add_months" {
   inspect(d.add_months(12L), content="-1999-02-28")
   inspect(d.add_months(24L), content="-1998-02-28")
   inspect(d.add_months(12L * 10000L), content="8000-02-29")
-  assert_true((try? d.add_months(12L * -8000L)) is Err(_))
-  assert_true((try? d.add_months(@int64.MAX_VALUE)) is Err(_))
-  assert_true((try? d.add_months(@int64.MIN_VALUE)) is Err(_))
+  assert_true(
+    (try d.add_months(12L * -8000L) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try d.add_months(@int64.MAX_VALUE) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try d.add_months(@int64.MIN_VALUE) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -232,16 +372,44 @@ test "add_weeks" {
   inspect(d.add_weeks(-1L), content="2000-02-22")
   inspect(d.add_weeks(3L), content="2000-03-21")
   inspect(d.add_weeks(-3L), content="2000-02-08")
-  assert_true((try? d.add_weeks(@int64.MAX_VALUE)) is Err(_))
-  assert_true((try? d.add_weeks(@int64.MIN_VALUE)) is Err(_))
+  assert_true(
+    (try d.add_weeks(@int64.MAX_VALUE) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try d.add_weeks(@int64.MIN_VALUE) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
   let d = @time.PlainDate::of(-2000, 2, 29)
   inspect(d.add_weeks(0L), content="-2000-02-29")
   inspect(d.add_weeks(1L), content="-2000-03-07")
   inspect(d.add_weeks(-1L), content="-2000-02-22")
   inspect(d.add_weeks(3L), content="-2000-03-21")
   inspect(d.add_weeks(-3L), content="-2000-02-08")
-  assert_true((try? d.add_weeks(@int64.MAX_VALUE)) is Err(_))
-  assert_true((try? d.add_weeks(@int64.MIN_VALUE)) is Err(_))
+  assert_true(
+    (try d.add_weeks(@int64.MAX_VALUE) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try d.add_weeks(@int64.MIN_VALUE) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -252,16 +420,44 @@ test "add_days" {
   inspect(d.add_days(-1L), content="2000-02-28")
   inspect(d.add_days(365L), content="2001-02-28")
   inspect(d.add_days(-365L), content="1999-03-01")
-  assert_true((try? d.add_days(@int64.MAX_VALUE)) is Err(_))
-  assert_true((try? d.add_days(@int64.MIN_VALUE)) is Err(_))
+  assert_true(
+    (try d.add_days(@int64.MAX_VALUE) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try d.add_days(@int64.MIN_VALUE) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
   let d = @time.PlainDate::of(-2000, 2, 29)
   inspect(d.add_days(0L), content="-2000-02-29")
   inspect(d.add_days(1L), content="-2000-03-01")
   inspect(d.add_days(-1L), content="-2000-02-28")
   inspect(d.add_days(365L), content="-1999-02-28")
   inspect(d.add_days(-365L), content="-2001-03-01")
-  assert_true((try? d.add_days(@int64.MAX_VALUE)) is Err(_))
-  assert_true((try? d.add_days(@int64.MIN_VALUE)) is Err(_))
+  assert_true(
+    (try d.add_days(@int64.MAX_VALUE) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try d.add_days(@int64.MIN_VALUE) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -285,8 +481,22 @@ test "with_year" {
   inspect(d.with_year(0), content="0000-02-29")
   inspect(d.with_year(9999), content="9999-02-28")
   inspect(d.with_year(-9999), content="-9999-02-28")
-  assert_true((try? d.with_year(10000)) is Err(_))
-  assert_true((try? d.with_year(-10000)) is Err(_))
+  assert_true(
+    (try d.with_year(10000) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try d.with_year(-10000) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -295,8 +505,22 @@ test "with_month" {
   inspect(d.with_month(1), content="2000-01-31")
   inspect(d.with_month(2), content="2000-02-29")
   inspect(d.with_month(4), content="2000-04-30")
-  assert_true((try? d.with_month(0)) is Err(_))
-  assert_true((try? d.with_month(13)) is Err(_))
+  assert_true(
+    (try d.with_month(0) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try d.with_month(13) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -304,8 +528,22 @@ test "with_day" {
   let d = @time.PlainDate::of(2000, 2, 29)
   inspect(d.with_day(29), content="2000-02-29")
   inspect(d.with_day(1), content="2000-02-01")
-  assert_true((try? d.with_day(0)) is Err(_))
-  assert_true((try? d.with_day(30)) is Err(_))
+  assert_true(
+    (try d.with_day(0) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try d.with_day(30) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -313,8 +551,22 @@ test "with_ordinal" {
   let d = @time.PlainDate::of(2000, 2, 29)
   inspect(d.with_ordinal(1), content="2000-01-01")
   inspect(d.with_ordinal(366), content="2000-12-31")
-  assert_true((try? d.with_ordinal(0)) is Err(_))
-  assert_true((try? d.with_ordinal(367)) is Err(_))
+  assert_true(
+    (try d.with_ordinal(0) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try d.with_ordinal(367) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|

--- a/time/plain_date_time_test.mbt
+++ b/time/plain_date_time_test.mbt
@@ -69,9 +69,15 @@ test "from_unix_second" {
     content="2024-04-27T22:22:09.000001",
   )
   assert_true(
-    (try? @time.PlainDateTime::from_unix_second(
-      1714227729L, 1_000_000_000, @time.utc_offset,
-    ))
+    (try
+      @time.PlainDateTime::from_unix_second(
+        1714227729L, 1_000_000_000, @time.utc_offset,
+      )
+    catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
     is Err(_),
   )
 }
@@ -95,16 +101,45 @@ test "from_str" {
     content="2000-01-01T00:00:00.12345",
   )
   assert_true(
-    (try? @time.PlainDateTime::from_str("9999-12-31T23:59:60")) is Err(_),
+    (try @time.PlainDateTime::from_str("9999-12-31T23:59:60") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
   )
   assert_true(
-    (try? @time.PlainDateTime::from_str("10000-12-31T23:59:60")) is Err(_),
+    (try @time.PlainDateTime::from_str("10000-12-31T23:59:60") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
   )
   assert_true(
-    (try? @time.PlainDateTime::from_str("2000-01-01 00:00:00")) is Err(_),
+    (try @time.PlainDateTime::from_str("2000-01-01 00:00:00") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
   )
-  assert_true((try? @time.PlainDateTime::from_str("2000-01-01")) is Err(_))
-  assert_true((try? @time.PlainDateTime::from_str("00:00:00")) is Err(_))
+  assert_true(
+    (try @time.PlainDateTime::from_str("2000-01-01") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.PlainDateTime::from_str("00:00:00") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -147,9 +182,23 @@ test "add_years" {
   inspect(d.add_years(0L), content="2000-02-29T00:00:00")
   inspect(d.add_years(1L), content="2001-02-28T00:00:00")
   inspect(d.add_years(7999L), content="9999-02-28T00:00:00")
-  assert_true((try? d.add_years(8000L)) is Err(_))
+  assert_true(
+    (try d.add_years(8000L) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
   inspect(d.add_years(-11999L), content="-9999-02-28T00:00:00")
-  assert_true((try? d.add_years(-12000L)) is Err(_))
+  assert_true(
+    (try d.add_years(-12000L) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -158,9 +207,23 @@ test "add_months" {
   inspect(d.add_months(0L), content="2000-02-29T00:00:00")
   inspect(d.add_months(1L), content="2000-03-29T00:00:00")
   inspect(d.add_months(12L * 7999L), content="9999-02-28T00:00:00")
-  assert_true((try? d.add_months(12L * 8000L)) is Err(_))
+  assert_true(
+    (try d.add_months(12L * 8000L) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
   inspect(d.add_months(12L * -11999L), content="-9999-02-28T00:00:00")
-  assert_true((try? d.add_months(12L * -12000L)) is Err(_))
+  assert_true(
+    (try d.add_months(12L * -12000L) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -171,8 +234,22 @@ test "add_weeks" {
   inspect(d.add_weeks(-1L), content="2000-02-22T00:00:00")
   inspect(d.add_weeks(3L), content="2000-03-21T00:00:00")
   inspect(d.add_weeks(-3L), content="2000-02-08T00:00:00")
-  assert_true((try? d.add_weeks(@int64.MAX_VALUE)) is Err(_))
-  assert_true((try? d.add_weeks(@int64.MIN_VALUE)) is Err(_))
+  assert_true(
+    (try d.add_weeks(@int64.MAX_VALUE) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try d.add_weeks(@int64.MIN_VALUE) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -183,8 +260,22 @@ test "add_days" {
   inspect(d.add_days(-1L), content="2000-02-28T00:00:00")
   inspect(d.add_days(365L), content="2001-02-28T00:00:00")
   inspect(d.add_days(-365L), content="1999-03-01T00:00:00")
-  assert_true((try? d.add_days(@int64.MAX_VALUE)) is Err(_))
-  assert_true((try? d.add_days(@int64.MIN_VALUE)) is Err(_))
+  assert_true(
+    (try d.add_days(@int64.MAX_VALUE) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try d.add_days(@int64.MIN_VALUE) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -273,8 +364,22 @@ test "with_year" {
   inspect(d.with_year(0), content="0000-02-29T00:00:00")
   inspect(d.with_year(9999), content="9999-02-28T00:00:00")
   inspect(d.with_year(-9999), content="-9999-02-28T00:00:00")
-  assert_true((try? d.with_year(10000)) is Err(_))
-  assert_true((try? d.with_year(-10000)) is Err(_))
+  assert_true(
+    (try d.with_year(10000) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try d.with_year(-10000) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -283,8 +388,22 @@ test "with_month" {
   inspect(d.with_month(1), content="2000-01-31T00:00:00")
   inspect(d.with_month(2), content="2000-02-29T00:00:00")
   inspect(d.with_month(4), content="2000-04-30T00:00:00")
-  assert_true((try? d.with_month(0)) is Err(_))
-  assert_true((try? d.with_month(13)) is Err(_))
+  assert_true(
+    (try d.with_month(0) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try d.with_month(13) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -292,8 +411,22 @@ test "with_day" {
   let d = @time.PlainDateTime::of(2000, 2, 29)
   inspect(d.with_day(29), content="2000-02-29T00:00:00")
   inspect(d.with_day(1), content="2000-02-01T00:00:00")
-  assert_true((try? d.with_day(0)) is Err(_))
-  assert_true((try? d.with_day(30)) is Err(_))
+  assert_true(
+    (try d.with_day(0) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try d.with_day(30) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -301,8 +434,22 @@ test "with_ordinal" {
   let d = @time.PlainDateTime::of(2000, 2, 29)
   inspect(d.with_ordinal(1), content="2000-01-01T00:00:00")
   inspect(d.with_ordinal(366), content="2000-12-31T00:00:00")
-  assert_true((try? d.with_ordinal(0)) is Err(_))
-  assert_true((try? d.with_ordinal(367)) is Err(_))
+  assert_true(
+    (try d.with_ordinal(0) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try d.with_ordinal(367) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -312,8 +459,22 @@ test "with_hour" {
   inspect(d.with_hour(10), content="2000-01-01T10:00:00")
   inspect(d.with_hour(0), content="2000-01-01T00:00:00")
   inspect(d.with_hour(24), content="2000-01-01T24:00:00")
-  assert_true((try? d.with_hour(-1)) is Err(_))
-  assert_true((try? d.with_hour(25)) is Err(_))
+  assert_true(
+    (try d.with_hour(-1) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try d.with_hour(25) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -323,8 +484,22 @@ test "with_minute" {
   inspect(d.with_minute(10), content="2000-01-01T00:10:00")
   inspect(d.with_minute(0), content="2000-01-01T00:00:00")
   inspect(d.with_minute(59), content="2000-01-01T00:59:00")
-  assert_true((try? d.with_minute(-1)) is Err(_))
-  assert_true((try? d.with_minute(60)) is Err(_))
+  assert_true(
+    (try d.with_minute(-1) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try d.with_minute(60) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -334,8 +509,22 @@ test "with_second" {
   inspect(d.with_second(10), content="2000-01-01T00:00:10")
   inspect(d.with_second(0), content="2000-01-01T00:00:00")
   inspect(d.with_second(59), content="2000-01-01T00:00:59")
-  assert_true((try? d.with_second(-1)) is Err(_))
-  assert_true((try? d.with_second(60)) is Err(_))
+  assert_true(
+    (try d.with_second(-1) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try d.with_second(60) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -348,8 +537,22 @@ test "with_nanosecond" {
     d.with_nanosecond(999_999_999),
     content="2000-01-01T00:00:00.999999999",
   )
-  assert_true((try? d.with_nanosecond(-1)) is Err(_))
-  assert_true((try? d.with_nanosecond(1_000_000_000)) is Err(_))
+  assert_true(
+    (try d.with_nanosecond(-1) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try d.with_nanosecond(1_000_000_000) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|

--- a/time/plain_time_test.mbt
+++ b/time/plain_time_test.mbt
@@ -20,8 +20,22 @@ test "of" {
     @time.PlainTime::of(23, 59, 59, 999_999_999),
     content="23:59:59.999999999",
   )
-  assert_true((try? @time.PlainTime::of(24, 0, 0, 1)) is Err(_))
-  assert_true((try? @time.PlainTime::of(-1, 0, 0, 0)) is Err(_))
+  assert_true(
+    (try @time.PlainTime::of(24, 0, 0, 1) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.PlainTime::of(-1, 0, 0, 0) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -35,12 +49,54 @@ test "from_str" {
     @time.PlainTime::from_str("01:00:00.0000123"),
     content="01:00:00.0000123",
   )
-  assert_true((try? @time.PlainTime::from_str("1:00")) is Err(_))
-  assert_true((try? @time.PlainTime::from_str("10:0")) is Err(_))
-  assert_true((try? @time.PlainTime::from_str("100000")) is Err(_))
-  assert_true((try? @time.PlainTime::from_str("123:00:00")) is Err(_))
-  assert_true((try? @time.PlainTime::from_str("10:00:00.123zzz")) is Err(_))
-  assert_true((try? @time.PlainTime::from_str("z1:00:00")) is Err(_))
+  assert_true(
+    (try @time.PlainTime::from_str("1:00") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.PlainTime::from_str("10:0") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.PlainTime::from_str("100000") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.PlainTime::from_str("123:00:00") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.PlainTime::from_str("10:00:00.123zzz") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.PlainTime::from_str("z1:00:00") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -78,8 +134,22 @@ test "from_second_of_day" {
   inspect(@time.PlainTime::from_second_of_day(86400), content="24:00:00")
   inspect(@time.PlainTime::from_second_of_day(45030), content="12:30:30")
   inspect(@time.PlainTime::from_second_of_day(12345), content="03:25:45")
-  assert_true((try? @time.PlainTime::from_second_of_day(-1)) is Err(_))
-  assert_true((try? @time.PlainTime::from_second_of_day(86401)) is Err(_))
+  assert_true(
+    (try @time.PlainTime::from_second_of_day(-1) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.PlainTime::from_second_of_day(86401) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -93,9 +163,21 @@ test "from_nanosecond_of_day" {
     @time.PlainTime::from_nanosecond_of_day(45030123456789L),
     content="12:30:30.123456789",
   )
-  assert_true((try? @time.PlainTime::from_nanosecond_of_day(-1L)) is Err(_))
   assert_true(
-    (try? @time.PlainTime::from_nanosecond_of_day(86400000000001L)) is Err(_),
+    (try @time.PlainTime::from_nanosecond_of_day(-1L) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.PlainTime::from_nanosecond_of_day(86400000000001L) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
   )
 }
 
@@ -173,13 +255,28 @@ test "with_hour" {
     content="00:20:30.0000004",
   )
   assert_true(
-    (try? @time.PlainTime::of(1, 20, 30, 400).with_hour(-1)) is Err(_),
+    (try @time.PlainTime::of(1, 20, 30, 400).with_hour(-1) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
   )
   assert_true(
-    (try? @time.PlainTime::of(1, 20, 30, 400).with_hour(24)) is Err(_),
+    (try @time.PlainTime::of(1, 20, 30, 400).with_hour(24) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
   )
   assert_true(
-    (try? @time.PlainTime::of(1, 20, 30, 400).with_hour(25)) is Err(_),
+    (try @time.PlainTime::of(1, 20, 30, 400).with_hour(25) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
   )
 }
 
@@ -202,10 +299,20 @@ test "with_minute" {
     content="01:59:30.0000004",
   )
   assert_true(
-    (try? @time.PlainTime::of(1, 20, 30, 400).with_minute(-1)) is Err(_),
+    (try @time.PlainTime::of(1, 20, 30, 400).with_minute(-1) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
   )
   assert_true(
-    (try? @time.PlainTime::of(1, 20, 30, 400).with_minute(60)) is Err(_),
+    (try @time.PlainTime::of(1, 20, 30, 400).with_minute(60) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
   )
 }
 
@@ -228,10 +335,20 @@ test "with_second" {
     content="01:20:59.0000004",
   )
   assert_true(
-    (try? @time.PlainTime::of(1, 20, 30, 400).with_second(-1)) is Err(_),
+    (try @time.PlainTime::of(1, 20, 30, 400).with_second(-1) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
   )
   assert_true(
-    (try? @time.PlainTime::of(1, 20, 30, 400).with_second(60)) is Err(_),
+    (try @time.PlainTime::of(1, 20, 30, 400).with_second(60) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
   )
 }
 
@@ -254,10 +371,21 @@ test "with_nanosecond" {
     content="01:20:30.999999999",
   )
   assert_true(
-    (try? @time.PlainTime::of(1, 20, 30, 400).with_nanosecond(-1)) is Err(_),
+    (try @time.PlainTime::of(1, 20, 30, 400).with_nanosecond(-1) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
   )
   assert_true(
-    (try? @time.PlainTime::of(1, 20, 30, 400).with_nanosecond(1_000_000_000))
+    (try
+      @time.PlainTime::of(1, 20, 30, 400).with_nanosecond(1_000_000_000)
+    catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
     is Err(_),
   )
 }

--- a/time/util.mbt
+++ b/time/util.mbt
@@ -150,17 +150,46 @@ fn checked_mul_int64(x : Int64, y : Int64) -> Int64 raise Error {
 
 ///|
 test "checked_add_int" {
-  debug_inspect(try? checked_add_int(1, 1), content="Ok(2)")
-  debug_inspect(try? checked_add_int(1, -1), content="Ok(0)")
-  debug_inspect(try? checked_add_int(-1, -1), content="Ok(-2)")
   debug_inspect(
-    try? checked_add_int(@int.MAX_VALUE, 1),
+    try checked_add_int(1, 1) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(2)",
+  )
+  debug_inspect(
+    try checked_add_int(1, -1) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(0)",
+  )
+  debug_inspect(
+    try checked_add_int(-1, -1) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(-2)",
+  )
+  debug_inspect(
+    try checked_add_int(@int.MAX_VALUE, 1) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Err(Failure("Int overflow"))
     ),
   )
   debug_inspect(
-    try? checked_add_int(@int.MIN_VALUE, -1),
+    try checked_add_int(@int.MIN_VALUE, -1) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Err(Failure("Int overflow"))
     ),
@@ -169,17 +198,46 @@ test "checked_add_int" {
 
 ///|
 test "checked_mul_int" {
-  debug_inspect(try? checked_mul_int(2, 3), content="Ok(6)")
-  debug_inspect(try? checked_mul_int(2, -3), content="Ok(-6)")
-  debug_inspect(try? checked_mul_int(-2, -3), content="Ok(6)")
   debug_inspect(
-    try? checked_mul_int(@int.MAX_VALUE, 2),
+    try checked_mul_int(2, 3) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(6)",
+  )
+  debug_inspect(
+    try checked_mul_int(2, -3) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(-6)",
+  )
+  debug_inspect(
+    try checked_mul_int(-2, -3) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(6)",
+  )
+  debug_inspect(
+    try checked_mul_int(@int.MAX_VALUE, 2) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Err(Failure("Int overflow"))
     ),
   )
   debug_inspect(
-    try? checked_mul_int(@int.MIN_VALUE, 2),
+    try checked_mul_int(@int.MIN_VALUE, 2) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Err(Failure("Int overflow"))
     ),
@@ -188,17 +246,46 @@ test "checked_mul_int" {
 
 ///|
 test "checked_add_int64" {
-  debug_inspect(try? checked_add_int64(1L, 1L), content="Ok(2)")
-  debug_inspect(try? checked_add_int64(1L, -1L), content="Ok(0)")
-  debug_inspect(try? checked_add_int64(-1L, -1L), content="Ok(-2)")
   debug_inspect(
-    try? checked_add_int64(1L, @int64.MAX_VALUE),
+    try checked_add_int64(1L, 1L) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(2)",
+  )
+  debug_inspect(
+    try checked_add_int64(1L, -1L) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(0)",
+  )
+  debug_inspect(
+    try checked_add_int64(-1L, -1L) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(-2)",
+  )
+  debug_inspect(
+    try checked_add_int64(1L, @int64.MAX_VALUE) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Err(Failure("Int64 overflow"))
     ),
   )
   debug_inspect(
-    try? checked_add_int64(-1L, @int64.MIN_VALUE),
+    try checked_add_int64(-1L, @int64.MIN_VALUE) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Err(Failure("Int64 overflow"))
     ),
@@ -207,17 +294,46 @@ test "checked_add_int64" {
 
 ///|
 test "checked_mul_int64" {
-  debug_inspect(try? checked_mul_int64(2L, 3L), content="Ok(6)")
-  debug_inspect(try? checked_mul_int64(2L, -3L), content="Ok(-6)")
-  debug_inspect(try? checked_mul_int64(-2L, -3L), content="Ok(6)")
   debug_inspect(
-    try? checked_mul_int64(@int64.MAX_VALUE, 2L),
+    try checked_mul_int64(2L, 3L) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(6)",
+  )
+  debug_inspect(
+    try checked_mul_int64(2L, -3L) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(-6)",
+  )
+  debug_inspect(
+    try checked_mul_int64(-2L, -3L) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(6)",
+  )
+  debug_inspect(
+    try checked_mul_int64(@int64.MAX_VALUE, 2L) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Err(Failure("Int64 overflow"))
     ),
   )
   debug_inspect(
-    try? checked_mul_int64(@int64.MIN_VALUE, 2L),
+    try checked_mul_int64(@int64.MIN_VALUE, 2L) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Err(Failure("Int64 overflow"))
     ),
@@ -249,13 +365,52 @@ fn floor_div_int(x : Int, y : Int) -> Int raise Error {
 
 ///|
 test "floor_div_int" {
-  debug_inspect(try? floor_div_int(1, 10), content="Ok(0)")
-  debug_inspect(try? floor_div_int(-1, 10), content="Ok(-1)")
-  debug_inspect(try? floor_div_int(9, 10), content="Ok(0)")
-  debug_inspect(try? floor_div_int(-9, 10), content="Ok(-1)")
-  debug_inspect(try? floor_div_int(0, 10), content="Ok(0)")
   debug_inspect(
-    try? floor_div_int(10, 0),
+    try floor_div_int(1, 10) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(0)",
+  )
+  debug_inspect(
+    try floor_div_int(-1, 10) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(-1)",
+  )
+  debug_inspect(
+    try floor_div_int(9, 10) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(0)",
+  )
+  debug_inspect(
+    try floor_div_int(-9, 10) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(-1)",
+  )
+  debug_inspect(
+    try floor_div_int(0, 10) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(0)",
+  )
+  debug_inspect(
+    try floor_div_int(10, 0) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Err(Failure("division by zero"))
     ),
@@ -273,12 +428,54 @@ fn floor_div_int64(x : Int64, y : Int64) -> Int64 raise Error {
 
 ///|
 test "floor_div_int64" {
-  debug_inspect(try? floor_div_int64(1L, 10L), content="Ok(0)")
-  debug_inspect(try? floor_div_int64(-1L, 10L), content="Ok(-1)")
-  debug_inspect(try? floor_div_int64(9L, 10L), content="Ok(0)")
-  debug_inspect(try? floor_div_int64(-9L, 10L), content="Ok(-1)")
-  debug_inspect(try? floor_div_int64(0L, 10L), content="Ok(0)")
-  assert_true((try? floor_div_int64(10L, 0L)) is Err(_))
+  debug_inspect(
+    try floor_div_int64(1L, 10L) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(0)",
+  )
+  debug_inspect(
+    try floor_div_int64(-1L, 10L) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(-1)",
+  )
+  debug_inspect(
+    try floor_div_int64(9L, 10L) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(0)",
+  )
+  debug_inspect(
+    try floor_div_int64(-9L, 10L) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(-1)",
+  )
+  debug_inspect(
+    try floor_div_int64(0L, 10L) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(0)",
+  )
+  assert_true(
+    (try floor_div_int64(10L, 0L) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -288,13 +485,52 @@ fn floor_mod_int(x : Int, y : Int) -> Int raise Error {
 
 ///|
 test "floor_mod_int" {
-  debug_inspect(try? floor_mod_int(1, 10), content="Ok(1)")
-  debug_inspect(try? floor_mod_int(-1, 10), content="Ok(9)")
-  debug_inspect(try? floor_mod_int(11, 10), content="Ok(1)")
-  debug_inspect(try? floor_mod_int(-11, 10), content="Ok(9)")
-  debug_inspect(try? floor_mod_int(0, 10), content="Ok(0)")
   debug_inspect(
-    try? floor_mod_int(10, 0),
+    try floor_mod_int(1, 10) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(1)",
+  )
+  debug_inspect(
+    try floor_mod_int(-1, 10) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(9)",
+  )
+  debug_inspect(
+    try floor_mod_int(11, 10) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(1)",
+  )
+  debug_inspect(
+    try floor_mod_int(-11, 10) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(9)",
+  )
+  debug_inspect(
+    try floor_mod_int(0, 10) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(0)",
+  )
+  debug_inspect(
+    try floor_mod_int(10, 0) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Err(Failure("division by zero"))
     ),
@@ -308,10 +544,52 @@ fn floor_mod_int64(x : Int64, y : Int64) -> Int64 raise Error {
 
 ///|
 test "floor_mod_int64" {
-  debug_inspect(try? floor_mod_int64(1L, 10L), content="Ok(1)")
-  debug_inspect(try? floor_mod_int64(-1L, 10L), content="Ok(9)")
-  debug_inspect(try? floor_mod_int64(11L, 10L), content="Ok(1)")
-  debug_inspect(try? floor_mod_int64(-11L, 10L), content="Ok(9)")
-  debug_inspect(try? floor_mod_int64(0L, 10L), content="Ok(0)")
-  assert_true((try? floor_mod_int64(10L, 0L)) is Err(_))
+  debug_inspect(
+    try floor_mod_int64(1L, 10L) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(1)",
+  )
+  debug_inspect(
+    try floor_mod_int64(-1L, 10L) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(9)",
+  )
+  debug_inspect(
+    try floor_mod_int64(11L, 10L) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(1)",
+  )
+  debug_inspect(
+    try floor_mod_int64(-11L, 10L) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(9)",
+  )
+  debug_inspect(
+    try floor_mod_int64(0L, 10L) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="Ok(0)",
+  )
+  assert_true(
+    (try floor_mod_int64(10L, 0L) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }

--- a/time/zone_offset_test.mbt
+++ b/time/zone_offset_test.mbt
@@ -23,22 +23,102 @@ test "of" {
     @time.ZoneOffset::of(hours=1, minutes=30, seconds=30),
     content="+01:30:30",
   )
-  assert_true((try? @time.ZoneOffset::of(hours=19)) is Err(_))
-  assert_true((try? @time.ZoneOffset::of(hours=-19)) is Err(_))
-  assert_true((try? @time.ZoneOffset::of(minutes=60)) is Err(_))
-  assert_true((try? @time.ZoneOffset::of(minutes=-60)) is Err(_))
-  assert_true((try? @time.ZoneOffset::of(seconds=60)) is Err(_))
-  assert_true((try? @time.ZoneOffset::of(seconds=-60)) is Err(_))
   assert_true(
-    (try? @time.ZoneOffset::of(hours=1, minutes=-30, seconds=-30)) is Err(_),
+    (try @time.ZoneOffset::of(hours=19) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
   )
   assert_true(
-    (try? @time.ZoneOffset::of(hours=-1, minutes=30, seconds=30)) is Err(_),
+    (try @time.ZoneOffset::of(hours=-19) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
   )
-  assert_true((try? @time.ZoneOffset::of(minutes=-30, seconds=30)) is Err(_))
-  assert_true((try? @time.ZoneOffset::of(minutes=30, seconds=-30)) is Err(_))
-  assert_true((try? @time.ZoneOffset::of(hours=18, minutes=1)) is Err(_))
-  assert_true((try? @time.ZoneOffset::of(hours=-18, seconds=1)) is Err(_))
+  assert_true(
+    (try @time.ZoneOffset::of(minutes=60) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.ZoneOffset::of(minutes=-60) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.ZoneOffset::of(seconds=60) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.ZoneOffset::of(seconds=-60) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.ZoneOffset::of(hours=1, minutes=-30, seconds=-30) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.ZoneOffset::of(hours=-1, minutes=30, seconds=30) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.ZoneOffset::of(minutes=-30, seconds=30) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.ZoneOffset::of(minutes=30, seconds=-30) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.ZoneOffset::of(hours=18, minutes=1) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.ZoneOffset::of(hours=-18, seconds=1) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|
@@ -47,8 +127,22 @@ test "from_seconds" {
   inspect(@time.ZoneOffset::from_seconds(0), content="Z")
   inspect(@time.ZoneOffset::from_seconds(18 * 60 * 60), content="+18:00")
   inspect(@time.ZoneOffset::from_seconds(-18 * 60 * 60), content="-18:00")
-  assert_true((try? @time.ZoneOffset::from_seconds(19 * 60 * 60)) is Err(_))
-  assert_true((try? @time.ZoneOffset::from_seconds(-19 * 60 * 60)) is Err(_))
+  assert_true(
+    (try @time.ZoneOffset::from_seconds(19 * 60 * 60) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @time.ZoneOffset::from_seconds(-19 * 60 * 60) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|

--- a/uuid/uuid.mbt
+++ b/uuid/uuid.mbt
@@ -99,8 +99,22 @@ test "bytes" {
       #|b"\xc9\x82\xfbh\xdfPL\xa1\x91\xf8\xba\xa2\x04\x09\xe5\xb9"
     ),
   )
-  assert_true((try? from_bytes(Bytes::new(15))) is Err(_))
-  assert_true((try? from_bytes(Bytes::new(17))) is Err(_))
+  assert_true(
+    (try from_bytes(Bytes::new(15)) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try from_bytes(Bytes::new(17)) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|

--- a/uuid/uuid_test.mbt
+++ b/uuid/uuid_test.mbt
@@ -24,8 +24,22 @@ test "from_hex" {
     @uuid.from_hex("12345678-1234-1234-1234-ABCDEF098765"),
     content="12345678-1234-1234-1234-abcdef098765",
   )
-  assert_true((try? @uuid.from_hex("13cb")) is Err(_))
-  assert_true((try? @uuid.from_hex("13cb501c-99a8-c889-3234")) is Err(_))
+  assert_true(
+    (try @uuid.from_hex("13cb") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
+  assert_true(
+    (try @uuid.from_hex("13cb501c-99a8-c889-3234") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(_),
+  )
 }
 
 ///|


### PR DESCRIPTION
## Summary

- Replace deprecated `try?` usages with explicit `try ... catch ... noraise` result conversion.
- Clean warning-producing tests, benchmark helpers, and package-local test blocks without changing public APIs.

## Validation

- `moon fmt`
- `moon check`
- `moon check --target all`
- `moon test` (546 passed)
- `moon info`
- `git diff --check`
