### PR TITLE
fix(rational): reject zero denominator in div and reciprocal

### DIFF
--- a/rational/pkg.generated.mbti
+++ b/rational/pkg.generated.mbti
@@ -26,6 +26,8 @@ pub fn[T : Integral] Rational::abs(Self[T]) -> Self[T]
 #as_free_fn
 pub fn[T : Integral] Rational::ceil(Self[T]) -> T
 #as_free_fn
+pub fn[T : Integral] Rational::div_checked(Self[T], Self[T]) -> Self[T] raise RationalError
+#as_free_fn
 pub fn[T : Integral] Rational::floor(Self[T]) -> T
 #as_free_fn
 pub fn[T : Integral] Rational::fract(Self[T]) -> Self[T]
@@ -33,6 +35,8 @@ pub fn[T : Integral] Rational::fract(Self[T]) -> Self[T]
 pub fn[T : Integral] Rational::is_integer(Self[T]) -> Bool
 #as_free_fn
 pub fn[T : Integral] Rational::reciprocal(Self[T]) -> Self[T]
+#as_free_fn
+pub fn[T : Integral] Rational::reciprocal_checked(Self[T]) -> Self[T] raise RationalError
 pub fn Rational::to_double(Self[Int64]) -> Double
 #as_free_fn
 pub fn[T : Integral] Rational::trunc(Self[T]) -> T

--- a/rational/rational.mbt
+++ b/rational/rational.mbt
@@ -184,6 +184,59 @@ pub impl[T : Integral] Mul for Rational[T] with fn mul(self, other) {
 /// ```
 ///
 pub impl[T : Integral] Div for Rational[T] with fn div(self, other) {
+  if other.numerator == T::from_int(0) {
+    abort("division by zero")
+  }
+  if other.numerator.signum() < 0 {
+    new_unchecked(
+      self.numerator * -other.denominator,
+      self.denominator * -other.numerator,
+    )
+  } else {
+    new_unchecked(
+      self.numerator * other.denominator,
+      self.denominator * other.numerator,
+    )
+  }
+}
+
+///|
+/// Divides one rational number by another, raising an error when the divisor
+/// is zero.
+///
+/// Parameters:
+///
+/// * `self` : The dividend rational number.
+/// * `other` : The divisor rational number.
+///
+/// Returns the quotient of the division as a rational number.
+///
+/// Raises `RationalError("division by zero")` if `other` is zero.
+///
+/// Example:
+///
+/// ```moonbit check
+/// test {
+///   let a = @rational.new(1L, 2L)
+///   let b = @rational.new(2L, 3L)
+///   match (a, b) {
+///     (Some(x), Some(y)) => {
+///       let result = x.div_checked(y)
+///       inspect(result, content="3/4")
+///     }
+///     _ => ()
+///   }
+/// }
+/// ```
+///
+#as_free_fn
+pub fn[T : Integral] Rational::div_checked(
+  self : Rational[T],
+  other : Rational[T],
+) -> Rational[T] raise RationalError {
+  if other.numerator == T::from_int(0) {
+    raise RationalError("division by zero")
+  }
   if other.numerator.signum() < 0 {
     new_unchecked(
       self.numerator * -other.denominator,
@@ -221,6 +274,45 @@ pub impl[T : Integral] Div for Rational[T] with fn div(self, other) {
 ///
 #as_free_fn
 pub fn[T : Integral] Rational::reciprocal(self : Rational[T]) -> Rational[T] {
+  if self.numerator == T::from_int(0) {
+    abort("reciprocal of zero")
+  }
+  if self.numerator.signum() < 0 {
+    new_unchecked(-self.denominator, -self.numerator)
+  } else {
+    new_unchecked(self.denominator, self.numerator)
+  }
+}
+
+///|
+/// Returns the multiplicative inverse of a rational number, raising an error
+/// when the rational number is zero.
+///
+/// Parameters:
+///
+/// * `self` : The rational number to find the reciprocal of.
+///
+/// Returns a new rational number that is the reciprocal of the input.
+///
+/// Raises `RationalError("reciprocal of zero")` if `self` is zero.
+///
+/// Example:
+///
+/// ```moonbit check
+/// test {
+///   let half = @rational.new(1L, 2L).unwrap()
+///   let two = half.reciprocal_checked()
+///   inspect(two, content="2")
+/// }
+/// ```
+///
+#as_free_fn
+pub fn[T : Integral] Rational::reciprocal_checked(
+  self : Rational[T],
+) -> Rational[T] raise RationalError {
+  if self.numerator == T::from_int(0) {
+    raise RationalError("reciprocal of zero")
+  }
   if self.numerator.signum() < 0 {
     new_unchecked(-self.denominator, -self.numerator)
   } else {

--- a/rational/rational_test.mbt
+++ b/rational/rational_test.mbt
@@ -56,6 +56,40 @@ test "division" {
 }
 
 ///|
+test "panic division by zero" {
+  let a = @rational.new(1L, 2L).unwrap()
+  let b = @rational.new(0L, 1L).unwrap()
+  let _ = a / b
+}
+
+///|
+test "panic reciprocal of zero" {
+  let a = @rational.new(0L, 1L).unwrap()
+  let _ = a.reciprocal()
+}
+
+///|
+test "div_checked" {
+  let a = @rational.new(1L, 2L).unwrap()
+  let b = @rational.new(3L, 4L).unwrap()
+  let result = a.div_checked(b)
+  inspect(result, content="2/3")
+  let zero = @rational.new(0L, 1L).unwrap()
+  let result = @test.expect_error(() => a.div_checked(zero))
+  @debug.assert_eq(result, RationalError("division by zero"))
+}
+
+///|
+test "reciprocal_checked" {
+  let a = @rational.new(1L, 2L).unwrap()
+  let result = a.reciprocal_checked()
+  inspect(result, content="2")
+  let zero = @rational.new(0L, 1L).unwrap()
+  let result = @test.expect_error(() => zero.reciprocal_checked())
+  @debug.assert_eq(result, RationalError("reciprocal of zero"))
+}
+
+///|
 test "from_double overflow" {
   let result = @test.expect_error(() => @rational.from_double(10.0e200))
   @debug.assert_eq(result, RationalError("Rational::from_double: overflow"))


### PR DESCRIPTION
Dividing by zero or taking the reciprocal of zero previously produced an invalid 1/0 value. Panic with a clear message at both call sites, and guard `op_div` / `reciprocal` as a defense-in-depth invariant check. Add panic regression tests for both cases.

#266 