### PR TITLE
fix(rational): avoid overflow in comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - Added `AGENTS.md` with repository guidance for agent contributions (#283)
 
+### Fixed
+
+- Fixed `@rational` comparison overflowing silently by cross-multiplying with
+  `BigInt`, and made `@rational.new` return `None` when the reduced form does
+  not fit the target integer type
+
 ## [0.4.45]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,44 @@
 
 ## [Unreleased]
 
-### Added
-
-- Added `AGENTS.md` with repository guidance for agent contributions (#283)
-
 ### Fixed
 
 - Fixed `@rational` comparison overflowing silently by cross-multiplying with
   `BigInt`, and made `@rational.new` return `None` when the reduced form does
   not fit the target integer type
+
+## [0.4.48]
+
+### Changed
+
+- Updated MoonBit toolchain support to 20260803
+
+### Deprecated
+
+- Deprecated `@sys.get_cli_args`, `@sys.get_env_vars`, `@sys.get_env_var`,
+  `@sys.set_env_var`, and `@sys.unset_env_var` in favor of the `@env` package
+
+## [0.4.47]
+
+### Added
+
+- Added `AGENTS.md` with repository guidance for agent contributions (#283)
+
+### Changed
+
+- Improved `@crypto` performance with SIMD-accelerated MD5, SHA-1, SHA-256,
+  SM3, ChaCha, and HMAC
+
+### Fixed
+
+- Fixed `@path` win32 handling of verbatim prefixes, rooted paths, and UNC cwd
+- Fixed `@fs` and `@sys` native FFI to use wide (Unicode) Windows APIs
+
+## [0.4.46]
+
+### Changed
+
+- Aligned `@path` posix and win32 behavior with the Node.js `path` module
 
 ## [0.4.45]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Fixed `@rational` comparison overflowing silently by cross-multiplying with
   `BigInt`, and made `@rational.new` return `None` when the reduced form does
-  not fit the target integer type
+  not fit the target integer type (#291)
 
 ## [0.4.48]
 

--- a/rational/moon.pkg
+++ b/rational/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "moonbitlang/core/debug",
+  "moonbitlang/core/int",
   "moonbitlang/core/int64",
   "moonbitlang/core/quickcheck",
 }

--- a/rational/rational.mbt
+++ b/rational/rational.mbt
@@ -33,9 +33,11 @@ fn[T : Integral] gcd(a : T, b : T) -> T {
 /// * `numerator` : The numerator of the rational number.
 /// * `denominator` : The denominator of the rational number.
 ///
-/// Returns `Some(rational)` if the denominator is non-zero, where the rational
-/// number is automatically reduced to its simplest form with a positive
-/// denominator. Returns `None` if the denominator is zero.
+/// Returns `Some(rational)` if the denominator is non-zero and the reduced form
+/// fits in `T`, where the rational number is automatically reduced to its
+/// simplest form with a positive denominator. Returns `None` if the denominator
+/// is zero, or if the reduced form cannot be represented in `T` (e.g. its
+/// denominator is `2^63` for `Rational[Int64]`).
 ///
 /// Example:
 ///
@@ -71,17 +73,16 @@ pub fn[T : Integral] new(numerator : T, denominator : T) -> Rational[T]? {
   if denominator.signum() == 0 {
     None
   } else {
-    let sign = T::from_int(
-      if numerator.signum() == denominator.signum() {
-        1
-      } else {
-        -1
-      },
-    )
-    let numerator = numerator.abs()
-    let denominator = denominator.abs()
-    let gcd = gcd(numerator, denominator)
-    Some({ numerator: sign * numerator / gcd, denominator: denominator / gcd })
+    let bn = numerator.to_bigint()
+    let bd = denominator.to_bigint()
+    let g = gcd(bn, bd)
+    let bn = bn / g
+    let bd = bd / g
+    let (bn, bd) = if bd < 0N { (-bn, -bd) } else { (bn, bd) }
+    match (T::from_bigint(bn), T::from_bigint(bd)) {
+      (Some(n), Some(d)) => Some({ numerator: n, denominator: d })
+      _ => None
+    }
   }
 }
 
@@ -405,8 +406,8 @@ pub impl[T : Integral] Compare for Rational[T] with fn compare(
   self : Rational[T],
   other : Rational[T],
 ) -> Int {
-  let left = self.numerator * other.denominator
-  let right = other.numerator * self.denominator
+  let left = self.numerator.to_bigint() * other.denominator.to_bigint()
+  let right = other.numerator.to_bigint() * self.denominator.to_bigint()
   Compare::compare(left, right)
 }
 
@@ -1156,6 +1157,12 @@ test "eq and compare" {
   let b = new_unchecked(1L, 2L)
   assert_eq(a.compare(b), 0)
   assert_true(a == b)
+}
+
+///|
+test "compare no overflow" {
+  let p = new_unchecked(-3L, -9223372036854775808L)
+  assert_true(p.compare(-p) > 0)
 }
 
 ///|

--- a/rational/rational_test.mbt
+++ b/rational/rational_test.mbt
@@ -205,7 +205,7 @@ test "rational equality" {
 }
 
 ///|
-test "compare no overflow" {
+test "compare no overflow (int64 max denom)" {
   let max = 9223372036854775807L
   let a = @rational.new(1L, max).unwrap()
   let b = @rational.new(2L, max).unwrap()

--- a/rational/rational_test.mbt
+++ b/rational/rational_test.mbt
@@ -195,10 +195,23 @@ test "rational equality" {
   let c = @rational.new(1L, 3L).unwrap()
   inspect(a == b, content="true")
   inspect(a == c, content="false")
-  let a = @rational.new(-3L, -9223372036854775808L).unwrap()
-  let b = @rational.new(-1L, -9223372036854775808L).unwrap()
-  inspect(a == b, content="false")
+  let a = @rational.new(-3L, -9223372036854775808L)
+  let b = @rational.new(-1L, -9223372036854775808L)
+  assert_true(a is None)
+  assert_true(b is None)
   let x = @rational.new(-43L, 3689348814741910693L).unwrap()
   let y = @rational.new(5L, -43L).unwrap()
   inspect(x == y, content="false")
+}
+
+///|
+test "compare no overflow" {
+  let max = 9223372036854775807L
+  let a = @rational.new(1L, max).unwrap()
+  let b = @rational.new(2L, max).unwrap()
+  assert_eq(a.compare(b), -1)
+
+  let x = @rational.new(-43L, 3689348814741910693L).unwrap()
+  let y = @rational.new(5L, -43L).unwrap()
+  assert_true(x.compare(y) > 0)
 }

--- a/rational/types.mbt
+++ b/rational/types.mbt
@@ -28,6 +28,8 @@ trait Integral: Add + Sub + Mul + Div + Neg + Mod + Show + Eq + Compare + @quick
   fn from_int(Int) -> Self
   fn signum(self : Self) -> Int
   fn abs(self : Self) -> Self
+  fn to_bigint(self : Self) -> BigInt
+  fn from_bigint(BigInt) -> Self?
 }
 
 ///|
@@ -46,6 +48,21 @@ pub impl Integral for Int64 with fn signum(self : Int64) -> Int {
 }
 
 ///|
+pub impl Integral for Int64 with fn to_bigint(self : Int64) -> BigInt {
+  BigInt::from_int64(self)
+}
+
+///|
+pub impl Integral for Int64 with fn from_bigint(b : BigInt) -> Int64? {
+  if b.compare_int64(@int64.MIN_VALUE) >= 0 &&
+    b.compare_int64(@int64.MAX_VALUE) <= 0 {
+    Some(b.to_int64())
+  } else {
+    None
+  }
+}
+
+///|
 pub impl Integral for Int with fn from_int(i : Int) -> Int {
   i
 }
@@ -58,6 +75,20 @@ pub impl Integral for Int with fn abs(self : Int) -> Int {
 ///|
 pub impl Integral for Int with fn signum(self : Int) -> Int {
   self.compare(0)
+}
+
+///|
+pub impl Integral for Int with fn to_bigint(self : Int) -> BigInt {
+  BigInt::from_int(self)
+}
+
+///|
+pub impl Integral for Int with fn from_bigint(b : BigInt) -> Int? {
+  if b.compare_int(@int.MIN_VALUE) >= 0 && b.compare_int(@int.MAX_VALUE) <= 0 {
+    Some(b.to_int())
+  } else {
+    None
+  }
 }
 
 ///|
@@ -77,6 +108,16 @@ pub impl Integral for BigInt with fn abs(self : BigInt) -> BigInt {
 ///|
 pub impl Integral for BigInt with fn signum(self : BigInt) -> Int {
   self.compare(0N)
+}
+
+///|
+pub impl Integral for BigInt with fn to_bigint(self : BigInt) -> BigInt {
+  self
+}
+
+///|
+pub impl Integral for BigInt with fn from_bigint(b : BigInt) -> BigInt? {
+  Some(b)
 }
 
 ///|


### PR DESCRIPTION
## Summary

`Rational::compare` cross-multiplies numerators and denominators with
fixed-width integers, which can wrap silently and report wrong orderings.
For example, a rational compared equal to its own negation:

```moonbit
let p = @rational.new_unchecked(-3L, -9223372036854775808L)
p.compare(-p) == 0  // wrong, returns 0
```

The reproduction in the issue used `a == b` on `new(-3, MIN)` /
`new(-1, MIN)`; structural `Eq` already returns the correct `false`, but the
underlying `compare` overflow remains (#168).

## Changes

- Cross-multiply in `compare` via `BigInt` (no overflow).
- Reduce in `new` via `BigInt`; return `None` when the reduced
  positive-denominator form cannot be represented in `T` (e.g. denominator
  `2^63` for `Rational[Int64]`), instead of producing a negative denominator
  through `abs()` overflow on `Int64::MIN`.
- Add `to_bigint`/`from_bigint` to the package-private `Integral` trait.

## Behavior change

`@rational.new(-3L, -9223372036854775808L)` now returns `None` (was
`Some(3/-2^63)` with a negative denominator).

Regression tests were added and fail on the old implementation.