### PR TITLE
Fix Windows Unicode handling in native FFI

### DIFF
--- a/fs/fs_native.c
+++ b/fs/fs_native.c
@@ -20,6 +20,7 @@ extern "C" {
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <wchar.h>
 
 #ifdef _WIN32
 #include <direct.h>
@@ -31,9 +32,20 @@ extern "C" {
 
 #include "moonbit.h"
 
-MOONBIT_FFI_EXPORT FILE *moonbitlang_x_fs_fopen_ffi(moonbit_bytes_t path,
-                                                    moonbit_bytes_t mode) {
+#ifdef _WIN32
+typedef moonbit_string_t moonbitlang_x_os_string_t;
+#else
+typedef moonbit_bytes_t moonbitlang_x_os_string_t;
+#endif
+
+MOONBIT_FFI_EXPORT FILE *
+moonbitlang_x_fs_fopen_ffi(moonbitlang_x_os_string_t path,
+                           moonbitlang_x_os_string_t mode) {
+#ifdef _WIN32
+  return _wfopen((const wchar_t *)path, (const wchar_t *)mode);
+#else
   return fopen((const char *)path, (const char *)mode);
+#endif
 }
 
 MOONBIT_FFI_EXPORT int moonbitlang_x_fs_is_null(void *ptr) {
@@ -77,15 +89,21 @@ MOONBIT_FFI_EXPORT moonbit_bytes_t moonbitlang_x_fs_get_error_message(void) {
   return bytes;
 }
 
-MOONBIT_FFI_EXPORT int moonbitlang_x_fs_stat_ffi(moonbit_bytes_t path) {
+MOONBIT_FFI_EXPORT int
+moonbitlang_x_fs_stat_ffi(moonbitlang_x_os_string_t path) {
+#ifdef _WIN32
+  return GetFileAttributesW((LPCWSTR)path) == INVALID_FILE_ATTRIBUTES ? -1 : 0;
+#else
   struct stat buffer;
   int status = stat((const char *)path, &buffer);
   return status;
+#endif
 }
 
-MOONBIT_FFI_EXPORT int moonbitlang_x_fs_is_dir_ffi(moonbit_bytes_t path) {
+MOONBIT_FFI_EXPORT int
+moonbitlang_x_fs_is_dir_ffi(moonbitlang_x_os_string_t path) {
 #ifdef _WIN32
-  DWORD attrs = GetFileAttributes((const char *)path);
+  DWORD attrs = GetFileAttributesW((LPCWSTR)path);
   if (attrs == INVALID_FILE_ATTRIBUTES) {
     return -1;
   }
@@ -106,9 +124,10 @@ MOONBIT_FFI_EXPORT int moonbitlang_x_fs_is_dir_ffi(moonbit_bytes_t path) {
 #endif
 }
 
-MOONBIT_FFI_EXPORT int moonbitlang_x_fs_is_file_ffi(moonbit_bytes_t path) {
+MOONBIT_FFI_EXPORT int
+moonbitlang_x_fs_is_file_ffi(moonbitlang_x_os_string_t path) {
 #ifdef _WIN32
-  DWORD attrs = GetFileAttributes((const char *)path);
+  DWORD attrs = GetFileAttributesW((LPCWSTR)path);
   if (attrs == INVALID_FILE_ATTRIBUTES) {
     return -1;
   }
@@ -129,42 +148,52 @@ MOONBIT_FFI_EXPORT int moonbitlang_x_fs_is_file_ffi(moonbit_bytes_t path) {
 #endif
 }
 
-MOONBIT_FFI_EXPORT int moonbitlang_x_fs_remove_dir_ffi(moonbit_bytes_t path) {
+MOONBIT_FFI_EXPORT int
+moonbitlang_x_fs_remove_dir_ffi(moonbitlang_x_os_string_t path) {
 #ifdef _WIN32
-  return _rmdir((const char *)path);
+  return _wrmdir((const wchar_t *)path);
 #else
   return rmdir((const char *)path);
 #endif
 }
 
-MOONBIT_FFI_EXPORT int moonbitlang_x_fs_remove_file_ffi(moonbit_bytes_t path) {
+MOONBIT_FFI_EXPORT int
+moonbitlang_x_fs_remove_file_ffi(moonbitlang_x_os_string_t path) {
+#ifdef _WIN32
+  return _wremove((const wchar_t *)path);
+#else
   return remove((const char *)path);
+#endif
 }
 
-MOONBIT_FFI_EXPORT int moonbitlang_x_fs_create_dir_ffi(moonbit_bytes_t path) {
+MOONBIT_FFI_EXPORT int
+moonbitlang_x_fs_create_dir_ffi(moonbitlang_x_os_string_t path) {
 #ifdef _WIN32
-  return _mkdir((const char *)path);
+  return _wmkdir((const wchar_t *)path);
 #else
   return mkdir((const char *)path, 0777);
 #endif
 }
 
-MOONBIT_FFI_EXPORT moonbit_bytes_t *
-moonbitlang_x_fs_read_dir_ffi(moonbit_bytes_t path) {
+MOONBIT_FFI_EXPORT moonbitlang_x_os_string_t *
+moonbitlang_x_fs_read_dir_ffi(moonbitlang_x_os_string_t path) {
 #ifdef _WIN32
-  WIN32_FIND_DATA find_data;
+  WIN32_FIND_DATAW find_data;
   HANDLE dir;
-  moonbit_bytes_t *result = NULL;
+  moonbit_string_t *result = NULL;
   int count = 0;
 
-  size_t path_len = strlen((const char *)path);
-  char *search_path = malloc(path_len + 3);
+  size_t path_len = wcslen((const wchar_t *)path);
+  WCHAR *search_path = malloc((path_len + 3) * sizeof(WCHAR));
   if (search_path == NULL) {
     return NULL;
   }
 
-  sprintf(search_path, "%s\\*", (const char *)path);
-  dir = FindFirstFile(search_path, &find_data);
+  memcpy(search_path, path, path_len * sizeof(WCHAR));
+  search_path[path_len] = L'\\';
+  search_path[path_len + 1] = L'*';
+  search_path[path_len + 2] = L'\0';
+  dir = FindFirstFileW(search_path, &find_data);
   if (dir == INVALID_HANDLE_VALUE) {
     DWORD error = GetLastError();
     fprintf(stderr, "Failed to open directory: error code %lu\n", error);
@@ -173,17 +202,17 @@ moonbitlang_x_fs_read_dir_ffi(moonbit_bytes_t path) {
   }
 
   do {
-    if (strcmp(find_data.cFileName, ".") != 0 &&
-        strcmp(find_data.cFileName, "..") != 0) {
+    if (wcscmp(find_data.cFileName, L".") != 0 &&
+        wcscmp(find_data.cFileName, L"..") != 0) {
       count++;
     }
-  } while (FindNextFile(dir, &find_data));
+  } while (FindNextFileW(dir, &find_data));
 
   FindClose(dir);
-  dir = FindFirstFile(search_path, &find_data);
+  dir = FindFirstFileW(search_path, &find_data);
   free(search_path);
 
-  result = (moonbit_bytes_t *)moonbit_make_ref_array(count, NULL);
+  result = (moonbit_string_t *)moonbit_make_ref_array(count, NULL);
   if (result == NULL) {
     FindClose(dir);
     return NULL;
@@ -191,14 +220,14 @@ moonbitlang_x_fs_read_dir_ffi(moonbit_bytes_t path) {
 
   int index = 0;
   do {
-    if (strcmp(find_data.cFileName, ".") != 0 &&
-        strcmp(find_data.cFileName, "..") != 0) {
-      size_t name_len = strlen(find_data.cFileName);
-      moonbit_bytes_t item = moonbit_make_bytes(name_len, 0);
-      memcpy(item, find_data.cFileName, name_len);
+    if (wcscmp(find_data.cFileName, L".") != 0 &&
+        wcscmp(find_data.cFileName, L"..") != 0) {
+      size_t name_len = wcslen(find_data.cFileName);
+      moonbit_string_t item = moonbit_make_string(name_len, 0);
+      memcpy(item, find_data.cFileName, name_len * sizeof(WCHAR));
       result[index++] = item;
     }
-  } while (FindNextFile(dir, &find_data));
+  } while (FindNextFileW(dir, &find_data));
 
   FindClose(dir);
   return result;

--- a/fs/fs_native.mbt
+++ b/fs/fs_native.mbt
@@ -17,8 +17,40 @@
 priv type Handler
 
 ///|
+#cfg(platform="windows")
+priv struct OsString(String)
+
+///|
+#cfg(not(platform="windows"))
+priv struct OsString(Bytes)
+
+///|
+#cfg(platform="windows")
+fn OsString::from_string(str : String) -> OsString {
+  OsString(str)
+}
+
+///|
+#cfg(not(platform="windows"))
+fn OsString::from_string(str : String) -> OsString {
+  OsString(@ffi.mbt_string_to_utf8_bytes(str, true))
+}
+
+///|
+#cfg(platform="windows")
+fn OsString::to_string(self : OsString) -> String {
+  self.0
+}
+
+///|
+#cfg(not(platform="windows"))
+fn OsString::to_string(self : OsString) -> String {
+  @ffi.utf8_bytes_to_mbt_string(self.0)
+}
+
+///|
 #borrow(path, mode)
-extern "C" fn fopen_ffi(path : Bytes, mode : Bytes) -> Handler = "moonbitlang_x_fs_fopen_ffi"
+extern "C" fn fopen_ffi(path : OsString, mode : OsString) -> Handler = "moonbitlang_x_fs_fopen_ffi"
 
 ///|
 extern "C" fn is_null(ptr : Handler) -> Int = "moonbitlang_x_fs_is_null"
@@ -63,7 +95,7 @@ fn get_error_message() -> String {
 
 ///|
 fn read_file_to_bytes_internal(path : String) -> Bytes raise IOError {
-  let file = fopen_ffi(@ffi.mbt_string_to_utf8_bytes(path, true), b"rb\x00")
+  let file = fopen_ffi(OsString::from_string(path), OsString::from_string("rb"))
   guard is_null(file) == 0 else { raise IOError(get_error_message()) }
   guard fseek_ffi(file, 0, 2) == 0 else { raise IOError(get_error_message()) }
   let size = ftell_ffi(file)
@@ -94,7 +126,7 @@ fn write_bytes_to_file_internal(
   path : String,
   content : Bytes,
 ) -> Unit raise IOError {
-  let file = fopen_ffi(@ffi.mbt_string_to_utf8_bytes(path, true), b"wb\x00")
+  let file = fopen_ffi(OsString::from_string(path), OsString::from_string("wb"))
   guard is_null(file) == 0 else { raise IOError(get_error_message()) }
   let bytes_written = fwrite_ffi(content, 1, content.length(), file)
   guard bytes_written == content.length() else {
@@ -121,79 +153,79 @@ fn write_string_to_file_internal(
 
 ///|
 #borrow(path)
-extern "C" fn stat_ffi(path : Bytes) -> Int = "moonbitlang_x_fs_stat_ffi"
+extern "C" fn stat_ffi(path : OsString) -> Int = "moonbitlang_x_fs_stat_ffi"
 
 ///|
 fn path_exists_internal(path : String) -> Bool {
-  stat_ffi(@ffi.mbt_string_to_utf8_bytes(path, true)) != -1
+  stat_ffi(OsString::from_string(path)) != -1
 }
 
 ///|
 #borrow(path)
-extern "C" fn read_dir_ffi(path : Bytes) -> Handler = "moonbitlang_x_fs_read_dir_ffi"
+extern "C" fn read_dir_ffi(path : OsString) -> Handler = "moonbitlang_x_fs_read_dir_ffi"
 
 ///|
-fn handler_to_fixed_array(handler : Handler) -> FixedArray[Bytes] = "%identity"
+fn handler_to_fixed_array(handler : Handler) -> FixedArray[OsString] = "%identity"
 
 ///|
 fn read_dir_internal(path : String) -> Array[String] raise IOError {
-  let res = read_dir_ffi(@ffi.mbt_string_to_utf8_bytes(path, true))
+  let res = read_dir_ffi(OsString::from_string(path))
   guard is_null(res) == 0 else { raise IOError(get_error_message()) }
   let files = Array::from_fixed_array(handler_to_fixed_array(res))
-  files.map(@ffi.utf8_bytes_to_mbt_string)
+  files.map(OsString::to_string)
 }
 
 ///|
 #borrow(path)
-extern "C" fn create_dir_ffi(path : Bytes) -> Int = "moonbitlang_x_fs_create_dir_ffi"
+extern "C" fn create_dir_ffi(path : OsString) -> Int = "moonbitlang_x_fs_create_dir_ffi"
 
 ///|
 fn create_dir_internal(path : String) -> Unit raise IOError {
-  guard create_dir_ffi(@ffi.mbt_string_to_utf8_bytes(path, true)) == 0 else {
+  guard create_dir_ffi(OsString::from_string(path)) == 0 else {
     raise IOError(get_error_message())
   }
 }
 
 ///|
 #borrow(path)
-extern "C" fn is_dir_ffi(path : Bytes) -> Int = "moonbitlang_x_fs_is_dir_ffi"
+extern "C" fn is_dir_ffi(path : OsString) -> Int = "moonbitlang_x_fs_is_dir_ffi"
 
 ///|
 fn is_dir_internal(path : String) -> Bool raise IOError {
-  let res = is_dir_ffi(@ffi.mbt_string_to_utf8_bytes(path, true))
+  let res = is_dir_ffi(OsString::from_string(path))
   guard res != -1 else { raise IOError(get_error_message()) }
   res == 1
 }
 
 ///|
 #borrow(path)
-extern "C" fn is_file_ffi(path : Bytes) -> Int = "moonbitlang_x_fs_is_file_ffi"
+extern "C" fn is_file_ffi(path : OsString) -> Int = "moonbitlang_x_fs_is_file_ffi"
 
 ///|
 fn is_file_internal(path : String) -> Bool raise IOError {
-  let res = is_file_ffi(@ffi.mbt_string_to_utf8_bytes(path, true))
+  let res = is_file_ffi(OsString::from_string(path))
   guard res != -1 else { raise IOError(get_error_message()) }
   res == 1
 }
 
 ///|
 #borrow(path)
-extern "C" fn remove_dir_ffi(path : Bytes) -> Int = "moonbitlang_x_fs_remove_dir_ffi"
+extern "C" fn remove_dir_ffi(path : OsString) -> Int = "moonbitlang_x_fs_remove_dir_ffi"
 
 ///|
 fn remove_dir_internal(path : String) -> Unit raise IOError {
-  guard remove_dir_ffi(@ffi.mbt_string_to_utf8_bytes(path, true)) == 0 else {
+  guard remove_dir_ffi(OsString::from_string(path)) == 0 else {
     raise IOError(get_error_message())
   }
 }
 
 ///|
 #borrow(path)
-extern "C" fn remove_file_ffi(path : Bytes) -> Int = "moonbitlang_x_fs_remove_file_ffi"
+extern "C" fn remove_file_ffi(path : OsString) -> Int = "moonbitlang_x_fs_remove_file_ffi"
 
 ///|
 fn remove_file_internal(path : String) -> Unit raise IOError {
-  guard remove_file_ffi(@ffi.mbt_string_to_utf8_bytes(path, true)) == 0 else {
+  guard remove_file_ffi(OsString::from_string(path)) == 0 else {
     raise IOError(get_error_message())
   }
 }

--- a/sys/internal/ffi/native_stub.c
+++ b/sys/internal/ffi/native_stub.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <wchar.h>
 #include "moonbit.h"
 
 #ifdef _WIN32
@@ -12,14 +13,21 @@
 #include <unistd.h>
 #endif
 
-MOONBIT_FFI_EXPORT moonbit_bytes_t get_env_var(moonbit_bytes_t key) {
 #ifdef _WIN32
-    DWORD buf_size = GetEnvironmentVariable((LPSTR)key, NULL, 0);
+typedef moonbit_string_t moonbitlang_x_os_string_t;
+#else
+typedef moonbit_bytes_t moonbitlang_x_os_string_t;
+#endif
+
+MOONBIT_FFI_EXPORT moonbitlang_x_os_string_t
+get_env_var(moonbitlang_x_os_string_t key) {
+#ifdef _WIN32
+    DWORD buf_size = GetEnvironmentVariableW((LPCWSTR)key, NULL, 0);
     if (buf_size == 0) {
-        return moonbit_make_bytes(0, 0); // Return empty bytes to indicate None
+        return moonbit_make_string(0, 0);
     }
-    moonbit_bytes_t result = moonbit_make_bytes(buf_size - 1, 0);
-    GetEnvironmentVariable((LPSTR)key, (LPSTR)result, buf_size);
+    moonbit_string_t result = moonbit_make_string(buf_size - 1, 0);
+    GetEnvironmentVariableW((LPCWSTR)key, (LPWSTR)result, buf_size);
     return result;
 #else
     char* value = getenv((const char*)key);
@@ -33,57 +41,62 @@ MOONBIT_FFI_EXPORT moonbit_bytes_t get_env_var(moonbit_bytes_t key) {
 #endif
 }
 
-MOONBIT_FFI_EXPORT int32_t get_env_var_exists(moonbit_bytes_t key) {
+MOONBIT_FFI_EXPORT int32_t
+get_env_var_exists(moonbitlang_x_os_string_t key) {
 #ifdef _WIN32
-    DWORD buf_size = GetEnvironmentVariable((LPSTR)key, NULL, 0);
-    return buf_size != 0; // Variable exists
+    SetLastError(ERROR_SUCCESS);
+    DWORD buf_size = GetEnvironmentVariableW((LPCWSTR)key, NULL, 0);
+    return buf_size != 0 || GetLastError() != ERROR_ENVVAR_NOT_FOUND;
 #else
     char* value = getenv((const char*)key);
     return value != NULL; // Variable exists
 #endif
 }
 
-MOONBIT_FFI_EXPORT moonbit_bytes_t* get_env_vars() {
+MOONBIT_FFI_EXPORT moonbitlang_x_os_string_t* get_env_vars() {
 #ifdef _WIN32
     // Get environment block
-    LPCH env_block = GetEnvironmentStrings();
+    LPWCH env_block = GetEnvironmentStringsW();
     if (env_block == NULL) {
-        return (moonbit_bytes_t *)moonbit_make_ref_array(0, NULL);
+        return (moonbit_string_t *)moonbit_make_ref_array(0, NULL);
     }
 
     // Count variables and create array
     int count = 0;
-    LPCH env = env_block;
+    LPWCH env = env_block;
     while (*env) {
-        count++;
-        env += strlen(env) + 1;
+        WCHAR *equals = wcschr(env, L'=');
+        if (env[0] != L'=' && equals != NULL && equals != env) {
+            count++;
+        }
+        env += wcslen(env) + 1;
     }
 
-    moonbit_bytes_t* result = (moonbit_bytes_t*)moonbit_make_ref_array(count * 2, NULL);
+    moonbit_string_t* result = (moonbit_string_t*)moonbit_make_ref_array(count * 2, NULL);
     
     // Parse variables
     env = env_block;
     int i = 0;
     while (*env) {
-        char *equals = strchr(env, '=');
-        if (equals != NULL) {
+        WCHAR *equals = wcschr(env, L'=');
+        if (env[0] != L'=' && equals != NULL && equals != env) {
             size_t key_len = equals - env;
-            size_t val_len = strlen(equals + 1);
+            size_t val_len = wcslen(equals + 1);
             
-            moonbit_bytes_t key = moonbit_make_bytes(key_len, 0);
-            memcpy(key, env, key_len);
+            moonbit_string_t key = moonbit_make_string(key_len, 0);
+            memcpy(key, env, key_len * sizeof(WCHAR));
             
-            moonbit_bytes_t value = moonbit_make_bytes(val_len, 0);
-            memcpy(value, equals + 1, val_len);
+            moonbit_string_t value = moonbit_make_string(val_len, 0);
+            memcpy(value, equals + 1, val_len * sizeof(WCHAR));
 
             result[i * 2] = key;
             result[i * 2 + 1] = value;
+            i++;
         }
-        env += strlen(env) + 1;
-        i++;
+        env += wcslen(env) + 1;
     }
 
-    FreeEnvironmentStrings(env_block);
+    FreeEnvironmentStringsW(env_block);
     return result;
 #else
     // environ is a pointer to an array of environment variables
@@ -129,17 +142,18 @@ MOONBIT_FFI_EXPORT moonbit_bytes_t* get_env_vars() {
 #endif
 }
 
-MOONBIT_FFI_EXPORT void set_env_var(moonbit_bytes_t key, moonbit_bytes_t value) {
+MOONBIT_FFI_EXPORT void set_env_var(moonbitlang_x_os_string_t key,
+                                    moonbitlang_x_os_string_t value) {
 #ifdef _WIN32
-    SetEnvironmentVariable(key, value);
+    SetEnvironmentVariableW((LPCWSTR)key, (LPCWSTR)value);
 #else
     setenv((const char*)key, (const char*)value, 1);
 #endif
 }
 
-MOONBIT_FFI_EXPORT void unset_env_var(moonbit_bytes_t key) {
+MOONBIT_FFI_EXPORT void unset_env_var(moonbitlang_x_os_string_t key) {
 #ifdef _WIN32
-    SetEnvironmentVariable(key, NULL);
+    SetEnvironmentVariableW((LPCWSTR)key, NULL);
 #else
     unsetenv((const char*)key);
 #endif

--- a/sys/internal/ffi/sys_native.mbt
+++ b/sys/internal/ffi/sys_native.mbt
@@ -16,6 +16,40 @@
 fn internal_get_cli_args() -> FixedArray[Bytes] = "$moonbit.get_cli_args"
 
 ///|
+#cfg(not(platform="windows"))
+priv struct OsString(Bytes)
+
+///|
+// Windows APIs consume and produce UTF-16, which is also MoonBit String's
+// native representation.
+#cfg(platform="windows")
+priv struct OsString(String)
+
+///|
+#cfg(not(platform="windows"))
+fn OsString::from_string(str : String) -> OsString {
+  OsString(@common_ffi.mbt_string_to_utf8_bytes(str, true))
+}
+
+///|
+#cfg(platform="windows")
+fn OsString::from_string(str : String) -> OsString {
+  OsString(str)
+}
+
+///|
+#cfg(not(platform="windows"))
+fn OsString::to_string(self : OsString) -> String {
+  @common_ffi.utf8_bytes_to_mbt_string(self.0)
+}
+
+///|
+#cfg(platform="windows")
+fn OsString::to_string(self : OsString) -> String {
+  self.0
+}
+
+///|
 pub fn get_cli_args() -> Array[String] {
   Array::from_fixed_array(
     internal_get_cli_args().map(
@@ -28,9 +62,9 @@ pub fn get_cli_args() -> Array[String] {
 
 ///|
 pub fn get_env_var(key : String) -> String? {
-  let key_bytes = @common_ffi.mbt_string_to_utf8_bytes(key, true)
-  if get_env_var_exists_ffi(key_bytes) {
-    Some(@common_ffi.utf8_bytes_to_mbt_string(get_env_var_ffi(key_bytes)))
+  let key = OsString::from_string(key)
+  if get_env_var_exists_ffi(key) {
+    Some(get_env_var_ffi(key).to_string())
   } else {
     None
   }
@@ -38,17 +72,15 @@ pub fn get_env_var(key : String) -> String? {
 
 ///|
 #borrow(_key)
-extern "C" fn get_env_var_ffi(_key : Bytes) -> Bytes = "get_env_var"
+extern "C" fn get_env_var_ffi(_key : OsString) -> OsString = "get_env_var"
 
 ///|
 #borrow(_key)
-extern "C" fn get_env_var_exists_ffi(_key : Bytes) -> Bool = "get_env_var_exists"
+extern "C" fn get_env_var_exists_ffi(_key : OsString) -> Bool = "get_env_var_exists"
 
 ///|
 pub fn get_env_vars() -> Map[String, String] {
-  let env_vars = get_env_vars_ffi().map(env => {
-    @common_ffi.utf8_bytes_to_mbt_string(env)
-  })
+  let env_vars = get_env_vars_ffi().map(OsString::to_string)
   let res = Map([])
   for i = 0; i < env_vars.length(); i = i + 2 {
     res[env_vars[i]] = env_vars[i + 1]
@@ -57,28 +89,25 @@ pub fn get_env_vars() -> Map[String, String] {
 }
 
 ///|
-extern "C" fn get_env_vars_ffi() -> FixedArray[Bytes] = "get_env_vars"
+extern "C" fn get_env_vars_ffi() -> FixedArray[OsString] = "get_env_vars"
 
 ///|
 pub fn set_env_var(key : String, value : String) -> Unit {
-  set_env_var_ffi(
-    @common_ffi.mbt_string_to_utf8_bytes(key, true),
-    @common_ffi.mbt_string_to_utf8_bytes(value, true),
-  )
+  set_env_var_ffi(OsString::from_string(key), OsString::from_string(value))
 }
 
 ///|
 #borrow(_key, _value)
-extern "C" fn set_env_var_ffi(_key : Bytes, _value : Bytes) -> Unit = "set_env_var"
+extern "C" fn set_env_var_ffi(_key : OsString, _value : OsString) -> Unit = "set_env_var"
 
 ///|
 pub fn unset_env_var(key : String) -> Unit {
-  unset_env_var_ffi(@common_ffi.mbt_string_to_utf8_bytes(key, true))
+  unset_env_var_ffi(OsString::from_string(key))
 }
 
 ///|
 #borrow(_key)
-extern "C" fn unset_env_var_ffi(_key : Bytes) -> Unit = "unset_env_var"
+extern "C" fn unset_env_var_ffi(_key : OsString) -> Unit = "unset_env_var"
 
 ///|
 pub extern "C" fn exit(code : Int) = "exit"


### PR DESCRIPTION
## Summary

Windows native filesystem and environment bindings passed UTF-8 bytes to ANSI Win32 and CRT APIs. On systems using GBK or another non-UTF-8 code page, this corrupts non-ASCII paths and directory entries.

Use a platform-specific OS string representation instead:

- pass MoonBit `String` directly as UTF-16 on Windows
- call explicit wide filesystem and environment APIs
- continue using UTF-8 `Bytes` on non-Windows platforms

## Why this is correct

MoonBit strings already use NUL-terminated UTF-16 in native Windows builds, matching the `W` Win32 APIs. Directory entries returned by `FindFirstFileW` and `FindNextFileW` can therefore be returned as MoonBit strings without passing through the system ANSI code page.

The change is limited to the existing native filesystem and environment FFI boundaries; public APIs and non-Windows behavior are unchanged.

Closes #281