### PR TITLE
chore: release 0.4.49

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.4.49]
+
 ### Fixed
 
 - Fixed `@rational` comparison overflowing silently by cross-multiplying with

--- a/moon.mod
+++ b/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbitlang/x"
 
-version = "0.4.48"
+version = "0.4.49"
 
 readme = "README.md"
 


### PR DESCRIPTION
Bumps `moon.mod` to 0.4.49 and cuts the pending `Unreleased` changelog entry into a `0.4.49` section.

Contents of this release (already merged to main):
- Fixed `@rational` comparison overflowing silently by cross-multiplying with `BigInt`, and made `@rational.new` return `None` when the reduced form does not fit the target integer type (#291)

Once this merges, `publish.yml` will be dispatched on `main` to publish to mooncakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)