### PR TITLE
Optimize SM3 block processing

### DIFF
--- a/crypto/sm3.mbt
+++ b/crypto/sm3.mbt
@@ -94,9 +94,11 @@ fn SM3::p_1(x : UInt) -> UInt {
 }
 
 ///|
-fn SM3::transform(data : FixedArray[Byte], reg : FixedArray[UInt]) -> Unit {
-  let w_0 = FixedArray::make(68, 0U)
-  let w_1 = FixedArray::make(64, 0U)
+fn SM3::transform(
+  data : FixedArray[Byte],
+  reg : FixedArray[UInt],
+  schedule : FixedArray[UInt],
+) -> Unit {
   guard reg.length() == 8
   let mut a = reg.unsafe_get(0)
   let mut b = reg.unsafe_get(1)
@@ -106,24 +108,24 @@ fn SM3::transform(data : FixedArray[Byte], reg : FixedArray[UInt]) -> Unit {
   let mut f = reg.unsafe_get(5)
   let mut g = reg.unsafe_get(6)
   let mut h = reg.unsafe_get(7)
-  for index = 0; index < 16; index = index + 1 {
-    w_0[index] = bytes_u8_to_u32be(data, i=4 * index)
-  }
+  parse_be_u32_block_into(data, 0, schedule)
   for index = 16; index < 68; index = index + 1 {
-    w_0[index] = SM3::p_1(
-        w_0[index - 16] ^ w_0[index - 9] ^ rotate_left_u(w_0[index - 3], 15),
+    schedule[index] = SM3::p_1(
+        schedule[index - 16] ^
+        schedule[index - 9] ^
+        rotate_left_u(schedule[index - 3], 15),
       ) ^
-      rotate_left_u(w_0[index - 13], 7) ^
-      w_0[index - 6]
-  }
-  for index = 0; index < 64; index = index + 1 {
-    w_1[index] = w_0[index] ^ w_0[index + 4]
+      rotate_left_u(schedule[index - 13], 7) ^
+      schedule[index - 6]
   }
   for index = 0; index < 16; index = index + 1 {
     let ss_1 = rotate_left_u(rotate_left_u(a, 12) + e + t[index], 7)
     let ss_2 = ss_1 ^ rotate_left_u(a, 12)
-    let tt_1 = SM3::ff_0(a, b, c) + d + ss_2 + w_1[index]
-    let tt_2 = SM3::gg_0(e, f, g) + h + ss_1 + w_0[index]
+    let tt_1 = SM3::ff_0(a, b, c) +
+      d +
+      ss_2 +
+      (schedule[index] ^ schedule[index + 4])
+    let tt_2 = SM3::gg_0(e, f, g) + h + ss_1 + schedule[index]
     d = c
     c = rotate_left_u(b, 9)
     b = a
@@ -136,8 +138,11 @@ fn SM3::transform(data : FixedArray[Byte], reg : FixedArray[UInt]) -> Unit {
   for index = 16; index < 64; index = index + 1 {
     let ss_1 = rotate_left_u(rotate_left_u(a, 12) + e + t[index], 7)
     let ss_2 = ss_1 ^ rotate_left_u(a, 12)
-    let tt_1 = SM3::ff_1(a, b, c) + d + ss_2 + w_1[index]
-    let tt_2 = SM3::gg_1(e, f, g) + h + ss_1 + w_0[index]
+    let tt_1 = SM3::ff_1(a, b, c) +
+      d +
+      ss_2 +
+      (schedule[index] ^ schedule[index + 4])
+    let tt_2 = SM3::gg_1(e, f, g) + h + ss_1 + schedule[index]
     d = c
     c = rotate_left_u(b, 9)
     b = a
@@ -159,13 +164,22 @@ fn SM3::transform(data : FixedArray[Byte], reg : FixedArray[UInt]) -> Unit {
 
 ///|
 pub fn SM3::update_from_iter(self : SM3, data : Iter[Byte]) -> Unit {
+  let mut schedule : FixedArray[UInt]? = None
   data.each(fn(b) {
     self.buf[self.buf_index] = b
     self.buf_index += 1
     if self.buf_index == 64 {
       self.buf_index = 0
       self.len += 512UL
-      SM3::transform(self.buf, self.reg)
+      let block_schedule = match schedule {
+        Some(schedule) => schedule
+        None => {
+          let new_schedule = FixedArray::make(68, 0U)
+          schedule = Some(new_schedule)
+          new_schedule
+        }
+      }
+      SM3::transform(self.buf, self.reg, block_schedule)
     }
   })
 }
@@ -178,26 +192,38 @@ pub impl CryptoHasher for SM3 with fn update(self : SM3, data : BytesView) -> Un
 ///|
 /// update the state of given context from new `data` 
 pub fn[Data : ByteSource] SM3::update(self : SM3, data : Data) -> Unit {
-  let mut offset = 0
-  while offset < data.length() {
-    let min_len = if 64 - self.buf_index >= data.length() - offset {
-      data.length() - offset
-    } else {
-      64 - self.buf_index
-    }
+  let data_len = data.length()
+  if data_len < 64 - self.buf_index {
     data.blit_to(
       self.buf,
-      len=min_len,
-      src_offset=offset,
+      len=data_len,
+      src_offset=0,
       dst_offset=self.buf_index,
     )
-    self.buf_index += min_len
-    if self.buf_index == 64 {
-      self.len += 512UL
-      self.buf_index = 0
-      SM3::transform(self.buf, self.reg)
+    self.buf_index += data_len
+  } else {
+    let schedule = FixedArray::make(68, 0U)
+    let mut offset = 0
+    while offset < data_len {
+      let min_len = if 64 - self.buf_index >= data_len - offset {
+        data_len - offset
+      } else {
+        64 - self.buf_index
+      }
+      data.blit_to(
+        self.buf,
+        len=min_len,
+        src_offset=offset,
+        dst_offset=self.buf_index,
+      )
+      self.buf_index += min_len
+      if self.buf_index == 64 {
+        self.len += 512UL
+        self.buf_index = 0
+        SM3::transform(self.buf, self.reg, schedule)
+      }
+      offset += min_len
     }
-    offset += min_len
   }
 }
 
@@ -214,6 +240,7 @@ fn SM3::_finalize_into(
   buffer : FixedArray[Byte],
   offset? : Int = 0,
 ) -> Unit {
+  let schedule = FixedArray::make(68, 0U)
   // Copy data
   let data : FixedArray[Byte] = FixedArray::make(64, 0)
   let mut cnt = self.buf_index
@@ -225,7 +252,7 @@ fn SM3::_finalize_into(
   data[cnt] = b'\x80'
   cnt += 1
   if cnt > 56 {
-    SM3::transform(data, reg)
+    SM3::transform(data, reg, schedule)
     data.fill(0)
   }
   data.unsafe_set(56, (len >> 56).to_byte())
@@ -236,7 +263,7 @@ fn SM3::_finalize_into(
   data.unsafe_set(61, (len >> 16).to_byte())
   data.unsafe_set(62, (len >> 8).to_byte())
   data.unsafe_set(63, (len >> 0).to_byte())
-  SM3::transform(data, reg)
+  SM3::transform(data, reg, schedule)
 
   // Write result to buffer
   arr_u32_to_u8be_into(reg.iter(), buffer, offset)

--- a/crypto/utils.mbt
+++ b/crypto/utils.mbt
@@ -65,38 +65,6 @@ test "uints_to_hex_string" {
 }
 
 ///|
-fn uint32(x : Byte) -> UInt {
-  x.to_int().reinterpret_as_uint()
-}
-
-/// convert 4 bytes of a byte sequence to a UInt in big endian 
-/// - `x` : A byte sequence consisting of 4 or more bytes
-/// - `i` : An offset. e.g. i = 4 will convert `x[4~7]` to a UInt.
-
-// fn u8_to_u32be(x : Bytes, ~i : Int = 0) -> UInt {
-//   uint32(x[i]).lsl(24) | uint32(x[i + 1]).lsl(16) | uint32(x[i + 2]).lsl(8) | uint32(
-//     x[i + 3],
-//   )
-// }
-
-// fn arr_u8_to_u32be(x : Array[Byte], ~i : Int = 0) -> UInt {
-//   uint32(x[i]).lsl(24) | uint32(x[i + 1]).lsl(16) | uint32(x[i + 2]).lsl(8) | uint32(
-//     x[i + 3],
-//   )
-// }
-
-///|
-/// convert 4 bytes of a byte array to a UInt in big endian 
-/// - `x` : A byte sequence consisting of 4 or more bytes
-/// - `i` : An offset. e.g. i = 4 will convert `x[4~7]` to a UInt.
-fn bytes_u8_to_u32be(x : FixedArray[Byte], i? : Int = 0) -> UInt {
-  (uint32(x[i]) << 24) |
-  (uint32(x[i + 1]) << 16) |
-  (uint32(x[i + 2]) << 8) |
-  uint32(x[i + 3])
-}
-
-///|
 fn arr_u32_to_u8be_into(
   x : Iter[UInt],
   buffer : FixedArray[Byte],


### PR DESCRIPTION
## Summary

- allocate the 68-word SM3 schedule only when compression runs and reuse it across blocks within the same operation
- use the shared V128 big-endian block loader on native and Wasm
- compute derived schedule words on demand instead of allocating a second array
- remove scalar conversion helpers that are no longer referenced

## Why

SM3 blocks are chained, but their input packing and schedule bookkeeping can be made substantially cheaper without changing the compression function.

## Performance

Local release benchmark on 64 KiB:

| Target | Before | After | Change |
| --- | ---: | ---: | ---: |
| Native | 287.01 µs | 213.71 µs | -25.5% |
| Wasm | 741.34 µs | 444.84 µs | -40.0% |

## Stack

5 of 7. Depends on #277. Next: #279 (SHA-1).

## Validation

- `moon check --target all --warn-list +73`
- `moon test crypto/sm3_test.mbt --target all --release` — passed on Wasm, Wasm-GC, JavaScript, and native
