### PR TITLE
Add debug object trace writer

### DIFF
--- a/debug/moon.pkg
+++ b/debug/moon.pkg
@@ -1,0 +1,18 @@
+import {
+  "moonbitlang/core/debug" @core_debug,
+}
+
+import {
+  "moonbitlang/core/test",
+} for "test"
+
+warnings = "-alert_visibility-test_unqualified_package"
+
+options(
+  targets: {
+    "trace_debug.mbt": [ "debug" ],
+    "trace_debug_test.mbt": [ "debug" ],
+    "trace_release.mbt": [ "not", "debug" ],
+    "trace_release_test.mbt": [ "not", "debug" ],
+  },
+)

--- a/debug/pkg.generated.mbti
+++ b/debug/pkg.generated.mbti
@@ -1,0 +1,18 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbitlang/x/debug"
+
+// Values
+pub let debug_object : DebugObject?
+
+// Errors
+
+// Types and methods
+type DebugObject
+pub fn DebugObject::write_object_begin(Self) -> Unit
+pub fn DebugObject::write_object_end(Self) -> Unit
+pub fn[T : @moonbitlang/core/debug.Debug] DebugObject::write_object_field(Self, String, T) -> Unit
+
+// Type aliases
+
+// Traits
+

--- a/debug/trace.mbt
+++ b/debug/trace.mbt
@@ -1,0 +1,63 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Debug-only object-template writer.
+///
+/// This type supports object-template fields so
+/// `@debug.debug_object <? { "name": value }` can log debug values in debug
+/// builds while compiling to a no-op in release builds.
+#warnings("-struct_never_constructed")
+struct DebugObject {
+  buffer : StringBuilder
+  mut first : Bool
+}
+
+///|
+/// Starts a debug object template.
+///
+/// This resets the internal buffer before object fields are written.
+pub fn DebugObject::write_object_begin(self : DebugObject) -> Unit {
+  self.buffer.reset()
+  self.first = true
+}
+
+///|
+/// Ends a debug object template.
+///
+/// This flushes the accumulated object fields.
+pub fn DebugObject::write_object_end(self : DebugObject) -> Unit {
+  println(self.buffer.to_string())
+  self.buffer.reset()
+  self.first = true
+}
+
+///|
+/// Writes one debug object-template field.
+///
+/// The field value must implement `Debug`.
+pub fn[T : Debug] DebugObject::write_object_field(
+  self : DebugObject,
+  name : String,
+  value : T,
+) -> Unit {
+  if self.first {
+    self.first = false
+  } else {
+    self.buffer.write_string(", ")
+  }
+  self.buffer.write_string(name)
+  self.buffer.write_string(" = ")
+  self.buffer.write_string(@core_debug.to_string(value))
+}

--- a/debug/trace_debug.mbt
+++ b/debug/trace_debug.mbt
@@ -1,0 +1,30 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Return a debug object-template writer in debug builds.
+///
+/// Intended usage:
+///
+/// ```mbt nocheck
+/// @debug.debug_object <? { "value": value }
+/// ```
+///
+/// The object field value must implement `Debug`. In release builds this
+/// value is `None`, so `<?` skips the template and does not evaluate field
+/// values.
+pub let debug_object : DebugObject? = Some({
+  buffer: StringBuilder(),
+  first: true,
+})

--- a/debug/trace_debug_test.mbt
+++ b/debug/trace_debug_test.mbt
@@ -1,0 +1,27 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "debug_object/debug" {
+  guard debug_object is Some(_)
+  let mut evaluated = false
+  debug_object <?
+    {
+      "value": {
+        evaluated = true
+        [1, 2, 3]
+      },
+    }
+  inspect(evaluated, content="true")
+}

--- a/debug/trace_release.mbt
+++ b/debug/trace_release.mbt
@@ -1,0 +1,17 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Return no debug object-template writer in release builds.
+pub let debug_object : DebugObject? = None

--- a/debug/trace_release_test.mbt
+++ b/debug/trace_release_test.mbt
@@ -1,0 +1,27 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "debug_object/release" {
+  guard debug_object is None
+  let mut evaluated = false
+  debug_object <?
+    {
+      "value": {
+        evaluated = true
+        [1, 2, 3]
+      },
+    }
+  inspect(evaluated, content="false")
+}


### PR DESCRIPTION
## Summary

- add a new `moonbitlang/x/debug` package with `debug_object`
- provide a debug-only object-template writer and release-mode `None` value
- add debug/release tests covering field evaluation behavior

## Tests

- `moon check debug`
- `moon check --release debug`
- `moon test debug`
- `moon test --release debug`
- `moon fmt`
- `moon info`
- `moon check`
- `moon check --release`