### PR TITLE
fix: eliminate lexical matching warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Fixed
 
-- Fixed compiler warnings in `@json5`, `@path`, and `@time`. 
+- Fixed compiler warnings in `@json5`, `@path`, and `@time` with MoonBit
+  0.1.20260807 (#295)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed compiler warnings in `@json5`, `@path`, and `@time`. 
+
+### Changed
+
+- Improved `@rational` comparison to avoid `BigInt` allocation, keeping
+  cross-multiplication in fixed-width arithmetic when safe
+
 ## [0.4.49]
 
 ### Fixed
@@ -9,11 +18,6 @@
 - Fixed `@rational` comparison overflowing silently for fixed-width integer
   values, and made `@rational.new` return `None` when the reduced form does not
   fit the target integer type (#291)
-
-### Changed
-
-- Improved `@rational` comparison to avoid `BigInt` allocation, keeping
-  cross-multiplication in fixed-width arithmetic when safe
 
 ## [0.4.48]
 

--- a/json5/lex_main.mbt
+++ b/json5/lex_main.mbt
@@ -19,7 +19,7 @@ fn lex_value(
 ) -> Token raise ParseError {
   for ;; {
     let view = ctx.input[ctx.offset:]
-    lexscan view with longest {
+    lexmatch view with longest {
       (
         re"^[\t\u000B\u000C \n\r\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF]",
         after=rest,
@@ -31,11 +31,11 @@ fn lex_value(
         ctx.offset = rest.start_offset()
         continue
       }
-      (re"^/[*]([*][^/]?|[^*])*[*]/", after=rest) => {
+      (re"^/[*]([^*]|[*]+[^*/])*[*]+/", after=rest) => {
         ctx.offset = rest.start_offset()
         continue
       }
-      re"^/[*]([*][^/]?|[^*])*$" => parse_error(InvalidEof)
+      re"^/[*]([^*]|[*]+[^*/])*[*]*$" => parse_error(InvalidEof)
       (re"^[{]", after=rest) => {
         ctx.offset = rest.start_offset()
         return LBrace
@@ -112,7 +112,6 @@ fn lex_value(
         no_valid_token(ctx)
       }
       re"^$" => parse_error(InvalidEof)
-      _ => panic()
     }
   }
 }

--- a/json5/parse_test.mbt
+++ b/json5/parse_test.mbt
@@ -359,6 +359,15 @@ test "parses multi-line comments" {
   let json = test_parse("{/*comment\n** */}")
   @debug.assert_eq(json, Json::object(Map([])))
 }
+
+///|
+test "parses multi-line comments at value positions" {
+  @test.assert_eq(
+    test_parse("{a:/*c*/1}"),
+    Json::object(Map([("a", Json::number(1.0))])),
+  )
+  @test.assert_eq(test_parse("[/*c*/1]"), Json::array([Json::number(1.0)]))
+}
 //endregion
 
 //region whitespace

--- a/path/win32/path.mbt
+++ b/path/win32/path.mbt
@@ -275,7 +275,7 @@ pub fn Path::is_absolute(path : Path) -> Bool {
 ///|
 fn Path::prefix(path : Path) -> StringView {
   let path = path.0
-  lexscan path with longest {
+  lexmatch path with longest {
     ((re"^\\\\\?\\" + (re"[^\\]+" as _symlink) + re"(\\)+") as prefix, after=_) =>
       prefix
     (
@@ -302,12 +302,6 @@ fn Path::prefix(path : Path) -> StringView {
       (re"^\\\\\?\\Volume[{]" + (re"[^}]+" as _guid) + re"[}]") as prefix,
       after=_,
     ) => prefix
-    ((re"^\\\\\.\\" + (re"[^\\]+" as _device) + re"(\\)+") as prefix, after=_) =>
-      prefix
-    (
-      (re"^\\\\\?\\" + (re"[a-zA-Z]" as _letter) + re":(\\)+") as prefix,
-      after=_,
-    ) => prefix
     (re"^\\+" as prefix, after=_) => prefix
     (((re"^[a-zA-Z]" as _letter) + re":(\\)+") as prefix, after=_) => prefix
     (((re"^[a-zA-Z]" as _letter) + re":") as prefix, after=_) => prefix
@@ -318,7 +312,7 @@ fn Path::prefix(path : Path) -> StringView {
 
 ///|
 fn join_rest(lhs : StringView, rhs : StringView) -> StringView? {
-  lexscan rhs with longest {
+  lexmatch rhs with longest {
     (re"^\\\\\?\\" + (re"[^\\]+" as _symlink) + re"(\\)+", after=_) => None
     (
       re"^\\\\\?UNC\\" +
@@ -337,12 +331,10 @@ fn join_rest(lhs : StringView, rhs : StringView) -> StringView? {
       after=_,
     ) => None
     (re"^\\\\\?\\Volume[{]" + (re"[^}]+" as _guid) + re"[}]", after=_) => None
-    (re"^\\\\\.\\" + (re"[^\\]+" as _device) + re"(\\)+", after=_) => None
-    (re"^\\\\\?\\" + (re"[a-zA-Z]" as _letter) + re":(\\)+", after=_) => None
     (re"^\\", after=_) => None
     ((re"^[a-zA-Z]" as _letter) + re":(\\)+", after=_) => None
     ((re"^[a-zA-Z]" as rhs_letter) + re":", after=rhs_rest) =>
-      lexscan lhs with longest {
+      lexmatch lhs with longest {
         ((re"^[a-zA-Z]" as lhs_letter) + re":", after=_) =>
           if lhs_letter == rhs_letter {
             Some(rhs_rest)

--- a/time/plain_date.mbt
+++ b/time/plain_date.mbt
@@ -77,7 +77,7 @@ pub fn PlainDate::from_string(str : String) -> PlainDate raise Error {
 
 ///|
 fn PlainDate::parse_str(str : StringView) -> PlainDate raise Error {
-  lexscan str with longest {
+  lexmatch str with longest {
     (re"^-?[0-9]{4}" as year_str) +
     re"-" +
     (re"[0-9]{2}" as month_str) +

--- a/time/plain_time.mbt
+++ b/time/plain_time.mbt
@@ -45,7 +45,7 @@ pub fn PlainTime::from_string(str : String) -> PlainTime raise Error {
 
 ///|
 fn PlainTime::parse_str(str : StringView) -> PlainTime raise Error {
-  let (hour, minute, second, nanosecond) = lexscan str with longest {
+  let (hour, minute, second, nanosecond) = lexmatch str with longest {
     (re"^[0-9]{2}" as hour_str) + re":" + (re"[0-9]{2}$" as minute_str) =>
       (@string.parse_int(hour_str), @string.parse_int(minute_str), 0, 0)
     (re"^[0-9]{2}" as hour_str) +


### PR DESCRIPTION
## Summary

- Migrate non-streaming lexical matches from `lexscan` to `lexmatch`.
- Fix JSON5 block comments at object and array value positions.
- Remove unreachable Windows path matching arms.
- Add regression coverage for JSON5 block comments.

## Verification

- `moon info`
- `moon fmt`
- `moon check --deny-warn`
- `moon test` (536 tests passed)

Closes #293
