### PR TITLE
Optimize SHA-256 block processing

### DIFF
--- a/crypto/sha256.mbt
+++ b/crypto/sha256.mbt
@@ -49,7 +49,7 @@ let sha256_t : FixedArray[UInt] = [ // pre calculated
 
 ///|
 fn SHA256::transform(data : FixedArray[Byte], reg : FixedArray[UInt]) -> Unit {
-  let w = FixedArray::make(64, 0U)
+  let w = FixedArray::make(16, 0U)
   guard reg.length() == 8
   let mut a = reg.unsafe_get(0)
   let mut b = reg.unsafe_get(1)
@@ -59,23 +59,31 @@ fn SHA256::transform(data : FixedArray[Byte], reg : FixedArray[UInt]) -> Unit {
   let mut f = reg.unsafe_get(5)
   let mut g = reg.unsafe_get(6)
   let mut h = reg.unsafe_get(7)
-  for index = 0; index < 16; index = index + 1 {
-    w[index] = bytes_u8_to_u32be(data, i=4 * index)
-  }
-  for index = 16; index < 64; index = index + 1 {
-    let sigma_0 = rotate_right_u(w[index - 15], 7) ^
-      rotate_right_u(w[index - 15], 18) ^
-      (w[index - 15] >> 3)
-    let sigma_1 = rotate_right_u(w[index - 2], 17) ^
-      rotate_right_u(w[index - 2], 19) ^
-      (w[index - 2] >> 10)
-    w[index] = w[index - 16] + sigma_0 + w[index - 7] + sigma_1
-  }
+  parse_be_u32_block_into(data, 0, w)
   for index = 0; index < 64; index = index + 1 {
+    let word = if index < 16 {
+      w.unsafe_get(index)
+    } else {
+      let sigma_0_source = w.unsafe_get((index + 1) & 15)
+      let sigma_0 = rotate_right_u(sigma_0_source, 7) ^
+        rotate_right_u(sigma_0_source, 18) ^
+        (sigma_0_source >> 3)
+      let sigma_1_source = w.unsafe_get((index + 14) & 15)
+      let sigma_1 = rotate_right_u(sigma_1_source, 17) ^
+        rotate_right_u(sigma_1_source, 19) ^
+        (sigma_1_source >> 10)
+      let slot = index & 15
+      let word = w.unsafe_get(slot) +
+        sigma_0 +
+        w.unsafe_get((index + 9) & 15) +
+        sigma_1
+      w.unsafe_set(slot, word)
+      word
+    }
     let big_sigma_1 = rotate_right_u(e, 6) ^
       rotate_right_u(e, 11) ^
       rotate_right_u(e, 25)
-    let t_1 = h + big_sigma_1 + SM3::gg_1(e, f, g) + sha256_t[index] + w[index]
+    let t_1 = h + big_sigma_1 + SM3::gg_1(e, f, g) + sha256_t[index] + word
     let big_sigma_0 = rotate_right_u(a, 2) ^
       rotate_right_u(a, 13) ^
       rotate_right_u(a, 22)

--- a/crypto/simd.mbt
+++ b/crypto/simd.mbt
@@ -14,6 +14,47 @@
 
 ///|
 #cfg(any(target="native", target="wasm"))
+#inline
+fn parse_be_u32_block_into(
+  bytes : FixedArray[Byte],
+  byte_offset : Int,
+  words : FixedArray[UInt],
+) -> Unit {
+  for group in 0..<4 {
+    let value = @v128.v128_load(bytes, byte_offset + group * 16)
+    let value = @v128.i8x16_shuffle(
+      value, value, 3, 2, 1, 0, 7, 6, 5, 4, 11, 10, 9, 8, 15, 14, 13, 12,
+    )
+    let word_offset = group * 4
+    words.unsafe_set(word_offset, @v128.i32x4_extract_lane(value, 0))
+    words.unsafe_set(word_offset + 1, @v128.i32x4_extract_lane(value, 1))
+    words.unsafe_set(word_offset + 2, @v128.i32x4_extract_lane(value, 2))
+    words.unsafe_set(word_offset + 3, @v128.i32x4_extract_lane(value, 3))
+  }
+}
+
+///|
+#cfg(not(any(target="native", target="wasm")))
+#inline
+fn parse_be_u32_block_into(
+  bytes : FixedArray[Byte],
+  byte_offset : Int,
+  words : FixedArray[UInt],
+) -> Unit {
+  for word_offset in 0..<16 {
+    let offset = byte_offset + word_offset * 4
+    words.unsafe_set(
+      word_offset,
+      (bytes.unsafe_get(offset).to_uint() << 24) |
+      (bytes.unsafe_get(offset + 1).to_uint() << 16) |
+      (bytes.unsafe_get(offset + 2).to_uint() << 8) |
+      bytes.unsafe_get(offset + 3).to_uint(),
+    )
+  }
+}
+
+///|
+#cfg(any(target="native", target="wasm"))
 fn xor_bytes_with_splat_in_place(
   bytes : FixedArray[Byte],
   length : Int,


### PR DESCRIPTION
## Summary

- load the first 16 SHA-256 words with V128 byte shuffles on native and Wasm
- retain a scalar big-endian loader for other backends
- replace the 64-word message schedule with a rolling 16-word schedule

## Why

SHA-256 blocks are sequentially chained, so consecutive blocks cannot be computed in parallel. This instead accelerates input packing and removes most schedule storage while keeping the compression rounds unchanged.

## Performance

Local release benchmark on 64 KiB:

| Target | Before | After | Change |
| --- | ---: | ---: | ---: |
| Native | 213.87 µs | 172.67 µs | -19.3% |
| Wasm | 635.99 µs | 229.98 µs | -63.8% |

## Stack

4 of 7. Depends on #276. Next: #278 (SM3).

## Validation

- `moon check --target all --warn-list +73`
- `moon test crypto/sha256_test.mbt --target all --release` — passed on Wasm, Wasm-GC, JavaScript, and native
