### PR TITLE
Optimize crypto with target-aware SIMD

### DIFF
--- a/crypto/chacha.mbt
+++ b/crypto/chacha.mbt
@@ -250,6 +250,106 @@ test "chachaBlockLoop" {
 /// - chacha8: round = 4
 /// - chacha12: round = 6
 /// - chacha20: round = 10
+#cfg(any(target="wasm", target="wasm-gc"))
+fn chachaBlockBytes(
+  key : FixedArray[UInt],
+  count : UInt,
+  nonce : FixedArray[UInt],
+  round : UInt,
+  _scratch : FixedArray[UInt],
+  output : FixedArray[Byte],
+) -> Unit {
+  guard key.length() == 8
+  guard nonce.length() == 3
+  guard output.length() >= 64
+  let initial_a = @v128.i32x4_const(
+    0X61707865, 0X3320646e, 0X79622d32, 0X6b206574,
+  )
+  let initial_b = @v128.i32x4_const(key[0], key[1], key[2], key[3])
+  let initial_c = @v128.i32x4_const(key[4], key[5], key[6], key[7])
+  let initial_d = @v128.i32x4_const(count, nonce[0], nonce[1], nonce[2])
+  let mut a = initial_a
+  let mut b = initial_b
+  let mut c = initial_c
+  let mut d = initial_d
+  for _ in 0U..<round {
+    // Four column quarter-rounds in parallel.
+    a = @v128.i32x4_add(a, b)
+    let d_xor_a = @v128.v128_xor(d, a)
+    d = @v128.i8x16_shuffle(
+      d_xor_a, d_xor_a, 2, 3, 0, 1, 6, 7, 4, 5, 10, 11, 8, 9, 14, 15, 12, 13,
+    )
+    c = @v128.i32x4_add(c, d)
+    let b_xor_c = @v128.v128_xor(b, c)
+    b = @v128.v128_or_(
+      @v128.i32x4_shl(b_xor_c, 12),
+      @v128.i32x4_shr_u(b_xor_c, 20),
+    )
+    a = @v128.i32x4_add(a, b)
+    let d_xor_a = @v128.v128_xor(d, a)
+    d = @v128.i8x16_shuffle(
+      d_xor_a, d_xor_a, 3, 0, 1, 2, 7, 4, 5, 6, 11, 8, 9, 10, 15, 12, 13, 14,
+    )
+    c = @v128.i32x4_add(c, d)
+    let b_xor_c = @v128.v128_xor(b, c)
+    b = @v128.v128_or_(
+      @v128.i32x4_shl(b_xor_c, 7),
+      @v128.i32x4_shr_u(b_xor_c, 25),
+    )
+
+    // Align the rows so the same operations perform four diagonal rounds.
+    b = @v128.i8x16_shuffle(
+      b, b, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3,
+    )
+    c = @v128.i8x16_shuffle(
+      c, c, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7,
+    )
+    d = @v128.i8x16_shuffle(
+      d, d, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+    )
+    a = @v128.i32x4_add(a, b)
+    let d_xor_a = @v128.v128_xor(d, a)
+    d = @v128.i8x16_shuffle(
+      d_xor_a, d_xor_a, 2, 3, 0, 1, 6, 7, 4, 5, 10, 11, 8, 9, 14, 15, 12, 13,
+    )
+    c = @v128.i32x4_add(c, d)
+    let b_xor_c = @v128.v128_xor(b, c)
+    b = @v128.v128_or_(
+      @v128.i32x4_shl(b_xor_c, 12),
+      @v128.i32x4_shr_u(b_xor_c, 20),
+    )
+    a = @v128.i32x4_add(a, b)
+    let d_xor_a = @v128.v128_xor(d, a)
+    d = @v128.i8x16_shuffle(
+      d_xor_a, d_xor_a, 3, 0, 1, 2, 7, 4, 5, 6, 11, 8, 9, 10, 15, 12, 13, 14,
+    )
+    c = @v128.i32x4_add(c, d)
+    let b_xor_c = @v128.v128_xor(b, c)
+    b = @v128.v128_or_(
+      @v128.i32x4_shl(b_xor_c, 7),
+      @v128.i32x4_shr_u(b_xor_c, 25),
+    )
+    b = @v128.i8x16_shuffle(
+      b, b, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+    )
+    c = @v128.i8x16_shuffle(
+      c, c, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7,
+    )
+    d = @v128.i8x16_shuffle(
+      d, d, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3,
+    )
+  }
+  a = @v128.i32x4_add(a, initial_a)
+  b = @v128.i32x4_add(b, initial_b)
+  c = @v128.i32x4_add(c, initial_c)
+  d = @v128.i32x4_add(d, initial_d)
+  @v128.v128_store(output, 0, a)
+  @v128.v128_store(output, 16, b)
+  @v128.v128_store(output, 32, c)
+  @v128.v128_store(output, 48, d)
+}
+
+///|
 fn chachaBlock(
   key : FixedArray[UInt],
   count : UInt,
@@ -272,6 +372,22 @@ fn chachaBlock(
   state.chachaBlockLoop(round)
   for i in 0..<16 {
     state[i] += initial_state[i]
+  }
+}
+
+///|
+#cfg(not(any(target="wasm", target="wasm-gc")))
+fn chachaBlockBytes(
+  key : FixedArray[UInt],
+  count : UInt,
+  nonce : FixedArray[UInt],
+  round : UInt,
+  scratch : FixedArray[UInt],
+  output : FixedArray[Byte],
+) -> Unit {
+  chachaBlock(key, count, nonce, round, scratch)
+  for group in 0..<4 {
+    store_u32x4_le(scratch, group * 4, output, group * 16)
   }
 }
 
@@ -377,6 +493,49 @@ fn stateToBytes(state : FixedArray[UInt]) -> FixedArray[Byte] {
 }
 
 ///|
+#cfg(target="js")
+#inline
+fn[Data : ByteSource] chacha_xor_into(
+  data : Data,
+  input_offset : Int,
+  target : FixedArray[Byte],
+  target_offset : Int,
+  key_stream : FixedArray[Byte],
+  key_stream_offset : Int,
+  length : Int,
+) -> Unit {
+  for i in 0..<length {
+    target.unsafe_set(
+      target_offset + i,
+      data[input_offset + i] ^ key_stream.unsafe_get(key_stream_offset + i),
+    )
+  }
+}
+
+///|
+#cfg(not(target="js"))
+#inline
+fn[Data : ByteSource] chacha_xor_into(
+  data : Data,
+  input_offset : Int,
+  target : FixedArray[Byte],
+  target_offset : Int,
+  key_stream : FixedArray[Byte],
+  key_stream_offset : Int,
+  length : Int,
+) -> Unit {
+  data.blit_to(
+    target,
+    len=length,
+    src_offset=input_offset,
+    dst_offset=target_offset,
+  )
+  xor_byte_ranges_in_place(
+    target, target_offset, key_stream, key_stream_offset, length,
+  )
+}
+
+///|
 test "stateToBytes" {
   let state = FixedArray::make(16, 0U)
   state[0] = 0x879531e0
@@ -475,20 +634,35 @@ fn[Data : ByteSource] chacha(
     return FixedArray::make(0, Byte::default())
   }
   let buffer = FixedArray::make(block.length(), Byte::default())
-  let keyStream = FixedArray::make(16, 0U)
-  for i = 0; i < block.length(); i = i + 64 {
-    chachaBlock(
+  let keyStreamWords = FixedArray::make(16, 0U)
+  let keyStream = FixedArray::make(64, b'\x00')
+  let bulkKeyStream = FixedArray::make(256, b'\x00')
+  let mut i = 0
+  for ; chacha4_enabled() && i + 256 <= block.length(); {
+    chacha4BlockBytes(
       key,
       counter + i.reinterpret_as_uint() / 64,
       nonce,
       round,
+      keyStreamWords,
+      keyStream,
+      bulkKeyStream,
+    )
+    chacha_xor_into(block, i, buffer, i, bulkKeyStream, 0, 256)
+    i += 256
+  }
+  for ; i < block.length(); {
+    chachaBlockBytes(
+      key,
+      counter + i.reinterpret_as_uint() / 64,
+      nonce,
+      round,
+      keyStreamWords,
       keyStream,
     )
-    let pad = stateToBytes(keyStream)
     let len = @cmp.minimum(block.length() - i, 64)
-    for j in 0..<len {
-      buffer[i + j] = pad[j] ^ block[i + j]
-    }
+    chacha_xor_into(block, i, buffer, i, keyStream, 0, len)
+    i += 64
   }
   buffer
 }
@@ -497,7 +671,9 @@ fn[Data : ByteSource] chacha(
 struct ChaCha {
   key : FixedArray[UInt]
   nonce : FixedArray[UInt]
-  key_stream : FixedArray[UInt]
+  key_stream_words : FixedArray[UInt]
+  key_stream : FixedArray[Byte]
+  bulk_key_stream : FixedArray[Byte]
   mut counter : UInt
   mut offset : Int
   round : UInt
@@ -533,7 +709,9 @@ fn[K : ByteSource, N : ByteSource] ChaCha::new(
   {
     key: key_,
     nonce: nonce_,
-    key_stream: FixedArray::make(16, 0U),
+    key_stream_words: FixedArray::make(16, 0U),
+    key_stream: FixedArray::make(64, b'\x00'),
+    bulk_key_stream: FixedArray::make(256, b'\x00'),
     round,
     offset: 64,
     counter,
@@ -598,21 +776,77 @@ pub fn[D : ByteSource] ChaCha::transform(
   target : FixedArray[Byte],
   offset? : Int = 0,
 ) -> Unit {
-  for i in 0..<data.length() {
-    if self.offset == 64 {
-      chachaBlock(
-        self.key,
-        self.counter,
-        self.nonce,
-        self.round,
-        self.key_stream,
-      )
-      self.offset = 0
-      self.counter += 1
+  let length = data.length()
+  let mut input_offset = 0
+  if self.offset < 64 {
+    let prefix_length = @cmp.minimum(length, 64 - self.offset)
+    for i in 0..<prefix_length {
+      target[offset + i] = self.key_stream[self.offset + i] ^ data[i]
     }
-    target[offset + i] = (self.key_stream[self.offset / 4] >>
-      (self.offset % 4 * 8)).to_byte() ^
-      data[i]
-    self.offset += 1
+    self.offset += prefix_length
+    input_offset = prefix_length
+  }
+  if input_offset == length {
+    return
+  }
+  for ; chacha4_enabled() && input_offset + 256 <= length; {
+    chacha4BlockBytes(
+      self.key,
+      self.counter,
+      self.nonce,
+      self.round,
+      self.key_stream_words,
+      self.key_stream,
+      self.bulk_key_stream,
+    )
+    self.counter += 4
+    chacha_xor_into(
+      data,
+      input_offset,
+      target,
+      offset + input_offset,
+      self.bulk_key_stream,
+      0,
+      256,
+    )
+    input_offset += 256
+  }
+  for ; input_offset + 64 <= length; {
+    chachaBlockBytes(
+      self.key,
+      self.counter,
+      self.nonce,
+      self.round,
+      self.key_stream_words,
+      self.key_stream,
+    )
+    self.counter += 1
+    chacha_xor_into(
+      data,
+      input_offset,
+      target,
+      offset + input_offset,
+      self.key_stream,
+      0,
+      64,
+    )
+    input_offset += 64
+  }
+  if input_offset < length {
+    chachaBlockBytes(
+      self.key,
+      self.counter,
+      self.nonce,
+      self.round,
+      self.key_stream_words,
+      self.key_stream,
+    )
+    self.counter += 1
+    self.offset = length - input_offset
+    for i in input_offset..<length {
+      target[offset + i] = self.key_stream[i - input_offset] ^ data[i]
+    }
+  } else {
+    self.offset = 64
   }
 }

--- a/crypto/chacha_simd.mbt
+++ b/crypto/chacha_simd.mbt
@@ -1,0 +1,262 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#cfg(any(target="native", target="wasm"))
+#inline
+fn chacha4_enabled() -> Bool {
+  true
+}
+
+///|
+#cfg(not(any(target="native", target="wasm")))
+#inline
+fn chacha4_enabled() -> Bool {
+  false
+}
+
+///|
+#cfg(target="native")
+#inline
+fn chacha_quarter_round_v128(
+  a : V128,
+  b : V128,
+  c : V128,
+  d : V128,
+) -> (V128, V128, V128, V128) {
+  let a1 = @v128.i32x4_add(a, b)
+  let d_xor_a = @v128.v128_xor(d, a1)
+  let d1 = @v128.i8x16_shuffle(
+    d_xor_a, d_xor_a, 2, 3, 0, 1, 6, 7, 4, 5, 10, 11, 8, 9, 14, 15, 12, 13,
+  )
+  let c1 = @v128.i32x4_add(c, d1)
+  let b_xor_c = @v128.v128_xor(b, c1)
+  let b1 = @v128.v128_or_(
+    @v128.i32x4_shl(b_xor_c, 12),
+    @v128.i32x4_shr_u(b_xor_c, 20),
+  )
+  let a2 = @v128.i32x4_add(a1, b1)
+  let d_xor_a = @v128.v128_xor(d1, a2)
+  let d2 = @v128.i8x16_shuffle(
+    d_xor_a, d_xor_a, 3, 0, 1, 2, 7, 4, 5, 6, 11, 8, 9, 10, 15, 12, 13, 14,
+  )
+  let c2 = @v128.i32x4_add(c1, d2)
+  let b_xor_c = @v128.v128_xor(b1, c2)
+  let b2 = @v128.v128_or_(
+    @v128.i32x4_shl(b_xor_c, 7),
+    @v128.i32x4_shr_u(b_xor_c, 25),
+  )
+  (a2, b2, c2, d2)
+}
+
+///|
+#cfg(target="native")
+#inline
+fn store_chacha4_word_group(
+  output : FixedArray[Byte],
+  byte_offset : Int,
+  a : V128,
+  b : V128,
+  c : V128,
+  d : V128,
+) -> Unit {
+  let ab_lo = @v128.i8x16_shuffle(
+    a, b, 0, 1, 2, 3, 16, 17, 18, 19, 4, 5, 6, 7, 20, 21, 22, 23,
+  )
+  let ab_hi = @v128.i8x16_shuffle(
+    a, b, 8, 9, 10, 11, 24, 25, 26, 27, 12, 13, 14, 15, 28, 29, 30, 31,
+  )
+  let cd_lo = @v128.i8x16_shuffle(
+    c, d, 0, 1, 2, 3, 16, 17, 18, 19, 4, 5, 6, 7, 20, 21, 22, 23,
+  )
+  let cd_hi = @v128.i8x16_shuffle(
+    c, d, 8, 9, 10, 11, 24, 25, 26, 27, 12, 13, 14, 15, 28, 29, 30, 31,
+  )
+  @v128.v128_store(
+    output,
+    byte_offset,
+    @v128.i8x16_shuffle(
+      ab_lo, cd_lo, 0, 1, 2, 3, 4, 5, 6, 7, 16, 17, 18, 19, 20, 21, 22, 23,
+    ),
+  )
+  @v128.v128_store(
+    output,
+    byte_offset + 64,
+    @v128.i8x16_shuffle(
+      ab_lo, cd_lo, 8, 9, 10, 11, 12, 13, 14, 15, 24, 25, 26, 27, 28, 29, 30, 31,
+    ),
+  )
+  @v128.v128_store(
+    output,
+    byte_offset + 128,
+    @v128.i8x16_shuffle(
+      ab_hi, cd_hi, 0, 1, 2, 3, 4, 5, 6, 7, 16, 17, 18, 19, 20, 21, 22, 23,
+    ),
+  )
+  @v128.v128_store(
+    output,
+    byte_offset + 192,
+    @v128.i8x16_shuffle(
+      ab_hi, cd_hi, 8, 9, 10, 11, 12, 13, 14, 15, 24, 25, 26, 27, 28, 29, 30, 31,
+    ),
+  )
+}
+
+///|
+#cfg(target="native")
+fn chacha4BlockBytes(
+  key : FixedArray[UInt],
+  count : UInt,
+  nonce : FixedArray[UInt],
+  round : UInt,
+  _scratch_words : FixedArray[UInt],
+  _scratch_bytes : FixedArray[Byte],
+  output : FixedArray[Byte],
+) -> Unit {
+  guard key.length() == 8
+  guard nonce.length() == 3
+  guard output.length() >= 256
+  let initial0 = @v128.i32x4_splat(0X61707865)
+  let initial1 = @v128.i32x4_splat(0X3320646e)
+  let initial2 = @v128.i32x4_splat(0X79622d32)
+  let initial3 = @v128.i32x4_splat(0X6b206574)
+  let initial4 = @v128.i32x4_splat(key[0])
+  let initial5 = @v128.i32x4_splat(key[1])
+  let initial6 = @v128.i32x4_splat(key[2])
+  let initial7 = @v128.i32x4_splat(key[3])
+  let initial8 = @v128.i32x4_splat(key[4])
+  let initial9 = @v128.i32x4_splat(key[5])
+  let initial10 = @v128.i32x4_splat(key[6])
+  let initial11 = @v128.i32x4_splat(key[7])
+  let initial12 = @v128.i32x4_const(count, count + 1, count + 2, count + 3)
+  let initial13 = @v128.i32x4_splat(nonce[0])
+  let initial14 = @v128.i32x4_splat(nonce[1])
+  let initial15 = @v128.i32x4_splat(nonce[2])
+  let mut x0 = initial0
+  let mut x1 = initial1
+  let mut x2 = initial2
+  let mut x3 = initial3
+  let mut x4 = initial4
+  let mut x5 = initial5
+  let mut x6 = initial6
+  let mut x7 = initial7
+  let mut x8 = initial8
+  let mut x9 = initial9
+  let mut x10 = initial10
+  let mut x11 = initial11
+  let mut x12 = initial12
+  let mut x13 = initial13
+  let mut x14 = initial14
+  let mut x15 = initial15
+  for _ in 0U..<round {
+    {
+      let (a, b, c, d) = chacha_quarter_round_v128(x0, x4, x8, x12)
+      x0 = a
+      x4 = b
+      x8 = c
+      x12 = d
+    }
+    {
+      let (a, b, c, d) = chacha_quarter_round_v128(x1, x5, x9, x13)
+      x1 = a
+      x5 = b
+      x9 = c
+      x13 = d
+    }
+    {
+      let (a, b, c, d) = chacha_quarter_round_v128(x2, x6, x10, x14)
+      x2 = a
+      x6 = b
+      x10 = c
+      x14 = d
+    }
+    {
+      let (a, b, c, d) = chacha_quarter_round_v128(x3, x7, x11, x15)
+      x3 = a
+      x7 = b
+      x11 = c
+      x15 = d
+    }
+    {
+      let (a, b, c, d) = chacha_quarter_round_v128(x0, x5, x10, x15)
+      x0 = a
+      x5 = b
+      x10 = c
+      x15 = d
+    }
+    {
+      let (a, b, c, d) = chacha_quarter_round_v128(x1, x6, x11, x12)
+      x1 = a
+      x6 = b
+      x11 = c
+      x12 = d
+    }
+    {
+      let (a, b, c, d) = chacha_quarter_round_v128(x2, x7, x8, x13)
+      x2 = a
+      x7 = b
+      x8 = c
+      x13 = d
+    }
+    let (a, b, c, d) = chacha_quarter_round_v128(x3, x4, x9, x14)
+    x3 = a
+    x4 = b
+    x9 = c
+    x14 = d
+  }
+  x0 = @v128.i32x4_add(x0, initial0)
+  x1 = @v128.i32x4_add(x1, initial1)
+  x2 = @v128.i32x4_add(x2, initial2)
+  x3 = @v128.i32x4_add(x3, initial3)
+  x4 = @v128.i32x4_add(x4, initial4)
+  x5 = @v128.i32x4_add(x5, initial5)
+  x6 = @v128.i32x4_add(x6, initial6)
+  x7 = @v128.i32x4_add(x7, initial7)
+  x8 = @v128.i32x4_add(x8, initial8)
+  x9 = @v128.i32x4_add(x9, initial9)
+  x10 = @v128.i32x4_add(x10, initial10)
+  x11 = @v128.i32x4_add(x11, initial11)
+  x12 = @v128.i32x4_add(x12, initial12)
+  x13 = @v128.i32x4_add(x13, initial13)
+  x14 = @v128.i32x4_add(x14, initial14)
+  x15 = @v128.i32x4_add(x15, initial15)
+  store_chacha4_word_group(output, 0, x0, x1, x2, x3)
+  store_chacha4_word_group(output, 16, x4, x5, x6, x7)
+  store_chacha4_word_group(output, 32, x8, x9, x10, x11)
+  store_chacha4_word_group(output, 48, x12, x13, x14, x15)
+}
+
+///|
+#cfg(not(target="native"))
+fn chacha4BlockBytes(
+  key : FixedArray[UInt],
+  count : UInt,
+  nonce : FixedArray[UInt],
+  round : UInt,
+  scratch_words : FixedArray[UInt],
+  scratch_bytes : FixedArray[Byte],
+  output : FixedArray[Byte],
+) -> Unit {
+  for block in 0..<4 {
+    chachaBlockBytes(
+      key,
+      count + block.reinterpret_as_uint(),
+      nonce,
+      round,
+      scratch_words,
+      scratch_bytes,
+    )
+    scratch_bytes.blit_to(output, len=64, dst_offset=block * 64)
+  }
+}

--- a/crypto/chacha_test.mbt
+++ b/crypto/chacha_test.mbt
@@ -46,6 +46,35 @@ test "chacha stream encrypt RFC8439" {
 }
 
 ///|
+test "chacha bulk SIMD matches fragmented streaming" {
+  let key = Bytes::make(32, b'\x42')
+  let nonce = Bytes::make(12, b'\x24')
+  let input = FixedArray::makei(1031, i => (i * 29 + 7).to_byte()).unsafe_reinterpret_as_bytes()
+  let bulk_output = FixedArray::make(input.length(), b'\x00')
+  let bulk_cipher = @crypto.ChaCha::chacha20(key, nonce, counter=17)
+  bulk_cipher.transform(input, bulk_output)
+  let fragmented_output = FixedArray::make(input.length(), b'\x00')
+  let fragmented_cipher = @crypto.ChaCha::chacha20(key, nonce, counter=17)
+  let chunk_sizes = [1, 63, 7, 64, 65, 19, 127, 3]
+  let mut input_offset = 0
+  let mut chunk_index = 0
+  for ; input_offset < input.length(); {
+    let chunk_length = @cmp.minimum(
+      chunk_sizes[chunk_index % chunk_sizes.length()],
+      input.length() - input_offset,
+    )
+    fragmented_cipher.transform(
+      input[input_offset:input_offset + chunk_length],
+      fragmented_output,
+      offset=input_offset,
+    )
+    input_offset += chunk_length
+    chunk_index += 1
+  }
+  assert_eq(bulk_output, fragmented_output)
+}
+
+///|
 test "chacha with error" {
   @test.assert_raise(() => {
     @crypto.ChaCha::chacha8(b"", Bytes::make(12, b'\x00'))

--- a/crypto/crypto_bench_test.mbt
+++ b/crypto/crypto_bench_test.mbt
@@ -1,0 +1,66 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let crypto_bench_size : Int = 64 * 1024
+
+///|
+fn crypto_bench_input() -> FixedArray[Byte] {
+  FixedArray::makei(crypto_bench_size, i => (i & 0xff).to_byte())
+}
+
+///|
+test "bench SHA-256 64 KiB" (it : @bench.T) {
+  let input = crypto_bench_input()
+  it.bench(fn() { it.keep(@crypto.sha256(input)) })
+}
+
+///|
+test "bench SM3 64 KiB" (it : @bench.T) {
+  let input = crypto_bench_input()
+  it.bench(fn() { it.keep(@crypto.sm3(input)) })
+}
+
+///|
+test "bench SHA-1 64 KiB" (it : @bench.T) {
+  let input = crypto_bench_input()
+  it.bench(fn() { it.keep(@crypto.sha1(input)) })
+}
+
+///|
+test "bench MD5 64 KiB" (it : @bench.T) {
+  let input = crypto_bench_input()
+  it.bench(fn() { it.keep(@crypto.md5(input)) })
+}
+
+///|
+test "bench ChaCha20 64 KiB" (it : @bench.T) {
+  let key = FixedArray::make(32, b'\x00')
+  let nonce = FixedArray::make(12, b'\x00')
+  let input = crypto_bench_input()
+  let output = FixedArray::make(crypto_bench_size, b'\x00')
+  let cipher = @crypto.ChaCha::chacha20(key, nonce)
+  it.bench(fn() {
+    cipher.transform(input, output)
+    it.keep(output)
+  })
+}
+
+///|
+test "bench HMAC-SHA-256 empty message" (it : @bench.T) {
+  let hash = @crypto.SHA256::new()
+  let key = FixedArray::make(32, b'\x88').unsafe_reinterpret_as_bytes()
+  let message = b""
+  it.bench(fn() { it.keep(@crypto.hmac(hash, key, message)) })
+}

--- a/crypto/hmac.mbt
+++ b/crypto/hmac.mbt
@@ -40,9 +40,7 @@ pub fn[H : CryptoHasher] hmac(
     padded_key.blit_from_bytesview(0, key)
   }
   // calculate inner hash
-  for i = 0; i < block_size; i = i + 1 {
-    padded_key[i] = padded_key[i] ^ b'\x36'
-  }
+  xor_bytes_with_splat_in_place(padded_key, block_size, b'\x36')
   let inner_hash = FixedArray::make(hash.size(), b'\x00')
   hash
   ..reset()
@@ -50,9 +48,7 @@ pub fn[H : CryptoHasher] hmac(
   ..update(message)
   .finalize_into(inner_hash, offset=0)
   // calculate outer hash
-  for i = 0; i < block_size; i = i + 1 {
-    padded_key[i] = padded_key[i] ^ b'\x36' ^ b'\x5c'
-  }
+  xor_bytes_with_splat_in_place(padded_key, block_size, b'\x6a')
   let result = FixedArray::make(hash.size(), b'\x00')
   hash
   ..reset()

--- a/crypto/md5.mbt
+++ b/crypto/md5.mbt
@@ -87,8 +87,8 @@ pub fn MD5::new() -> MD5 {
 fn MD5::md5_compute(self : MD5) -> FixedArray[Byte] {
   let input = FixedArray::make(16, 0U)
   let idx = ((self.count[0] >> 3) & 0x3f).reinterpret_as_int()
-  input[14] = self.count[0]
-  input[15] = self.count[1]
+  let count_low = self.count[0]
+  let count_high = self.count[1]
   let bytes_slice = if idx < 56 {
     let bytes_slice = FixedArray::make(56 - idx + 1, Byte::default())
     padding.blit_to(bytes_slice, len=56 - idx + 1)
@@ -99,26 +99,12 @@ fn MD5::md5_compute(self : MD5) -> FixedArray[Byte] {
     bytes_slice
   }
   md5_update(self, bytes_slice)
-  let mut j = 0
-  for i = 0; i < 14; i = i + 1 {
-    input[i] = u8_to_u32le(self.buffer, i=j)
-    j += 4
-  }
+  load_u32x16_le_into(self.buffer, 0, input)
+  input[14] = count_low
+  input[15] = count_high
   md5_transform(self.state, input)
   let digest = FixedArray::make(16, Byte::default())
-  let mut j = 0
-  // u32 to u8
-  for i = 0; i < 4; i = i + 1 {
-    digest[j] = (self.state[i] & 0xff).reinterpret_as_int().to_byte()
-    digest[j + 1] = ((self.state[i] >> 8) & 0xff).reinterpret_as_int().to_byte()
-    digest[j + 2] = ((self.state[i] >> 16) & 0xff)
-      .reinterpret_as_int()
-      .to_byte()
-    digest[j + 3] = ((self.state[i] >> 24) & 0xff)
-      .reinterpret_as_int()
-      .to_byte()
-    j += 4
-  }
+  store_u32x4_le(self.state, 0, digest, 0)
   digest
 }
 
@@ -160,15 +146,19 @@ fn[Data : ByteSource] md5_update(ctx : MD5, data : Data) -> Unit {
     ctx.count[1] += 1
   }
   ctx.count[1] += length.reinterpret_as_uint() >> 29
-  for i = 0; i < length; i = i + 1 {
-    ctx.buffer[idx] = data[i]
-    idx += 1
+  let mut offset = 0
+  while offset < length {
+    let chunk_length = @cmp.minimum(64 - idx, length - offset)
+    data.blit_to(
+      ctx.buffer,
+      len=chunk_length,
+      src_offset=offset,
+      dst_offset=idx,
+    )
+    idx += chunk_length
+    offset += chunk_length
     if idx == 0x40 {
-      let mut j = 0
-      for k = 0; k < 16; k = k + 1 {
-        input[k] = u8_to_u32le(ctx.buffer, i=j)
-        j += 4
-      }
+      load_u32x16_le_into(ctx.buffer, 0, input)
       md5_transform(ctx.state, input)
       idx = 0
     }

--- a/crypto/moon.pkg
+++ b/crypto/moon.pkg
@@ -1,6 +1,9 @@
+warnings = "-alert_experimental"
+
 import {
   "moonbitlang/core/cmp",
   "moonbitlang/core/bench",
+  "moonbitlang/core/v128",
 }
 
 import {

--- a/crypto/sha1.mbt
+++ b/crypto/sha1.mbt
@@ -31,42 +31,61 @@ pub fn[Data : ByteSource] sha1(input : Data) -> FixedArray[Byte] {
   let h = [0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0]
   let bytes_per_chunk = 512 / 8
   let chunk_count = new_length / bytes_per_chunk // `new_length` is a multiple of 512
+  let words = FixedArray::make(80, 0)
   for chunk = 0; chunk < chunk_count; chunk = chunk + 1 {
-    let words = FixedArray::make(80, 0)
-    for i = 0; i < 16; i = i + 1 {
-      let slice_start = chunk * bytes_per_chunk + i * 4
-      words[i] = (bytes[slice_start].to_int() << 24) |
-        (bytes[slice_start + 1].to_int() << 16) |
-        (bytes[slice_start + 2].to_int() << 8) |
-        bytes[slice_start + 3].to_int()
-    }
+    load_i32x16_be_into(bytes, chunk * bytes_per_chunk, words)
     for i = 16; i < 80; i = i + 1 {
       words[i] = rotate_left(
         words[i - 3] ^ words[i - 8] ^ words[i - 14] ^ words[i - 16],
         1,
       )
     }
-    let v = h.copy()
-    for i = 0; i < 80; i = i + 1 {
-      let (f, k) = if i < 20 {
-        ((v[1] & v[2]) | (v[1].lnot() & v[3]), 0x5A827999)
-      } else if i < 40 {
-        (v[1] ^ (v[2] ^ v[3]), 0x6ED9EBA1)
-      } else if i < 60 {
-        ((v[1] & v[2]) | (v[1] & v[3]) | (v[2] & v[3]), 0x8F1BBCDC)
-      } else {
-        (v[1] ^ (v[2] ^ v[3]), 0xCA62C1D6)
-      }
-      let temp = rotate_left(v[0], 5) + f + v[4] + k + words[i]
-      v[4] = v[3]
-      v[3] = v[2]
-      v[2] = rotate_left(v[1], 30)
-      v[1] = v[0]
-      v[0] = temp
+    let mut a = h[0]
+    let mut b = h[1]
+    let mut c = h[2]
+    let mut d = h[3]
+    let mut e = h[4]
+    for i in 0..<20 {
+      let f = (b & c) | (b.lnot() & d)
+      let temp = rotate_left(a, 5) + f + e + 0x5A827999 + words[i]
+      e = d
+      d = c
+      c = rotate_left(b, 30)
+      b = a
+      a = temp
     }
-    for i = 0; i < 5; i = i + 1 {
-      h[i] += v[i]
+    for i in 20..<40 {
+      let f = b ^ c ^ d
+      let temp = rotate_left(a, 5) + f + e + 0x6ED9EBA1 + words[i]
+      e = d
+      d = c
+      c = rotate_left(b, 30)
+      b = a
+      a = temp
     }
+    for i in 40..<60 {
+      let f = (b & c) | (b & d) | (c & d)
+      let temp = rotate_left(a, 5) + f + e + 0x8F1BBCDC + words[i]
+      e = d
+      d = c
+      c = rotate_left(b, 30)
+      b = a
+      a = temp
+    }
+    for i in 60..<80 {
+      let f = b ^ c ^ d
+      let temp = rotate_left(a, 5) + f + e + 0xCA62C1D6 + words[i]
+      e = d
+      d = c
+      c = rotate_left(b, 30)
+      b = a
+      a = temp
+    }
+    h[0] += a
+    h[1] += b
+    h[2] += c
+    h[3] += d
+    h[4] += e
   }
   // Digest
   let result = FixedArray::make(20, b'\x00')

--- a/crypto/sha256.mbt
+++ b/crypto/sha256.mbt
@@ -49,7 +49,7 @@ let sha256_t : FixedArray[UInt] = [ // pre calculated
 
 ///|
 fn SHA256::transform(data : FixedArray[Byte], reg : FixedArray[UInt]) -> Unit {
-  let w = FixedArray::make(64, 0U)
+  let w = FixedArray::make(16, 0U)
   guard reg.length() == 8
   let mut a = reg.unsafe_get(0)
   let mut b = reg.unsafe_get(1)
@@ -59,23 +59,31 @@ fn SHA256::transform(data : FixedArray[Byte], reg : FixedArray[UInt]) -> Unit {
   let mut f = reg.unsafe_get(5)
   let mut g = reg.unsafe_get(6)
   let mut h = reg.unsafe_get(7)
-  for index = 0; index < 16; index = index + 1 {
-    w[index] = bytes_u8_to_u32be(data, i=4 * index)
-  }
-  for index = 16; index < 64; index = index + 1 {
-    let sigma_0 = rotate_right_u(w[index - 15], 7) ^
-      rotate_right_u(w[index - 15], 18) ^
-      (w[index - 15] >> 3)
-    let sigma_1 = rotate_right_u(w[index - 2], 17) ^
-      rotate_right_u(w[index - 2], 19) ^
-      (w[index - 2] >> 10)
-    w[index] = w[index - 16] + sigma_0 + w[index - 7] + sigma_1
-  }
+  load_u32x16_be_into(data, 0, w)
   for index = 0; index < 64; index = index + 1 {
+    let word = if index < 16 {
+      w.unsafe_get(index)
+    } else {
+      let sigma_0_source = w.unsafe_get((index + 1) & 15)
+      let sigma_0 = rotate_right_u(sigma_0_source, 7) ^
+        rotate_right_u(sigma_0_source, 18) ^
+        (sigma_0_source >> 3)
+      let sigma_1_source = w.unsafe_get((index + 14) & 15)
+      let sigma_1 = rotate_right_u(sigma_1_source, 17) ^
+        rotate_right_u(sigma_1_source, 19) ^
+        (sigma_1_source >> 10)
+      let slot = index & 15
+      let word = w.unsafe_get(slot) +
+        sigma_0 +
+        w.unsafe_get((index + 9) & 15) +
+        sigma_1
+      w.unsafe_set(slot, word)
+      word
+    }
     let big_sigma_1 = rotate_right_u(e, 6) ^
       rotate_right_u(e, 11) ^
       rotate_right_u(e, 25)
-    let t_1 = h + big_sigma_1 + SM3::gg_1(e, f, g) + sha256_t[index] + w[index]
+    let t_1 = h + big_sigma_1 + SM3::gg_1(e, f, g) + sha256_t[index] + word
     let big_sigma_0 = rotate_right_u(a, 2) ^
       rotate_right_u(a, 13) ^
       rotate_right_u(a, 22)

--- a/crypto/simd.mbt
+++ b/crypto/simd.mbt
@@ -1,0 +1,269 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#cfg(any(target="native", target="wasm"))
+#inline
+fn load_u32x16_be_into(
+  bytes : FixedArray[Byte],
+  byte_offset : Int,
+  words : FixedArray[UInt],
+) -> Unit {
+  for group in 0..<4 {
+    let value = @v128.v128_load(bytes, byte_offset + group * 16)
+    let value = @v128.i8x16_shuffle(
+      value, value, 3, 2, 1, 0, 7, 6, 5, 4, 11, 10, 9, 8, 15, 14, 13, 12,
+    )
+    let word_offset = group * 4
+    words.unsafe_set(word_offset, @v128.i32x4_extract_lane(value, 0))
+    words.unsafe_set(word_offset + 1, @v128.i32x4_extract_lane(value, 1))
+    words.unsafe_set(word_offset + 2, @v128.i32x4_extract_lane(value, 2))
+    words.unsafe_set(word_offset + 3, @v128.i32x4_extract_lane(value, 3))
+  }
+}
+
+///|
+#cfg(not(any(target="native", target="wasm")))
+#inline
+fn load_u32x16_be_into(
+  bytes : FixedArray[Byte],
+  byte_offset : Int,
+  words : FixedArray[UInt],
+) -> Unit {
+  for word_offset in 0..<16 {
+    let offset = byte_offset + word_offset * 4
+    words.unsafe_set(
+      word_offset,
+      (bytes.unsafe_get(offset).to_uint() << 24) |
+      (bytes.unsafe_get(offset + 1).to_uint() << 16) |
+      (bytes.unsafe_get(offset + 2).to_uint() << 8) |
+      bytes.unsafe_get(offset + 3).to_uint(),
+    )
+  }
+}
+
+///|
+#cfg(any(target="native", target="wasm"))
+#inline
+fn load_i32x16_be_into(
+  bytes : FixedArray[Byte],
+  byte_offset : Int,
+  words : FixedArray[Int],
+) -> Unit {
+  for group in 0..<4 {
+    let value = @v128.v128_load(bytes, byte_offset + group * 16)
+    let value = @v128.i8x16_shuffle(
+      value, value, 3, 2, 1, 0, 7, 6, 5, 4, 11, 10, 9, 8, 15, 14, 13, 12,
+    )
+    let word_offset = group * 4
+    words.unsafe_set(
+      word_offset,
+      @v128.i32x4_extract_lane(value, 0).reinterpret_as_int(),
+    )
+    words.unsafe_set(
+      word_offset + 1,
+      @v128.i32x4_extract_lane(value, 1).reinterpret_as_int(),
+    )
+    words.unsafe_set(
+      word_offset + 2,
+      @v128.i32x4_extract_lane(value, 2).reinterpret_as_int(),
+    )
+    words.unsafe_set(
+      word_offset + 3,
+      @v128.i32x4_extract_lane(value, 3).reinterpret_as_int(),
+    )
+  }
+}
+
+///|
+#cfg(not(any(target="native", target="wasm")))
+#inline
+fn load_i32x16_be_into(
+  bytes : FixedArray[Byte],
+  byte_offset : Int,
+  words : FixedArray[Int],
+) -> Unit {
+  for word_offset in 0..<16 {
+    let offset = byte_offset + word_offset * 4
+    words.unsafe_set(
+      word_offset,
+      (bytes.unsafe_get(offset).to_int() << 24) |
+      (bytes.unsafe_get(offset + 1).to_int() << 16) |
+      (bytes.unsafe_get(offset + 2).to_int() << 8) |
+      bytes.unsafe_get(offset + 3).to_int(),
+    )
+  }
+}
+
+///|
+#cfg(any(target="native", target="wasm"))
+#inline
+fn load_u32x16_le_into(
+  bytes : FixedArray[Byte],
+  byte_offset : Int,
+  words : FixedArray[UInt],
+) -> Unit {
+  for group in 0..<4 {
+    let value = @v128.v128_load(bytes, byte_offset + group * 16)
+    let word_offset = group * 4
+    words.unsafe_set(word_offset, @v128.i32x4_extract_lane(value, 0))
+    words.unsafe_set(word_offset + 1, @v128.i32x4_extract_lane(value, 1))
+    words.unsafe_set(word_offset + 2, @v128.i32x4_extract_lane(value, 2))
+    words.unsafe_set(word_offset + 3, @v128.i32x4_extract_lane(value, 3))
+  }
+}
+
+///|
+#cfg(not(any(target="native", target="wasm")))
+#inline
+fn load_u32x16_le_into(
+  bytes : FixedArray[Byte],
+  byte_offset : Int,
+  words : FixedArray[UInt],
+) -> Unit {
+  for word_offset in 0..<16 {
+    let offset = byte_offset + word_offset * 4
+    words.unsafe_set(
+      word_offset,
+      bytes.unsafe_get(offset).to_uint() |
+      (bytes.unsafe_get(offset + 1).to_uint() << 8) |
+      (bytes.unsafe_get(offset + 2).to_uint() << 16) |
+      (bytes.unsafe_get(offset + 3).to_uint() << 24),
+    )
+  }
+}
+
+///|
+#cfg(any(target="native", target="wasm"))
+#inline
+fn store_u32x4_le(
+  words : FixedArray[UInt],
+  word_offset : Int,
+  bytes : FixedArray[Byte],
+  byte_offset : Int,
+) -> Unit {
+  @v128.v128_store(
+    bytes,
+    byte_offset,
+    @v128.i32x4_const(
+      words.unsafe_get(word_offset),
+      words.unsafe_get(word_offset + 1),
+      words.unsafe_get(word_offset + 2),
+      words.unsafe_get(word_offset + 3),
+    ),
+  )
+}
+
+///|
+#cfg(not(any(target="native", target="wasm")))
+#inline
+fn store_u32x4_le(
+  words : FixedArray[UInt],
+  word_offset : Int,
+  bytes : FixedArray[Byte],
+  byte_offset : Int,
+) -> Unit {
+  for lane in 0..<4 {
+    let word = words.unsafe_get(word_offset + lane)
+    let offset = byte_offset + lane * 4
+    bytes.unsafe_set(offset, word.to_byte())
+    bytes.unsafe_set(offset + 1, (word >> 8).to_byte())
+    bytes.unsafe_set(offset + 2, (word >> 16).to_byte())
+    bytes.unsafe_set(offset + 3, (word >> 24).to_byte())
+  }
+}
+
+///|
+#cfg(any(target="native", target="wasm"))
+#inline
+fn xor_bytes_with_splat_in_place(
+  bytes : FixedArray[Byte],
+  length : Int,
+  mask : Byte,
+) -> Unit {
+  let simd_end = length / 16 * 16
+  let vector_mask = @v128.i8x16_splat(mask)
+  for offset = 0; offset < simd_end; offset = offset + 16 {
+    @v128.v128_store(
+      bytes,
+      offset,
+      @v128.v128_xor(@v128.v128_load(bytes, offset), vector_mask),
+    )
+  }
+  for offset = simd_end; offset < length; offset = offset + 1 {
+    bytes.unsafe_set(offset, bytes.unsafe_get(offset) ^ mask)
+  }
+}
+
+///|
+#cfg(any(target="native", target="wasm"))
+#inline
+fn xor_byte_ranges_in_place(
+  bytes : FixedArray[Byte],
+  byte_offset : Int,
+  mask : FixedArray[Byte],
+  mask_offset : Int,
+  length : Int,
+) -> Unit {
+  let simd_end = length / 16 * 16
+  for offset = 0; offset < simd_end; offset = offset + 16 {
+    @v128.v128_store(
+      bytes,
+      byte_offset + offset,
+      @v128.v128_xor(
+        @v128.v128_load(bytes, byte_offset + offset),
+        @v128.v128_load(mask, mask_offset + offset),
+      ),
+    )
+  }
+  for offset = simd_end; offset < length; offset = offset + 1 {
+    bytes.unsafe_set(
+      byte_offset + offset,
+      bytes.unsafe_get(byte_offset + offset) ^
+      mask.unsafe_get(mask_offset + offset),
+    )
+  }
+}
+
+///|
+#cfg(not(any(target="native", target="wasm", target="js")))
+#inline
+fn xor_byte_ranges_in_place(
+  bytes : FixedArray[Byte],
+  byte_offset : Int,
+  mask : FixedArray[Byte],
+  mask_offset : Int,
+  length : Int,
+) -> Unit {
+  for offset in 0..<length {
+    bytes.unsafe_set(
+      byte_offset + offset,
+      bytes.unsafe_get(byte_offset + offset) ^
+      mask.unsafe_get(mask_offset + offset),
+    )
+  }
+}
+
+///|
+#cfg(not(any(target="native", target="wasm")))
+#inline
+fn xor_bytes_with_splat_in_place(
+  bytes : FixedArray[Byte],
+  length : Int,
+  mask : Byte,
+) -> Unit {
+  for offset in 0..<length {
+    bytes.unsafe_set(offset, bytes.unsafe_get(offset) ^ mask)
+  }
+}

--- a/crypto/sm3.mbt
+++ b/crypto/sm3.mbt
@@ -20,6 +20,7 @@
 #alias(SM3Context, deprecated="Use `SM3` instead")
 struct SM3 {
   reg : FixedArray[UInt] // register A B C D E F G H. i.e. digest
+  schedule : FixedArray[UInt]
   mut len : UInt64
   buf : FixedArray[Byte]
   mut buf_index : Int
@@ -33,6 +34,7 @@ pub fn SM3::new() -> SM3 {
       0x7380166F, 0x4914B2B9, 0x172442D7, 0xDA8A0600, 0xA96F30BC, 0x163138AA, 0xE38DEE4D,
       0xB0FB0E4E,
     ],
+    schedule: FixedArray::make(68, 0U),
     len: 0,
     buf: FixedArray::make(64, 0),
     buf_index: 0,
@@ -94,9 +96,11 @@ fn SM3::p_1(x : UInt) -> UInt {
 }
 
 ///|
-fn SM3::transform(data : FixedArray[Byte], reg : FixedArray[UInt]) -> Unit {
-  let w_0 = FixedArray::make(68, 0U)
-  let w_1 = FixedArray::make(64, 0U)
+fn SM3::transform(
+  data : FixedArray[Byte],
+  reg : FixedArray[UInt],
+  w_0 : FixedArray[UInt],
+) -> Unit {
   guard reg.length() == 8
   let mut a = reg.unsafe_get(0)
   let mut b = reg.unsafe_get(1)
@@ -106,9 +110,7 @@ fn SM3::transform(data : FixedArray[Byte], reg : FixedArray[UInt]) -> Unit {
   let mut f = reg.unsafe_get(5)
   let mut g = reg.unsafe_get(6)
   let mut h = reg.unsafe_get(7)
-  for index = 0; index < 16; index = index + 1 {
-    w_0[index] = bytes_u8_to_u32be(data, i=4 * index)
-  }
+  load_u32x16_be_into(data, 0, w_0)
   for index = 16; index < 68; index = index + 1 {
     w_0[index] = SM3::p_1(
         w_0[index - 16] ^ w_0[index - 9] ^ rotate_left_u(w_0[index - 3], 15),
@@ -116,13 +118,10 @@ fn SM3::transform(data : FixedArray[Byte], reg : FixedArray[UInt]) -> Unit {
       rotate_left_u(w_0[index - 13], 7) ^
       w_0[index - 6]
   }
-  for index = 0; index < 64; index = index + 1 {
-    w_1[index] = w_0[index] ^ w_0[index + 4]
-  }
   for index = 0; index < 16; index = index + 1 {
     let ss_1 = rotate_left_u(rotate_left_u(a, 12) + e + t[index], 7)
     let ss_2 = ss_1 ^ rotate_left_u(a, 12)
-    let tt_1 = SM3::ff_0(a, b, c) + d + ss_2 + w_1[index]
+    let tt_1 = SM3::ff_0(a, b, c) + d + ss_2 + (w_0[index] ^ w_0[index + 4])
     let tt_2 = SM3::gg_0(e, f, g) + h + ss_1 + w_0[index]
     d = c
     c = rotate_left_u(b, 9)
@@ -136,7 +135,7 @@ fn SM3::transform(data : FixedArray[Byte], reg : FixedArray[UInt]) -> Unit {
   for index = 16; index < 64; index = index + 1 {
     let ss_1 = rotate_left_u(rotate_left_u(a, 12) + e + t[index], 7)
     let ss_2 = ss_1 ^ rotate_left_u(a, 12)
-    let tt_1 = SM3::ff_1(a, b, c) + d + ss_2 + w_1[index]
+    let tt_1 = SM3::ff_1(a, b, c) + d + ss_2 + (w_0[index] ^ w_0[index + 4])
     let tt_2 = SM3::gg_1(e, f, g) + h + ss_1 + w_0[index]
     d = c
     c = rotate_left_u(b, 9)
@@ -165,7 +164,7 @@ pub fn SM3::update_from_iter(self : SM3, data : Iter[Byte]) -> Unit {
     if self.buf_index == 64 {
       self.buf_index = 0
       self.len += 512UL
-      SM3::transform(self.buf, self.reg)
+      SM3::transform(self.buf, self.reg, self.schedule)
     }
   })
 }
@@ -195,7 +194,7 @@ pub fn[Data : ByteSource] SM3::update(self : SM3, data : Data) -> Unit {
     if self.buf_index == 64 {
       self.len += 512UL
       self.buf_index = 0
-      SM3::transform(self.buf, self.reg)
+      SM3::transform(self.buf, self.reg, self.schedule)
     }
     offset += min_len
   }
@@ -225,7 +224,7 @@ fn SM3::_finalize_into(
   data[cnt] = b'\x80'
   cnt += 1
   if cnt > 56 {
-    SM3::transform(data, reg)
+    SM3::transform(data, reg, self.schedule)
     data.fill(0)
   }
   data.unsafe_set(56, (len >> 56).to_byte())
@@ -236,7 +235,7 @@ fn SM3::_finalize_into(
   data.unsafe_set(61, (len >> 16).to_byte())
   data.unsafe_set(62, (len >> 8).to_byte())
   data.unsafe_set(63, (len >> 0).to_byte())
-  SM3::transform(data, reg)
+  SM3::transform(data, reg, self.schedule)
 
   // Write result to buffer
   arr_u32_to_u8be_into(reg.iter(), buffer, offset)

--- a/crypto/utils.mbt
+++ b/crypto/utils.mbt
@@ -65,49 +65,6 @@ test "uints_to_hex_string" {
 }
 
 ///|
-fn uint32(x : Byte) -> UInt {
-  x.to_int().reinterpret_as_uint()
-}
-
-///|
-/// convert 4 bytes a byte sequence to a UInt in little endian
-/// - `x` : A byte sequence consisting of 4 or more bytes
-/// - `i` : An offset. e.g. i = 4 will convert `x[4~7]` to a UInt.
-fn u8_to_u32le(x : FixedArray[Byte], i? : Int = 0) -> UInt {
-  uint32(x[i]) |
-  (uint32(x[i + 1]) << 8) |
-  (uint32(x[i + 2]) << 16) |
-  (uint32(x[i + 3]) << 24)
-}
-
-/// convert 4 bytes of a byte sequence to a UInt in big endian 
-/// - `x` : A byte sequence consisting of 4 or more bytes
-/// - `i` : An offset. e.g. i = 4 will convert `x[4~7]` to a UInt.
-
-// fn u8_to_u32be(x : Bytes, ~i : Int = 0) -> UInt {
-//   uint32(x[i]).lsl(24) | uint32(x[i + 1]).lsl(16) | uint32(x[i + 2]).lsl(8) | uint32(
-//     x[i + 3],
-//   )
-// }
-
-// fn arr_u8_to_u32be(x : Array[Byte], ~i : Int = 0) -> UInt {
-//   uint32(x[i]).lsl(24) | uint32(x[i + 1]).lsl(16) | uint32(x[i + 2]).lsl(8) | uint32(
-//     x[i + 3],
-//   )
-// }
-
-///|
-/// convert 4 bytes of a byte array to a UInt in big endian 
-/// - `x` : A byte sequence consisting of 4 or more bytes
-/// - `i` : An offset. e.g. i = 4 will convert `x[4~7]` to a UInt.
-fn bytes_u8_to_u32be(x : FixedArray[Byte], i? : Int = 0) -> UInt {
-  (uint32(x[i]) << 24) |
-  (uint32(x[i + 1]) << 16) |
-  (uint32(x[i + 2]) << 8) |
-  uint32(x[i + 3])
-}
-
-///|
 fn arr_u32_to_u8be_into(
   x : Iter[UInt],
   buffer : FixedArray[Byte],


### PR DESCRIPTION
## Summary

- add target-aware SIMD load, store, byte-shuffle, and XOR helpers using the hidden `moonbitlang/core/v128` APIs
- vectorize ChaCha rounds, add a native four-block SIMD kernel, and process bulk input in 64/256-byte chunks
- use rolling or reused hash schedules and block-level input handling to remove allocation and per-byte overhead around SHA-1, SHA-256, SM3, and MD5
- retain scalar or single-block fallbacks on backends where the SIMD variant benchmarked slower
- add repeatable 64 KiB crypto benchmarks and fragmented-streaming coverage for the ChaCha bulk path

## Performance

Local release benchmarks on 64 KiB inputs:

| Algorithm | Native | Wasm |
| --- | ---: | ---: |
| SHA-256 | 213.87 → 172.67 µs (-19.3%) | 635.99 → 229.98 µs (-63.8%) |
| SM3 | 287.01 → 213.71 µs (-25.5%) | 741.34 → 444.84 µs (-40.0%) |
| SHA-1 | 288.45 → 128.18 µs (-55.6%) | 909.07 → 338.77 µs (-62.7%) |
| MD5 | 128.45 → 81.18 µs (-36.8%) | 494.63 → 222.30 µs (-55.1%) |
| ChaCha20 | 195.15 → 112.99 µs (-42.1%) | 750.96 → 124.39 µs (-83.4%) |

The larger hash gains combine SIMD input packing with dependency-aware schedules and lower surrounding loop/allocation overhead. Consecutive blocks in a single hash stream remain inherently chained.

## Validation

- `moon check --target all --warn-list +73`
- `moon test --target all` — 526/526 passed on Wasm, Wasm-GC, JavaScript, and native
- `moon info` — public API unchanged
- `git diff --check`
