### PR TITLE
refactor: dedupe utf16 surrogate handling and delegate encoding to core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Added `@unicode` package with per-character Unicode simple case folding to
   lowercase, following Node.js `toLowerCase` (#296)
 - Added `@unicode.utf16_pair_to_char` to combine a UTF-16 surrogate pair
-  into a char
+  into a char (#297)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Added `@unicode` package with per-character Unicode simple case folding to
   lowercase, following Node.js `toLowerCase` (#296)
+- Added `@unicode.utf16_pair_to_char` to combine a UTF-16 surrogate pair
+  into a char
 
 ### Fixed
 

--- a/encoding/decoding.mbt
+++ b/encoding/decoding.mbt
@@ -651,21 +651,20 @@ fn r_utf_16_lo(
   let b0 = bytes[offset0].to_int()
   let b1 = bytes[offset1].to_int()
   let lo = (b0 << 8) | b1
-  if lo < 0xDC00 || lo > 0xDFFF {
-    // NOTE(jinser): only hi malformed, skip lo if lo is illegal
-    //
-    // For example, b"\xD8\x00\x00\x48" (BE)
-    // Since \xD8\x00 is *legal* hi, here will try to parse lo next,
-    // however the whole \xD8\x00\x00\x48 is *illegal* so the result will be a `Malformed[b"\xD8\x00\x00\x48"]`
-    //
-    // But \x00\x48 itself is a *legal* UTF16 code point with a value of `H`,
-    // the ideal result should be: `[Malformed(b"\xD8\x00"), Uchar('H')]`
-    //
-    // > printf '\xD8\x00\x00\x48' | uconv --from-code UTF16BE --to-code UTF8 --from-callback substitute
-    // �H
-    Malformed([bytes[offset0], bytes[offset1]])
-  } else {
-    Uchar(Int::unsafe_to_char(((hi & 0x3FF) << 10) | ((lo & 0x3FF) + 0x10000)))
+  // NOTE(jinser): only hi malformed, skip lo if lo is illegal
+  //
+  // For example, b"\xD8\x00\x00\x48" (BE)
+  // Since \xD8\x00 is *legal* hi, here will try to parse lo next,
+  // however the whole \xD8\x00\x00\x48 is *illegal* so the result will be a `Malformed[b"\xD8\x00\x00\x48"]`
+  //
+  // But \x00\x48 itself is a *legal* UTF16 code point with a value of `H`,
+  // the ideal result should be: `[Malformed(b"\xD8\x00"), Uchar('H')]`
+  //
+  // > printf '\xD8\x00\x00\x48' | uconv --from-code UTF16BE --to-code UTF8 --from-callback substitute
+  // �H
+  match @unicode.utf16_pair_to_char(hi, lo) {
+    Some(ch) => Uchar(ch)
+    _ => Malformed([bytes[offset0], bytes[offset1]])
   }
 }
 
@@ -678,12 +677,12 @@ fn r_utf_16(
   let b0 = bytes[offset0].to_int()
   let b1 = bytes[offset1].to_int()
   let u = (b0 << 8) | b1
-  if u < 0xD800 || u > 0xDFFF {
-    UTF16Uchar(Int::unsafe_to_char(u))
-  } else if u > 0xDBFF {
+  if u.is_leading_surrogate() {
+    Hi(u)
+  } else if u.is_trailing_surrogate() {
     UTF16Malformed(slice(bytes, @cmp.minimum(offset0, offset1), 2))
   } else {
-    Hi(u)
+    UTF16Uchar(Int::unsafe_to_char(u))
   }
 }
 

--- a/encoding/encoding.mbt
+++ b/encoding/encoding.mbt
@@ -87,14 +87,8 @@ pub fn encode_to(
   encoding~ : Encoding,
 ) -> Unit {
   match encoding {
-    UTF8 =>
-      for char in src {
-        write_utf8_char(buffer, char)
-      }
-    UTF16BE =>
-      for char in src {
-        write_utf16be_char(buffer, char)
-      }
+    UTF8 => buffer.write_string_utf8(src)
+    UTF16BE => buffer.write_string_utf16be(src)
     UTF16 | UTF16LE => buffer.write_string_utf16le(src)
   }
 }
@@ -146,38 +140,7 @@ pub fn to_utf16be_bytes(value : Char) -> Bytes {
 ///|
 /// Write a char into buffer as UTF8.
 pub fn write_utf8_char(buf : @buffer.Buffer, value : Char) -> Unit {
-  let code = value.to_uint()
-  match code {
-    _..<0x80 => {
-      let b0 = ((code & 0x7F) | 0x00).to_byte()
-      buf.write_byte(b0)
-    }
-    _..<0x0800 => {
-      let b0 = (((code >> 6) & 0x1F) | 0xC0).to_byte()
-      let b1 = ((code & 0x3F) | 0x80).to_byte()
-      buf.write_byte(b0)
-      buf.write_byte(b1)
-    }
-    _..<0x010000 => {
-      let b0 = (((code >> 12) & 0x0F) | 0xE0).to_byte()
-      let b1 = (((code >> 6) & 0x3F) | 0x80).to_byte()
-      let b2 = ((code & 0x3F) | 0x80).to_byte()
-      buf.write_byte(b0)
-      buf.write_byte(b1)
-      buf.write_byte(b2)
-    }
-    _..<0x110000 => {
-      let b0 = (((code >> 18) & 0x07) | 0xF0).to_byte()
-      let b1 = (((code >> 12) & 0x3F) | 0x80).to_byte()
-      let b2 = (((code >> 6) & 0x3F) | 0x80).to_byte()
-      let b3 = ((code & 0x3F) | 0x80).to_byte()
-      buf.write_byte(b0)
-      buf.write_byte(b1)
-      buf.write_byte(b2)
-      buf.write_byte(b3)
-    }
-    _ => abort("Char out of range")
-  }
+  buf.write_char_utf8(value)
 }
 
 ///|
@@ -190,51 +153,11 @@ pub fn write_utf16_char(buf : @buffer.Buffer, value : Char) -> Unit {
 ///|
 /// Write a char into buffer as UTF16LE.
 pub fn write_utf16le_char(buf : @buffer.Buffer, value : Char) -> Unit {
-  let code = value.to_uint()
-  if code < 0x10000 {
-    let b0 = (code & 0xFF).to_byte()
-    let b1 = (code >> 8).to_byte()
-    buf.write_byte(b0)
-    buf.write_byte(b1)
-  } else if code < 0x110000 {
-    let hi = code - 0x10000
-    let lo = (hi >> 10) | 0xD800
-    let hi = (hi & 0x3FF) | 0xDC00
-    let b0 = (lo & 0xFF).to_byte()
-    let b1 = (lo >> 8).to_byte()
-    let b2 = (hi & 0xFF).to_byte()
-    let b3 = (hi >> 8).to_byte()
-    buf.write_byte(b0)
-    buf.write_byte(b1)
-    buf.write_byte(b2)
-    buf.write_byte(b3)
-  } else {
-    abort("Char out of range")
-  }
+  buf.write_char_utf16le(value)
 }
 
 ///|
 /// Write a char into buffer as UTF16BE.
 pub fn write_utf16be_char(buf : @buffer.Buffer, value : Char) -> Unit {
-  let code = value.to_uint()
-  if code < 0x10000 {
-    let b0 = (code >> 8).to_byte()
-    let b1 = (code & 0xFF).to_byte()
-    buf.write_byte(b0)
-    buf.write_byte(b1)
-  } else if code < 0x110000 {
-    let hi = code - 0x10000
-    let lo = (hi >> 10) | 0xD800
-    let hi = (hi & 0x3FF) | 0xDC00
-    let b0 = (lo >> 8).to_byte()
-    let b1 = (lo & 0xFF).to_byte()
-    let b2 = (hi >> 8).to_byte()
-    let b3 = (hi & 0xFF).to_byte()
-    buf.write_byte(b0)
-    buf.write_byte(b1)
-    buf.write_byte(b2)
-    buf.write_byte(b3)
-  } else {
-    abort("Char out of range")
-  }
+  buf.write_char_utf16be(value)
 }

--- a/encoding/moon.pkg
+++ b/encoding/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "moonbitlang/core/buffer",
   "moonbitlang/core/cmp",
+  "moonbitlang/x/unicode",
 }
 
 import {

--- a/internal/ffi/moon.pkg
+++ b/internal/ffi/moon.pkg
@@ -1,3 +1,7 @@
+import {
+  "moonbitlang/x/unicode",
+}
+
 options(
   targets: {
     "byte_array_wasm.mbt": [ "wasm", "wasm-gc" ],

--- a/internal/ffi/string_convert.mbt
+++ b/internal/ffi/string_convert.mbt
@@ -19,11 +19,10 @@ pub fn mbt_string_to_utf8_bytes(str : String, is_filename : Bool) -> Bytes {
   let mut i = 0
   while i < len {
     let mut c = str.code_unit_at(i).to_int()
-    if 0xD800 <= c && c <= 0xDBFF {
-      c -= 0xD800
+    if c.is_leading_surrogate() {
       i = i + 1
-      let l = str.code_unit_at(i).to_int() - 0xDC00
-      c = (c << 10) + l + 0x10000
+      let l = str.code_unit_at(i).to_int()
+      c = @unicode.utf16_pair_to_char(c, l).unwrap().to_int()
     }
 
     // stdout accepts UTF-8, so convert the stream to UTF-8 first

--- a/json5/lex_misc.mbt
+++ b/json5/lex_misc.mbt
@@ -17,15 +17,14 @@ fn read_char(ctx : ParseContext) -> Char? {
   if ctx.offset < ctx.end_offset {
     let c = ctx.input.code_unit_at(ctx.offset).to_int()
     ctx.offset += 1
-    let c1 = c
-    if c1 >= 0xD800 && c1 <= 0xDBFF {
-      if ctx.offset < ctx.end_offset {
-        let c2 = ctx.input.code_unit_at(ctx.offset).to_int()
-        if c2 >= 0xDC00 && c2 <= 0xDFFF {
+    if ctx.offset < ctx.end_offset {
+      let c2 = ctx.input.code_unit_at(ctx.offset).to_int()
+      match @unicode.utf16_pair_to_char(c, c2) {
+        Some(ch) => {
           ctx.offset += 1
-          let c3 = (c1 << 10) + c2 - 0x35fdc00
-          return Some(Int::unsafe_to_char(c3))
+          return Some(ch)
         }
+        _ => ()
       }
     }
     Some(Int::unsafe_to_char(c))

--- a/json5/moon.pkg
+++ b/json5/moon.pkg
@@ -2,6 +2,7 @@ import {
   "moonbitlang/core/debug",
   "moonbitlang/core/double",
   "moonbitlang/core/string",
+  "moonbitlang/x/unicode",
 }
 
 import {

--- a/unicode/basic_test.mbt
+++ b/unicode/basic_test.mbt
@@ -13,14 +13,18 @@
 // limitations under the License.
 
 ///|
-fn Char::shift_char(c : Char, delta : Int) -> Char {
-  Int::to_char(c.to_int() + delta).unwrap()
+test "from_utf16_pair combines a valid surrogate pair" {
+  debug_inspect(utf16_pair_to_char(0xD83D, 0xDE00), content="Some('😀')")
+  debug_inspect(utf16_pair_to_char(0xD800, 0xDC00), content="Some('\u{10000}')")
+  debug_inspect(
+    utf16_pair_to_char(0xDBFF, 0xDFFF),
+    content="Some('\\u{10ffff}')",
+  )
 }
 
 ///|
-/// Combine a UTF-16 leading surrogate `hi` and trailing surrogate `lo` into
-/// a char, or `None` if the code units are not a valid surrogate pair.
-pub fn utf16_pair_to_char(hi : Int, lo : Int) -> Char? {
-  guard hi.is_leading_surrogate() && lo.is_trailing_surrogate() else { None }
-  Some(Int::unsafe_to_char((hi << 10) + lo - 0x35fdc00))
+test "from_utf16_pair rejects invalid pairs" {
+  debug_inspect(utf16_pair_to_char(0x0041, 0xDE00), content="None")
+  debug_inspect(utf16_pair_to_char(0xD83D, 0x0041), content="None")
+  debug_inspect(utf16_pair_to_char(0xD83D, 0xD83D), content="None")
 }

--- a/unicode/lowercase.mbt
+++ b/unicode/lowercase.mbt
@@ -213,19 +213,14 @@ let lowercase_map : @hashmap.HashMap[Char, Char] = {
     [],
     capacity=LOWERCASE_ENTRY_COUNT * 2,
   )
-  for ch in shift_one {
-    map[ch] = ch.shift_char(0x1)
-  }
-  for item in shift_ranges {
+  shift_one.each(e => map[e] = e.shift_char(0x1))
+  explicit_maps.each(e => map[e.0] = e.1)
+  shift_ranges.each(item => {
     let (start, end, delta) = item
     for code in start.to_int().until(end.to_int(), inclusive=true) {
-      let ch = Int::to_char(code).unwrap()
+      let ch = code.to_char().unwrap()
       map[ch] = ch.shift_char(delta)
     }
-  }
-  for item in explicit_maps {
-    let (upper, lower) = item
-    map[upper] = lower
-  }
+  })
   map
 }

--- a/unicode/pkg.generated.mbti
+++ b/unicode/pkg.generated.mbti
@@ -4,6 +4,8 @@ package "moonbitlang/x/unicode"
 // Values
 pub fn to_lowercase(Char) -> Char
 
+pub fn utf16_pair_to_char(Int, Int) -> Char?
+
 // Errors
 
 // Types and methods


### PR DESCRIPTION
## Summary

Two refactors that remove duplicated Unicode encoding logic in favor of shared or core implementations. No user-facing API or behavior changes.

## Changes

### 1. Dedupe UTF-16 surrogate pair combination (`refactor(unicode)`)

The same surrogate-pair combination formula (`(hi << 10) + lo - 0x35fdc00`) was hand-written in three places:

- `json5/lex_misc.mbt` — `read_char` combining surrogate pairs in the lexer
- `encoding/decoding.mbt` — `r_utf_16_lo` in the UTF-16 decoder
- `internal/ffi/string_convert.mbt` — UTF-8 conversion for `@fs`

Extracted it as `@unicode.utf16_pair_to_char(hi, lo) -> Char?`, and replaced the duplicated surrogate range checks (`0xD800..0xDBFF`, `0xDC00..0xDFFF`) with core's `Int::is_leading_surrogate` / `Int::is_trailing_surrogate`. The `encoding` UTF-16 decoder semantics (malformed reporting, lone-surrogate handling) are unchanged.

Also converted the `lowercase_map` construction loops in `unicode/lowercase.mbt` to `.each` style (behavior-equivalent).

### 2. Delegate char writing to core Buffer API (`refactor(encoding)`)

`@encoding`'s `write_utf8_char` / `write_utf16_char` / `write_utf16le_char` / `write_utf16be_char` and the `encode_to` UTF-8/UTF-16BE branches re-implemented byte sequences already provided by core `@buffer.Buffer`:

- `write_char_utf8` / `write_char_utf16le` / `write_char_utf16be`
- `write_string_utf8` / `write_string_utf16be` / `write_string_utf16le`

The wrappers now delegate to the core methods (-82 lines), keeping the existing public API surface.

## Verification

- `moon test` — 551/551 pass (including 77 json5, 72 encoding tests)
- `moon test encoding --target wasm-gc` — 72/72 pass
- `moon info` + `moon fmt` run; only the `unicode` interface file changed (new `utf16_pair_to_char`)
