### PR TITLE
Optimize HMAC padding with SIMD

### DIFF
--- a/crypto/hmac.mbt
+++ b/crypto/hmac.mbt
@@ -40,9 +40,7 @@ pub fn[H : CryptoHasher] hmac(
     padded_key.blit_from_bytesview(0, key)
   }
   // calculate inner hash
-  for i = 0; i < block_size; i = i + 1 {
-    padded_key[i] = padded_key[i] ^ b'\x36'
-  }
+  xor_bytes_with_splat_in_place(padded_key, block_size, b'\x36')
   let inner_hash = FixedArray::make(hash.size(), b'\x00')
   hash
   ..reset()
@@ -50,9 +48,7 @@ pub fn[H : CryptoHasher] hmac(
   ..update(message)
   .finalize_into(inner_hash, offset=0)
   // calculate outer hash
-  for i = 0; i < block_size; i = i + 1 {
-    padded_key[i] = padded_key[i] ^ b'\x36' ^ b'\x5c'
-  }
+  xor_bytes_with_splat_in_place(padded_key, block_size, b'\x6a')
   let result = FixedArray::make(hash.size(), b'\x00')
   hash
   ..reset()

--- a/crypto/moon.pkg
+++ b/crypto/moon.pkg
@@ -1,6 +1,9 @@
+warnings = "-alert_experimental"
+
 import {
   "moonbitlang/core/cmp",
   "moonbitlang/core/bench",
+  "moonbitlang/core/v128",
 }
 
 import {

--- a/crypto/simd.mbt
+++ b/crypto/simd.mbt
@@ -1,0 +1,44 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#cfg(any(target="native", target="wasm"))
+fn xor_bytes_with_splat_in_place(
+  bytes : FixedArray[Byte],
+  length : Int,
+  mask : Byte,
+) -> Unit {
+  let simd_end = length / 16 * 16
+  let vector_mask = @v128.i8x16_splat(mask)
+  for offset = 0; offset < simd_end; offset = offset + 16 {
+    @v128.v128_load(bytes, offset)
+    |> @v128.v128_xor(vector_mask)
+    |> value => { @v128.v128_store(bytes, offset, value) }
+  }
+  for offset in simd_end..<length {
+    bytes.unsafe_set(offset, bytes.unsafe_get(offset) ^ mask)
+  }
+}
+
+///|
+#cfg(not(any(target="native", target="wasm")))
+fn xor_bytes_with_splat_in_place(
+  bytes : FixedArray[Byte],
+  length : Int,
+  mask : Byte,
+) -> Unit {
+  for offset in 0..<length {
+    bytes.unsafe_set(offset, bytes.unsafe_get(offset) ^ mask)
+  }
+}


### PR DESCRIPTION
## Summary

- XOR HMAC pads 16 bytes at a time with V128 on native and Wasm
- retain scalar fallbacks for other backends
- combine the second pad transition into one XOR with `0x6a`
- use a range loop for the scalar SIMD tail

## Why

HMAC repeatedly XORs a full hash block with constant byte masks. The operation is independent per byte and maps directly to SIMD without changing the public API or hash behavior.

## Performance

Local release benchmark for HMAC-SHA-256 with an empty message (the focused HMAC benchmark merged in #274):

| Target | Before | After | Change |
| --- | ---: | ---: | ---: |
| Native | 1.11 µs | 1.11 µs | neutral |
| Wasm | 3.99 µs | 3.83 µs | -4.0% |

I also tried enabling the V128 path on Wasm-GC. Repeated A/B runs measured 1.38–1.39 µs for the scalar path versus 1.45–1.55 µs for V128, so this PR leaves Wasm-GC on the scalar path. In the generated Wasm, loading and storing a V128 from a GC byte array packs and unpacks 16 scalar `array.get_u`/`array.set` operations; the single `v128.xor` does not offset that conversion cost.

## Stack

2 of 7. #274 is merged. Next: #276 (MD5).

## Validation

- `moon check --target all --warn-list +73`
- `moon test crypto --target all --release` — 31/31 passed on Wasm, Wasm-GC, JavaScript, and native
