### PR TITLE
Optimize SHA-1 block processing

### DIFF
--- a/crypto/sha1.mbt
+++ b/crypto/sha1.mbt
@@ -28,53 +28,69 @@ pub fn[Data : ByteSource] sha1(input : Data) -> FixedArray[Byte] {
     bytes[i] = (bits >> (56 - (i - (new_length - 8)) * 8)).to_byte()
   }
   // Hash
-  let h = [0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0]
+  let h : FixedArray[UInt] = [
+    0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0,
+  ]
   let bytes_per_chunk = 512 / 8
   let chunk_count = new_length / bytes_per_chunk // `new_length` is a multiple of 512
+  let words = FixedArray::make(80, 0U)
   for chunk = 0; chunk < chunk_count; chunk = chunk + 1 {
-    let words = FixedArray::make(80, 0)
-    for i = 0; i < 16; i = i + 1 {
-      let slice_start = chunk * bytes_per_chunk + i * 4
-      words[i] = (bytes[slice_start].to_int() << 24) |
-        (bytes[slice_start + 1].to_int() << 16) |
-        (bytes[slice_start + 2].to_int() << 8) |
-        bytes[slice_start + 3].to_int()
-    }
+    parse_be_u32_block_into(bytes, chunk * bytes_per_chunk, words)
     for i = 16; i < 80; i = i + 1 {
-      words[i] = rotate_left(
+      words[i] = rotate_left_u(
         words[i - 3] ^ words[i - 8] ^ words[i - 14] ^ words[i - 16],
         1,
       )
     }
-    let v = h.copy()
-    for i = 0; i < 80; i = i + 1 {
-      let (f, k) = if i < 20 {
-        ((v[1] & v[2]) | (v[1].lnot() & v[3]), 0x5A827999)
-      } else if i < 40 {
-        (v[1] ^ (v[2] ^ v[3]), 0x6ED9EBA1)
-      } else if i < 60 {
-        ((v[1] & v[2]) | (v[1] & v[3]) | (v[2] & v[3]), 0x8F1BBCDC)
-      } else {
-        (v[1] ^ (v[2] ^ v[3]), 0xCA62C1D6)
-      }
-      let temp = rotate_left(v[0], 5) + f + v[4] + k + words[i]
-      v[4] = v[3]
-      v[3] = v[2]
-      v[2] = rotate_left(v[1], 30)
-      v[1] = v[0]
-      v[0] = temp
+    let mut a = h[0]
+    let mut b = h[1]
+    let mut c = h[2]
+    let mut d = h[3]
+    let mut e = h[4]
+    for i in 0..<20 {
+      let f = (b & c) | (b.lnot() & d)
+      let temp = rotate_left_u(a, 5) + f + e + 0x5A827999 + words[i]
+      e = d
+      d = c
+      c = rotate_left_u(b, 30)
+      b = a
+      a = temp
     }
-    for i = 0; i < 5; i = i + 1 {
-      h[i] += v[i]
+    for i in 20..<40 {
+      let f = b ^ c ^ d
+      let temp = rotate_left_u(a, 5) + f + e + 0x6ED9EBA1 + words[i]
+      e = d
+      d = c
+      c = rotate_left_u(b, 30)
+      b = a
+      a = temp
     }
+    for i in 40..<60 {
+      let f = (b & c) | (b & d) | (c & d)
+      let temp = rotate_left_u(a, 5) + f + e + 0x8F1BBCDC + words[i]
+      e = d
+      d = c
+      c = rotate_left_u(b, 30)
+      b = a
+      a = temp
+    }
+    for i in 60..<80 {
+      let f = b ^ c ^ d
+      let temp = rotate_left_u(a, 5) + f + e + 0xCA62C1D6 + words[i]
+      e = d
+      d = c
+      c = rotate_left_u(b, 30)
+      b = a
+      a = temp
+    }
+    h[0] += a
+    h[1] += b
+    h[2] += c
+    h[3] += d
+    h[4] += e
   }
   // Digest
   let result = FixedArray::make(20, b'\x00')
-  for i = 0; i < 5; i = i + 1 {
-    result[i * 4 + 0] = (h[i].reinterpret_as_uint() >> 24).to_byte()
-    result[i * 4 + 1] = (h[i].reinterpret_as_uint() >> 16).to_byte()
-    result[i * 4 + 2] = (h[i].reinterpret_as_uint() >> 8).to_byte()
-    result[i * 4 + 3] = h[i].to_byte()
-  }
+  arr_u32_to_u8be_into(h.iter(), result, 0)
   result
 }

--- a/crypto/utils.mbt
+++ b/crypto/utils.mbt
@@ -81,12 +81,6 @@ fn arr_u32_to_u8be_into(
 }
 
 ///|
-/// rotate a Int `x` left by `n` bit(s)
-fn rotate_left(x : Int, n : Int) -> Int {
-  (x << n) | (x.reinterpret_as_uint() >> (32 - n)).reinterpret_as_int()
-}
-
-///|
 /// rotate a UInt `x` left by `n` bit(s)
 fn rotate_left_u(x : UInt, n : Int) -> UInt {
   (x << n) | (x >> (32 - n))


### PR DESCRIPTION
## Summary

- parse SHA-1 input through the shared V128 big-endian UInt path on native and Wasm
- reuse the 80-word message schedule across chunks
- keep compression state in scalar locals instead of copying an array
- split the 80 rounds into their four fixed phases, removing the per-round phase branch

## Why

The hash chain remains sequential. The gains come from faster input packing and lower allocation, indexing, and branch overhead inside each block.

## Performance

Local release benchmark on 64 KiB:

| Target | Before | After | Change |
| --- | ---: | ---: | ---: |
| Native | 288.45 µs | 128.18 µs | -55.6% |
| Wasm | 909.07 µs | 338.77 µs | -62.7% |

## Stack

6 of 7. Depends on #278. Next: #280 (ChaCha).

## Validation

- `moon check --target all --warn-list +73`
- `moon test crypto/sha1_test.mbt --target all --release` — passed on Wasm, Wasm-GC, JavaScript, and native
