### PR TITLE
feat(crypto): add MD4, RIPEMD-160, SHA-512/384 and AES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,26 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added MD4, RIPEMD-160, SHA-384 and SHA-512 hashing (with streaming
+  contexts) and an AES-128/192/256 block cipher with ECB/CBC modes to
+  `@crypto`, ported from `mbtexcel` (#298)
+- Added `SHA224` with a streaming context implementing `CryptoHasher`, so
+  SHA-224 no longer requires the deprecated `reg` parameter of `SHA256::new`
+  (#298)
+
 ### Fixed
 
 - Fixed deprecation warnings from trait method extension calls in
   `@rational`, `@time`, `@path`, `@uuid`, and `@decimal` (#302)
+- Hardened `@crypto` AES, ChaCha, and SHA-512 handling for side-channel,
+  counter-exhaustion, and message-length edge cases. (#298)
+
+### Deprecated
+
+- Deprecated the `reg` parameter of `SHA256::new`; to compute SHA-224, use
+  `SHA224::new()` instead (#298)
 
 ## [0.4.50]
 

--- a/crypto/README.mbt.md
+++ b/crypto/README.mbt.md
@@ -4,6 +4,17 @@
 
 A collection of cryptographic hash functions and utilities.
 
+## Security
+
+MD4, MD5, SHA-1, and RIPEMD-160 are provided for compatibility and should not
+be used where collision resistance is required. Prefer SHA-256, SHA-384,
+SHA-512, or SM3 for new applications.
+
+AES-ECB, AES-CBC, and raw ChaCha encryption do not authenticate ciphertexts.
+New protocols should use an authenticated-encryption construction. AES modes
+also do not apply padding. ChaCha callers that need to handle exhaustion of the
+32-bit block counter should use `ChaCha::transform_checked`.
+
 ## Usage
 
 > Strings in MoonBit are UTF-16 LE encoded.
@@ -63,6 +74,64 @@ test {
   inspect(
     bytes_to_hex_string(ctx.finalize()),
     content="66c7f0f462eeedd9d1f2d46bdc10e4e24167c4875cf2f7a2297da02b8f4ba8e0",
+  )
+}
+```
+
+### MD4
+
+```moonbit check
+///|
+test {
+  inspect(
+    bytes_to_hex_string(md4(b"abc")),
+    content="a448017aaf21d8525fc10ae87aa6729d",
+  )
+}
+```
+
+### RIPEMD-160
+
+```moonbit check
+///|
+test {
+  inspect(
+    bytes_to_hex_string(ripemd160(b"abc")),
+    content="8eb208f7e05d987a9b044a8e98c6b087f15a0bfc",
+  )
+}
+```
+
+### SHA-512 / SHA-384
+
+```moonbit check
+///|
+test {
+  inspect(
+    bytes_to_hex_string(sha512(b"abc")),
+    content="ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f",
+  )
+  inspect(
+    bytes_to_hex_string(sha384(b"abc")),
+    content="cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7",
+  )
+}
+```
+
+### AES
+
+AES-128/192/256 block cipher, with ECB and CBC modes. All functions raise
+`CryptoError` on invalid key, block, IV or data lengths; no padding is applied.
+
+```moonbit check
+///|
+test {
+  let key = b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f"
+  let data = b"0123456789abcdef0123456789abcdef"
+  let encrypted = aes_ecb_encrypt(key, data)
+  inspect(
+    aes_ecb_decrypt(key, encrypted),
+    content="b\"0123456789abcdef0123456789abcdef\"",
   )
 }
 ```

--- a/crypto/aes.mbt
+++ b/crypto/aes.mbt
@@ -1,0 +1,445 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// An AES block-cipher implementation based on
+// [FIPS 197] https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.197.pdf
+
+///|
+/// Errors raised by AES operations on invalid key, block, IV or data lengths.
+pub suberror CryptoError {
+  InvalidCrypto(msg~ : String)
+}
+
+///|
+/// An expanded AES key schedule, shared by the ECB/CBC mode functions. No
+/// padding is applied anywhere; callers must pad themselves.
+priv struct AesSchedule {
+  round_keys : FixedArray[UInt]
+  rounds : Int
+}
+
+///|
+/// Multiplies two bytes in GF(2^8) without secret-dependent branches.
+fn gf_mul(a : Int, b : Int) -> Int {
+  let mut x = a & 0xff
+  let mut y = b & 0xff
+  let mut res = 0
+  for _ in 0..<=7 {
+    let y_mask = 0 - (y & 1)
+    res = res ^ (x & y_mask)
+    let high_bit_mask = 0 - ((x >> 7) & 1)
+    x = ((x << 1) & 0xff) ^ (0x1b & high_bit_mask)
+    y = y >> 1
+  }
+  res & 0xff
+}
+
+///|
+fn gf_pow(x : Int, exp : Int) -> Int {
+  let mut result = 1
+  let mut base = x & 0xff
+  let mut e = exp
+  while e > 0 {
+    if (e & 1) != 0 {
+      result = gf_mul(result, base)
+    }
+    base = gf_mul(base, base)
+    e = e >> 1
+  }
+  result & 0xff
+}
+
+///|
+fn rotl8(x : Int, bits : Int) -> Int {
+  ((x << bits) | (x >> (8 - bits))) & 0xff
+}
+
+///|
+fn aes_sub_byte(value : Byte) -> Byte {
+  let inv = gf_pow(value.to_int(), 254)
+  (inv ^ rotl8(inv, 1) ^ rotl8(inv, 2) ^ rotl8(inv, 3) ^ rotl8(inv, 4) ^ 0x63).to_byte()
+}
+
+///|
+fn aes_inv_sub_byte(value : Byte) -> Byte {
+  let x = value.to_int()
+  let inverse_affine = rotl8(x, 1) ^ rotl8(x, 3) ^ rotl8(x, 6) ^ 0x05
+  gf_pow(inverse_affine, 254).to_byte()
+}
+
+///|
+fn aes_rcon() -> Array[UInt] {
+  let rcon : Array[UInt] = []
+  let mut value = 1
+  for _ in 0..<=13 {
+    rcon.push(value.reinterpret_as_uint() << 24)
+    value = gf_mul(value, 2)
+  }
+  rcon
+}
+
+///|
+fn u32_from_be(bytes : BytesView, offset : Int) -> UInt {
+  let b0 = bytes[offset].to_uint()
+  let b1 = bytes[offset + 1].to_uint()
+  let b2 = bytes[offset + 2].to_uint()
+  let b3 = bytes[offset + 3].to_uint()
+  (b0 << 24) | (b1 << 16) | (b2 << 8) | b3
+}
+
+///|
+fn aes_sub_word(word : UInt) -> UInt {
+  let b0 = aes_sub_byte((word >> 24).to_byte()).to_uint()
+  let b1 = aes_sub_byte((word >> 16).to_byte()).to_uint()
+  let b2 = aes_sub_byte((word >> 8).to_byte()).to_uint()
+  let b3 = aes_sub_byte(word.to_byte()).to_uint()
+  (b0 << 24) | (b1 << 16) | (b2 << 8) | b3
+}
+
+///|
+fn aes_rot_word(word : UInt) -> UInt {
+  (word << 8) | (word >> 24)
+}
+
+///|
+let aes_rcon_cached : Array[UInt] = aes_rcon()
+
+///|
+fn aes_schedule(key : BytesView) -> AesSchedule raise CryptoError {
+  let key_len = key.length()
+  guard key_len == 16 || key_len == 24 || key_len == 32 else {
+    raise InvalidCrypto(msg="invalid AES key size")
+  }
+  let nk = key_len / 4
+  let rounds = nk + 6
+  let total_words = 4 * (rounds + 1)
+  let w : FixedArray[UInt] = FixedArray::make(total_words, 0U)
+  for i in 0..<nk {
+    w[i] = u32_from_be(key, i * 4)
+  }
+  let rcon = aes_rcon_cached
+  for i in nk..<total_words {
+    let mut temp = w[i - 1]
+    if i % nk == 0 {
+      temp = aes_sub_word(aes_rot_word(temp)) ^ rcon[i / nk - 1]
+    } else if nk > 6 && i % nk == 4 {
+      temp = aes_sub_word(temp)
+    }
+    w[i] = w[i - nk] ^ temp
+  }
+  { round_keys: w, rounds }
+}
+
+///|
+fn byte_xor(a : Byte, b : Byte) -> Byte {
+  (a.to_int() ^ b.to_int()).to_byte()
+}
+
+///|
+fn aes_add_round_key(
+  state : Array[Byte],
+  round_keys : FixedArray[UInt],
+  round : Int,
+) -> Unit {
+  let base = round * 4
+  for word_index in 0..<4 {
+    let word = round_keys[base + word_index]
+    let offset = word_index * 4
+    state[offset] = byte_xor(state[offset], (word >> 24).to_byte())
+    state[offset + 1] = byte_xor(state[offset + 1], (word >> 16).to_byte())
+    state[offset + 2] = byte_xor(state[offset + 2], (word >> 8).to_byte())
+    state[offset + 3] = byte_xor(state[offset + 3], word.to_byte())
+  }
+}
+
+///|
+fn aes_sub_bytes(state : Array[Byte]) -> Unit {
+  for i in 0..<=15 {
+    state[i] = aes_sub_byte(state[i])
+  }
+}
+
+///|
+fn aes_inv_sub_bytes(state : Array[Byte]) -> Unit {
+  for i in 0..<=15 {
+    state[i] = aes_inv_sub_byte(state[i])
+  }
+}
+
+///|
+fn aes_shift_rows(state : Array[Byte]) -> Unit {
+  let row_1 = state[1]
+  state[1] = state[5]
+  state[5] = state[9]
+  state[9] = state[13]
+  state[13] = row_1
+  let row_2_a = state[2]
+  let row_2_b = state[6]
+  state[2] = state[10]
+  state[6] = state[14]
+  state[10] = row_2_a
+  state[14] = row_2_b
+  let row_3 = state[3]
+  state[3] = state[15]
+  state[15] = state[11]
+  state[11] = state[7]
+  state[7] = row_3
+}
+
+///|
+fn aes_inv_shift_rows(state : Array[Byte]) -> Unit {
+  let row_1 = state[13]
+  state[13] = state[9]
+  state[9] = state[5]
+  state[5] = state[1]
+  state[1] = row_1
+  let row_2_a = state[2]
+  let row_2_b = state[6]
+  state[2] = state[10]
+  state[6] = state[14]
+  state[10] = row_2_a
+  state[14] = row_2_b
+  let row_3 = state[3]
+  state[3] = state[7]
+  state[7] = state[11]
+  state[11] = state[15]
+  state[15] = row_3
+}
+
+///|
+fn aes_mix_columns(state : Array[Byte]) -> Unit {
+  for column in 0..<4 {
+    let offset = column * 4
+    let s0 = state[offset].to_int()
+    let s1 = state[offset + 1].to_int()
+    let s2 = state[offset + 2].to_int()
+    let s3 = state[offset + 3].to_int()
+    state[offset] = (gf_mul(s0, 2) ^ gf_mul(s1, 3) ^ s2 ^ s3).to_byte()
+    state[offset + 1] = (s0 ^ gf_mul(s1, 2) ^ gf_mul(s2, 3) ^ s3).to_byte()
+    state[offset + 2] = (s0 ^ s1 ^ gf_mul(s2, 2) ^ gf_mul(s3, 3)).to_byte()
+    state[offset + 3] = (gf_mul(s0, 3) ^ s1 ^ s2 ^ gf_mul(s3, 2)).to_byte()
+  }
+}
+
+///|
+fn aes_inv_mix_columns(state : Array[Byte]) -> Unit {
+  for column in 0..<4 {
+    let offset = column * 4
+    let s0 = state[offset].to_int()
+    let s1 = state[offset + 1].to_int()
+    let s2 = state[offset + 2].to_int()
+    let s3 = state[offset + 3].to_int()
+    state[offset] = (gf_mul(s0, 14) ^
+    gf_mul(s1, 11) ^
+    gf_mul(s2, 13) ^
+    gf_mul(s3, 9)).to_byte()
+    state[offset + 1] = (gf_mul(s0, 9) ^
+    gf_mul(s1, 14) ^
+    gf_mul(s2, 11) ^
+    gf_mul(s3, 13)).to_byte()
+    state[offset + 2] = (gf_mul(s0, 13) ^
+    gf_mul(s1, 9) ^
+    gf_mul(s2, 14) ^
+    gf_mul(s3, 11)).to_byte()
+    state[offset + 3] = (gf_mul(s0, 11) ^
+    gf_mul(s1, 13) ^
+    gf_mul(s2, 9) ^
+    gf_mul(s3, 14)).to_byte()
+  }
+}
+
+///|
+fn aes_encrypt_state(schedule : AesSchedule, state : Array[Byte]) -> Unit {
+  aes_add_round_key(state, schedule.round_keys, 0)
+  for round in 1..<schedule.rounds {
+    aes_sub_bytes(state)
+    aes_shift_rows(state)
+    aes_mix_columns(state)
+    aes_add_round_key(state, schedule.round_keys, round)
+  }
+  aes_sub_bytes(state)
+  aes_shift_rows(state)
+  aes_add_round_key(state, schedule.round_keys, schedule.rounds)
+}
+
+///|
+fn aes_decrypt_state(schedule : AesSchedule, state : Array[Byte]) -> Unit {
+  aes_add_round_key(state, schedule.round_keys, schedule.rounds)
+  for round = schedule.rounds - 1; round > 0; round = round - 1 {
+    aes_inv_shift_rows(state)
+    aes_inv_sub_bytes(state)
+    aes_add_round_key(state, schedule.round_keys, round)
+    aes_inv_mix_columns(state)
+  }
+  aes_inv_shift_rows(state)
+  aes_inv_sub_bytes(state)
+  aes_add_round_key(state, schedule.round_keys, 0)
+}
+
+///|
+/// Encrypts a 16-byte `state` in place (used by the CBC mode for chaining,
+/// where the caller XORs before encrypting, without an intermediate copy).
+///
+/// Raises `CryptoError` if `state` is not exactly 16 bytes long.
+fn AesSchedule::encrypt_block_in_place(
+  self : AesSchedule,
+  state : Array[Byte],
+) -> Unit raise CryptoError {
+  guard state.length() == 16 else {
+    raise InvalidCrypto(msg="invalid AES block size")
+  }
+  aes_encrypt_state(self, state)
+}
+
+///|
+/// Decrypts a 16-byte `state` in place (used by the CBC mode for chaining,
+/// where the caller XORs after decrypting, without an intermediate copy).
+///
+/// Raises `CryptoError` if `state` is not exactly 16 bytes long.
+fn AesSchedule::decrypt_block_in_place(
+  self : AesSchedule,
+  state : Array[Byte],
+) -> Unit raise CryptoError {
+  guard state.length() == 16 else {
+    raise InvalidCrypto(msg="invalid AES block size")
+  }
+  aes_decrypt_state(self, state)
+}
+
+///|
+/// Encrypts `data` (a multiple of 16 bytes) with AES in ECB mode.
+/// No padding is applied; callers must pad themselves.
+///
+/// Raises `CryptoError` if `key` or `data` has an invalid length.
+pub fn aes_ecb_encrypt(
+  key : BytesView,
+  data : BytesView,
+) -> Bytes raise CryptoError {
+  let data_length = data.length()
+  guard data_length % 16 == 0 else {
+    raise InvalidCrypto(msg="invalid AES data length")
+  }
+  let schedule = aes_schedule(key)
+  let out : Array[Byte] = Array::new(capacity=data_length)
+  let state = Array::make(16, Byte::default())
+  let mut offset = 0
+  while offset < data_length {
+    for i in 0..<=15 {
+      state[i] = data[offset + i]
+    }
+    schedule.encrypt_block_in_place(state)
+    out.append(state)
+    offset = offset + 16
+  }
+  Bytes::from_array(out)
+}
+
+///|
+/// Decrypts `data` (a multiple of 16 bytes) with AES in ECB mode.
+///
+/// Raises `CryptoError` if `key` or `data` has an invalid length.
+pub fn aes_ecb_decrypt(
+  key : BytesView,
+  data : BytesView,
+) -> Bytes raise CryptoError {
+  let data_length = data.length()
+  guard data_length % 16 == 0 else {
+    raise InvalidCrypto(msg="invalid AES data length")
+  }
+  let schedule = aes_schedule(key)
+  let out : Array[Byte] = Array::new(capacity=data_length)
+  let state = Array::make(16, Byte::default())
+  let mut offset = 0
+  while offset < data_length {
+    for i in 0..<=15 {
+      state[i] = data[offset + i]
+    }
+    schedule.decrypt_block_in_place(state)
+    out.append(state)
+    offset = offset + 16
+  }
+  Bytes::from_array(out)
+}
+
+///|
+/// Encrypts `data` (a multiple of 16 bytes) with AES in CBC mode.
+/// No padding is applied; callers must pad themselves.
+///
+/// Raises `CryptoError` if `key`, `iv` or `data` has an invalid length.
+pub fn aes_cbc_encrypt(
+  key : BytesView,
+  iv : BytesView,
+  data : BytesView,
+) -> Bytes raise CryptoError {
+  guard iv.length() == 16 else {
+    raise InvalidCrypto(msg="invalid AES IV length")
+  }
+  let data_length = data.length()
+  guard data_length % 16 == 0 else {
+    raise InvalidCrypto(msg="invalid AES data length")
+  }
+  let schedule = aes_schedule(key)
+  let out : Array[Byte] = Array::new(capacity=data_length)
+  let prev = iv.to_array()
+  let state = Array::make(16, Byte::default())
+  let mut offset = 0
+  while offset < data_length {
+    for i in 0..<=15 {
+      state[i] = byte_xor(data[offset + i], prev[i])
+    }
+    schedule.encrypt_block_in_place(state)
+    out.append(state)
+    for i in 0..<=15 {
+      prev[i] = state[i]
+    }
+    offset = offset + 16
+  }
+  Bytes::from_array(out)
+}
+
+///|
+/// Decrypts `data` (a multiple of 16 bytes) with AES in CBC mode.
+///
+/// Raises `CryptoError` if `key`, `iv` or `data` has an invalid length.
+pub fn aes_cbc_decrypt(
+  key : BytesView,
+  iv : BytesView,
+  data : BytesView,
+) -> Bytes raise CryptoError {
+  guard iv.length() == 16 else {
+    raise InvalidCrypto(msg="invalid AES IV length")
+  }
+  let data_length = data.length()
+  guard data_length % 16 == 0 else {
+    raise InvalidCrypto(msg="invalid AES data length")
+  }
+  let schedule = aes_schedule(key)
+  let out : Array[Byte] = Array::new(capacity=data_length)
+  let prev = iv.to_array()
+  let state = Array::make(16, Byte::default())
+  let mut offset = 0
+  while offset < data_length {
+    for i in 0..<=15 {
+      state[i] = data[offset + i]
+    }
+    schedule.decrypt_block_in_place(state)
+    for i in 0..<=15 {
+      state[i] = byte_xor(state[i], prev[i])
+      prev[i] = data[offset + i]
+    }
+    out.append(state)
+    offset = offset + 16
+  }
+  Bytes::from_array(out)
+}

--- a/crypto/aes_test.mbt
+++ b/crypto/aes_test.mbt
@@ -1,0 +1,103 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn aestest_ecb(key : BytesView, data : BytesView) -> String raise CryptoError {
+  bytes_to_hex_string(@crypto.aes_ecb_encrypt(key, data))
+}
+
+///|
+test "aes_fips197_vectors" { // FIPS 197 Appendix C
+  let pt = b"\x00\x11\x22\x33\x44\x55\x66\x77\x88\x99\xaa\xbb\xcc\xdd\xee\xff"
+  inspect(
+    aestest_ecb(
+      b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f", pt,
+    ),
+    content="69c4e0d86a7b0430d8cdb78070b4c55a",
+  )
+  inspect(
+    aestest_ecb(
+      b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17",
+      pt,
+    ),
+    content="dda97ca4864cdfe06eaf70a0ec0d7191",
+  )
+  inspect(
+    aestest_ecb(
+      b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f",
+      pt,
+    ),
+    content="8ea2b7ca516745bfeafc49904b496089",
+  )
+}
+
+///|
+test "aes ecb roundtrip (128/192/256)" {
+  let data = b"0123456789abcdef0123456789abcdef"
+  let key128 = b"0123456789abcdef"
+  let key192 = b"0123456789abcdef01234567"
+  let key256 = b"0123456789abcdef0123456789abcdef"
+  let ecb128 = @crypto.aes_ecb_encrypt(key128, data)
+  let ecb128_dec = @crypto.aes_ecb_decrypt(key128, ecb128)
+  inspect(ecb128_dec, content="b\"0123456789abcdef0123456789abcdef\"")
+  let ecb192 = @crypto.aes_ecb_encrypt(key192, data)
+  let ecb192_dec = @crypto.aes_ecb_decrypt(key192, ecb192)
+  inspect(ecb192_dec, content="b\"0123456789abcdef0123456789abcdef\"")
+  let ecb256 = @crypto.aes_ecb_encrypt(key256, data)
+  let ecb256_dec = @crypto.aes_ecb_decrypt(key256, ecb256)
+  inspect(ecb256_dec, content="b\"0123456789abcdef0123456789abcdef\"")
+}
+
+///|
+test "aes cbc" {
+  let key = b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f"
+  let iv = b"\x00\x11\x22\x33\x44\x55\x66\x77\x88\x99\xaa\xbb\xcc\xdd\xee\xff"
+  let data = b"\x00\x11\x22\x33\x44\x55\x66\x77\x88\x99\xaa\xbb\xcc\xdd\xee\xff\x00\x11\x22\x33\x44\x55\x66\x77\x88\x99\xaa\xbb\xcc\xdd\xee\xff"
+  let enc = @crypto.aes_cbc_encrypt(key, iv, data)
+  inspect(
+    bytes_to_hex_string(enc),
+    content="c6a13b37878f5b826f4f8162a1c8d8798d4df1c219d7c77049d4ea996ce7ae4c",
+  )
+  let dec = @crypto.aes_cbc_decrypt(key, iv, enc)
+  inspect(
+    bytes_to_hex_string(dec),
+    content="00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
+  )
+}
+
+///|
+test "aes invalid key/iv/data lengths" {
+  let key128 = b"0123456789abcdef"
+  let data = b"0123456789abcdef0123456789abcdef"
+  try @crypto.aes_ecb_encrypt(b"short", data) catch {
+    e => inspect(e is @crypto.CryptoError::InvalidCrypto(_), content="true")
+  } noraise {
+    _ => fail("expected aes_ecb_encrypt to raise")
+  }
+  try @crypto.aes_ecb_encrypt(key128, b"123") catch {
+    e => inspect(e is @crypto.CryptoError::InvalidCrypto(_), content="true")
+  } noraise {
+    _ => fail("expected aes_ecb_encrypt to raise")
+  }
+  try @crypto.aes_cbc_decrypt(key128, b"iv", data) catch {
+    e => inspect(e is @crypto.CryptoError::InvalidCrypto(_), content="true")
+  } noraise {
+    _ => fail("expected aes_cbc_decrypt to raise")
+  }
+  try @crypto.aes_cbc_encrypt(key128, b"0000000000000000", b"123") catch {
+    e => inspect(e is @crypto.CryptoError::InvalidCrypto(_), content="true")
+  } noraise {
+    _ => fail("expected aes_cbc_encrypt to raise")
+  }
+}

--- a/crypto/chacha.mbt
+++ b/crypto/chacha.mbt
@@ -295,7 +295,7 @@ pub fn[Data : ByteSource] chacha8(
   block : Data,
   nonce? : UInt = 0,
 ) -> FixedArray[Byte] raise Error {
-  if key.length() != 8 {
+  guard key.length() == 8 else {
     fail("Invalid key length -- key must be 8 32-bit unsigned integers")
   }
   chacha(key.map(flipWord), counter, block, 4, [nonce, nonce, nonce])
@@ -315,7 +315,7 @@ pub fn[Data : ByteSource] chacha12(
   block : Data,
   nonce? : UInt = 0,
 ) -> FixedArray[Byte] raise Error {
-  if key.length() != 8 {
+  guard key.length() == 8 else {
     fail("Invalid key length -- key must be 8 32-bit unsigned integers")
   }
   chacha(key.map(flipWord), counter, block, 6, [nonce, nonce, nonce])
@@ -335,7 +335,7 @@ pub fn[Data : ByteSource] chacha20(
   block : Data,
   nonce? : UInt = 0,
 ) -> FixedArray[Byte] raise Error {
-  if key.length() != 8 {
+  guard key.length() == 8 else {
     fail("Invalid key length -- key must be 8 32-bit unsigned integers")
   }
   chacha(key.map(flipWord), counter, block, 10, [nonce, nonce, nonce])
@@ -350,12 +350,16 @@ fn[Data : ByteSource] chacha(
   round : UInt,
   nonce : FixedArray[UInt],
 ) -> FixedArray[Byte] {
-  if block.length() == 0 {
-    return FixedArray::make(0, Byte::default())
+  let block_length = block.length()
+  guard block_length > 0 else { FixedArray::make(0, Byte::default()) }
+  let block_count = (block_length - 1) / 64 + 1
+  let available_blocks = 0x100000000UL - counter.to_uint64()
+  guard block_count.to_uint64() <= available_blocks else {
+    abort("ChaCha counter exhausted")
   }
-  let buffer = FixedArray::make(block.length(), Byte::default())
+  let buffer = FixedArray::make(block_length, Byte::default())
   let key_stream = FixedArray::make(64, b'\x00')
-  for i = 0; i < block.length(); i = i + 64 {
+  for i = 0; i < block_length; i = i + 64 {
     chachaBlock(
       key,
       counter + i.reinterpret_as_uint() / 64,
@@ -363,10 +367,17 @@ fn[Data : ByteSource] chacha(
       round,
       key_stream,
     )
-    let len = @cmp.minimum(block.length() - i, 64)
+    let len = @cmp.minimum(block_length - i, 64)
     chacha_xor_into(block, i, buffer, i, key_stream, 0, len)
   }
   buffer
+}
+
+///|
+/// Errors raised by ChaCha operations.
+pub suberror ChaChaError {
+  CounterExhausted
+  InvalidOutputRange
 }
 
 ///|
@@ -375,6 +386,7 @@ struct ChaCha {
   nonce : FixedArray[UInt]
   key_stream : FixedArray[Byte]
   mut counter : UInt
+  mut exhausted : Bool
   mut offset : Int
   round : UInt
 }
@@ -386,10 +398,10 @@ fn[K : ByteSource, N : ByteSource] ChaCha::new(
   round : UInt,
   counter : UInt,
 ) -> ChaCha raise Error {
-  if key.length() != 32 {
+  guard key.length() == 32 else {
     fail("Invalid key length -- key must be 256 bits")
   }
-  if nonce.length() != 12 {
+  guard nonce.length() == 12 else {
     fail("Invalid nonce length -- nonce must be 96 bits")
   }
   let key_ = FixedArray::make(8, 0U)
@@ -413,6 +425,7 @@ fn[K : ByteSource, N : ByteSource] ChaCha::new(
     round,
     offset: 64,
     counter,
+    exhausted: false,
   }
 }
 
@@ -462,19 +475,45 @@ pub fn[K : ByteSource, N : ByteSource] ChaCha::chacha20(
 }
 
 ///|
-/// Transforms the given data using the ChaCha encryption algorithm.
-/// - [data] is the data to be transformed.
-/// - [target] is the output buffer to store the transformed data.
-/// - [offset] is the offset in the target buffer where the transformed data will be written
-/// 
-/// If the length of [data] is less then the length of [target] minus [offset], it will panic.
-pub fn[D : ByteSource] ChaCha::transform(
+fn ChaCha::can_transform(self : ChaCha, data_length : Int) -> Bool {
+  let buffered_bytes = if self.offset < 64 { 64 - self.offset } else { 0 }
+  guard data_length > buffered_bytes else { true }
+  guard !self.exhausted else { false }
+  let remaining_bytes = data_length - buffered_bytes
+  let required_blocks = (remaining_bytes - 1) / 64 + 1
+  let available_blocks = 0x100000000UL - self.counter.to_uint64()
+  required_blocks.to_uint64() <= available_blocks
+}
+
+///|
+fn target_has_capacity(
+  target : FixedArray[Byte],
+  offset : Int,
+  data_length : Int,
+) -> Bool {
+  guard offset >= 0 && offset <= target.length() else { false }
+  data_length <= target.length() - offset
+}
+
+///|
+fn ChaCha::generate_block(self : ChaCha) -> Unit {
+  guard! !self.exhausted
+  chachaBlock(self.key, self.counter, self.nonce, self.round, self.key_stream)
+  if self.counter == 0xffffffff {
+    self.exhausted = true
+  } else {
+    self.counter += 1
+  }
+}
+
+///|
+fn[D : ByteSource] ChaCha::transform_unchecked(
   self : Self,
   data : D,
   target : FixedArray[Byte],
-  offset? : Int = 0,
+  offset : Int,
+  data_length : Int,
 ) -> Unit {
-  let data_length = data.length()
   let remaining_offset = if self.offset < 64 {
     let length = @cmp.minimum(data_length, 64 - self.offset)
     chacha_xor_into(
@@ -492,8 +531,7 @@ pub fn[D : ByteSource] ChaCha::transform(
     0
   }
   for input_offset = remaining_offset; input_offset + 64 <= data_length; {
-    chachaBlock(self.key, self.counter, self.nonce, self.round, self.key_stream)
-    self.counter += 1
+    self.generate_block()
     chacha_xor_into(
       data,
       input_offset,
@@ -506,14 +544,7 @@ pub fn[D : ByteSource] ChaCha::transform(
     continue input_offset + 64
   } nobreak {
     if input_offset < data_length {
-      chachaBlock(
-        self.key,
-        self.counter,
-        self.nonce,
-        self.round,
-        self.key_stream,
-      )
-      self.counter += 1
+      self.generate_block()
       self.offset = data_length - input_offset
       chacha_xor_into(
         data,
@@ -526,4 +557,46 @@ pub fn[D : ByteSource] ChaCha::transform(
       )
     }
   }
+}
+
+///|
+/// Transforms `data` with ChaCha and writes it into `target` at `offset`.
+///
+/// Aborts if `target` does not have room for the output or if the 32-bit block
+/// counter would be exhausted. Use `transform_checked` when the caller needs
+/// to handle these conditions.
+pub fn[D : ByteSource] ChaCha::transform(
+  self : Self,
+  data : D,
+  target : FixedArray[Byte],
+  offset? : Int = 0,
+) -> Unit {
+  let data_length = data.length()
+  guard target_has_capacity(target, offset, data_length) else {
+    abort("invalid ChaCha target range")
+  }
+  guard self.can_transform(data_length) else {
+    abort("ChaCha counter exhausted")
+  }
+  self.transform_unchecked(data, target, offset, data_length)
+}
+
+///|
+/// Transforms `data` with ChaCha and writes it into `target` at `offset`.
+///
+/// Raises `ChaChaError::InvalidOutputRange` or
+/// `ChaChaError::CounterExhausted` before writing any output if the target
+/// range is invalid or the operation would exhaust the 32-bit block counter.
+pub fn[D : ByteSource] ChaCha::transform_checked(
+  self : Self,
+  data : D,
+  target : FixedArray[Byte],
+  offset? : Int = 0,
+) -> Unit raise ChaChaError {
+  let data_length = data.length()
+  guard target_has_capacity(target, offset, data_length) else {
+    raise InvalidOutputRange
+  }
+  guard self.can_transform(data_length) else { raise CounterExhausted }
+  self.transform_unchecked(data, target, offset, data_length)
 }

--- a/crypto/chacha_test.mbt
+++ b/crypto/chacha_test.mbt
@@ -56,6 +56,64 @@ test "chacha with error" {
 }
 
 ///|
+test "chacha rejects counter exhaustion before writing output" {
+  let cipher = @crypto.ChaCha::chacha20(
+    Bytes::make(32, b'\x00'),
+    Bytes::make(12, b'\x00'),
+    counter=0xffffffff,
+  )
+  let output = FixedArray::make(65, b'\xaa')
+  let error = @test.expect_error(() => {
+    cipher.transform_checked(FixedArray::make(65, b'\x00'), output)
+  })
+  inspect(error is @crypto.ChaChaError::CounterExhausted, content="true")
+  inspect(output[0], content="b'\\xAA'")
+  inspect(output[64], content="b'\\xAA'")
+  let last_block = @crypto.ChaCha::chacha20(
+    Bytes::make(32, b'\x00'),
+    Bytes::make(12, b'\x00'),
+    counter=0xffffffff,
+  )
+  last_block.transform_checked(
+    FixedArray::make(1, b'\x00'),
+    FixedArray::make(1, b'\x00'),
+  )
+  last_block.transform_checked(
+    FixedArray::make(63, b'\x00'),
+    FixedArray::make(63, b'\x00'),
+  )
+  @test.assert_raise(() => {
+    last_block.transform_checked(
+      FixedArray::make(1, b'\x00'),
+      FixedArray::make(1, b'\x00'),
+    )
+  })
+}
+
+///|
+test "chacha rejects a short target before advancing state" {
+  let key = Bytes::make(32, b'\x00')
+  let nonce = Bytes::make(12, b'\x00')
+  let cipher = ChaCha::chacha20(key, nonce)
+  let target = FixedArray::make(64, b'\xaa')
+  let error = @test.expect_error(() => {
+    cipher.transform_checked(FixedArray::make(65, b'\x00'), target)
+  })
+  @test.assert_eq(error is @crypto.ChaChaError::InvalidOutputRange, true)
+  @test.assert_eq(target[0], b'\xaa')
+  @test.assert_eq(target[63], b'\xaa')
+
+  let output = FixedArray::make(64, b'\x00')
+  cipher.transform_checked(FixedArray::make(64, b'\x00'), output)
+  let expected = FixedArray::make(64, b'\x00')
+  ChaCha::chacha20(key, nonce).transform_checked(
+    FixedArray::make(64, b'\x00'),
+    expected,
+  )
+  @test.assert_eq(bytes_to_hex_string(output), bytes_to_hex_string(expected))
+}
+
+///|
 test (bench : @bench.T) {
   let key = Bytes::make(32, b'\x00')
   let nonce = Bytes::make(12, b'\x00')

--- a/crypto/crypto_bench_test.mbt
+++ b/crypto/crypto_bench_test.mbt
@@ -45,6 +45,36 @@ test "bench MD5 64 KiB" (it : @bench.T) {
 }
 
 ///|
+test "bench MD4 64 KiB" (it : @bench.T) {
+  let input = crypto_bench_input()
+  it.bench(fn() { it.keep(@crypto.md4(input)) })
+}
+
+///|
+test "bench RIPEMD-160 64 KiB" (it : @bench.T) {
+  let input = crypto_bench_input()
+  it.bench(fn() { it.keep(@crypto.ripemd160(input)) })
+}
+
+///|
+test "bench SHA-512 64 KiB" (it : @bench.T) {
+  let input = crypto_bench_input()
+  it.bench(fn() { it.keep(@crypto.sha512(input)) })
+}
+
+///|
+test "bench AES-128 ECB 64 KiB" (it : @bench.T) {
+  let key = b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f"
+  let input = crypto_bench_input()
+  it.bench(fn() {
+    let out = @crypto.aes_ecb_encrypt(key, input.unsafe_reinterpret_as_bytes()) catch {
+      _ => Default::default()
+    }
+    it.keep(out)
+  })
+}
+
+///|
 test "bench ChaCha20 64 KiB" (it : @bench.T) {
   let key = FixedArray::make(32, b'\x00')
   let nonce = FixedArray::make(12, b'\x00')

--- a/crypto/md4.mbt
+++ b/crypto/md4.mbt
@@ -1,0 +1,335 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// An MD4 message-digest algorithm implementation based on
+// [RFC1320]       https://www.ietf.org/rfc/rfc1320.txt
+// Note that MD4 is considered _cryptographically broken_.
+// Unless mandated, more secure alternatives should be preferred.
+
+///|
+struct MD4 {
+  reg : FixedArray[UInt] // state 'a' 'b' 'c' 'd'
+  mut len : UInt64
+  buf : FixedArray[Byte]
+  mut buf_index : Int
+}
+
+///|
+pub impl CryptoHasher for MD4 with fn size(_self : MD4) -> Int {
+  16
+}
+
+///|
+pub impl CryptoHasher for MD4 with fn block_size(_self : MD4) -> Int {
+  64
+}
+
+///|
+pub impl CryptoHasher for MD4 with fn reset(self : MD4) -> Unit {
+  self.reg[0] = 0x67452301
+  self.reg[1] = 0xefcdab89
+  self.reg[2] = 0x98badcfe
+  self.reg[3] = 0x10325476
+  self.len = 0
+  self.buf.fill(0)
+  self.buf_index = 0
+}
+
+///|
+/// Instantiate an MD4 context
+pub fn MD4::new() -> MD4 {
+  {
+    reg: [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476],
+    len: 0,
+    buf: FixedArray::make(64, Byte::default()),
+    buf_index: 0,
+  }
+}
+
+// no macros, nor inline. basic md4 functions
+// three auxiliary functions
+//          F(X,Y,Z) = XY v not(X) Z
+//          G(X,Y,Z) = XY v XZ v YZ
+//          H(X,Y,Z) = X xor Y xor Z
+
+///|
+fn MD4::f(x : UInt, y : UInt, z : UInt) -> UInt {
+  (x & y) | (x.lnot() & z)
+}
+
+///|
+fn MD4::g(x : UInt, y : UInt, z : UInt) -> UInt {
+  (x & y) | (x & z) | (y & z)
+}
+
+///|
+fn MD4::h(x : UInt, y : UInt, z : UInt) -> UInt {
+  x ^ y ^ z
+}
+
+///|
+fn MD4::ff(a : UInt, b : UInt, c : UInt, d : UInt, x : UInt, s : Int) -> UInt {
+  rotate_left_u(a + MD4::f(b, c, d) + x, s)
+}
+
+///|
+fn MD4::gg(a : UInt, b : UInt, c : UInt, d : UInt, x : UInt, s : Int) -> UInt {
+  rotate_left_u(a + MD4::g(b, c, d) + x + 0x5a827999, s)
+}
+
+///|
+fn MD4::hh(a : UInt, b : UInt, c : UInt, d : UInt, x : UInt, s : Int) -> UInt {
+  rotate_left_u(a + MD4::h(b, c, d) + x + 0x6ed9eba1, s)
+}
+
+///|
+#inline
+fn MD4::transform(state : FixedArray[UInt], input : FixedArray[UInt]) -> Unit {
+  // parse_le_u32x16_into always supplies exactly 16 words; every constant
+  // word index used by the rounds below is therefore in bounds.
+  let mut a = state[0]
+  let mut b = state[1]
+  let mut c = state[2]
+  let mut d = state[3]
+
+  // Round 1
+  // s[ 0..15] := { 3, 7, 11, 19, 3, 7, 11, 19, ... }
+  a = MD4::ff(a, b, c, d, input.unsafe_get(0), 3)
+  d = MD4::ff(d, a, b, c, input.unsafe_get(1), 7)
+  c = MD4::ff(c, d, a, b, input.unsafe_get(2), 11)
+  b = MD4::ff(b, c, d, a, input.unsafe_get(3), 19)
+  a = MD4::ff(a, b, c, d, input.unsafe_get(4), 3)
+  d = MD4::ff(d, a, b, c, input.unsafe_get(5), 7)
+  c = MD4::ff(c, d, a, b, input.unsafe_get(6), 11)
+  b = MD4::ff(b, c, d, a, input.unsafe_get(7), 19)
+  a = MD4::ff(a, b, c, d, input.unsafe_get(8), 3)
+  d = MD4::ff(d, a, b, c, input.unsafe_get(9), 7)
+  c = MD4::ff(c, d, a, b, input.unsafe_get(10), 11)
+  b = MD4::ff(b, c, d, a, input.unsafe_get(11), 19)
+  a = MD4::ff(a, b, c, d, input.unsafe_get(12), 3)
+  d = MD4::ff(d, a, b, c, input.unsafe_get(13), 7)
+  c = MD4::ff(c, d, a, b, input.unsafe_get(14), 11)
+  b = MD4::ff(b, c, d, a, input.unsafe_get(15), 19)
+
+  // Round 2
+  // message index := { 0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15 }
+  // s[16..31] := { 3, 5, 9, 13, 3, 5, 9, 13, ... }
+  a = MD4::gg(a, b, c, d, input.unsafe_get(0), 3)
+  d = MD4::gg(d, a, b, c, input.unsafe_get(4), 5)
+  c = MD4::gg(c, d, a, b, input.unsafe_get(8), 9)
+  b = MD4::gg(b, c, d, a, input.unsafe_get(12), 13)
+  a = MD4::gg(a, b, c, d, input.unsafe_get(1), 3)
+  d = MD4::gg(d, a, b, c, input.unsafe_get(5), 5)
+  c = MD4::gg(c, d, a, b, input.unsafe_get(9), 9)
+  b = MD4::gg(b, c, d, a, input.unsafe_get(13), 13)
+  a = MD4::gg(a, b, c, d, input.unsafe_get(2), 3)
+  d = MD4::gg(d, a, b, c, input.unsafe_get(6), 5)
+  c = MD4::gg(c, d, a, b, input.unsafe_get(10), 9)
+  b = MD4::gg(b, c, d, a, input.unsafe_get(14), 13)
+  a = MD4::gg(a, b, c, d, input.unsafe_get(3), 3)
+  d = MD4::gg(d, a, b, c, input.unsafe_get(7), 5)
+  c = MD4::gg(c, d, a, b, input.unsafe_get(11), 9)
+  b = MD4::gg(b, c, d, a, input.unsafe_get(15), 13)
+
+  // Round 3
+  // message index := { 0, 8, 4, 12, 2, 10, 6, 14, 1, 9, 5, 13, 3, 11, 7, 15 }
+  // s[32..47] := { 3, 9, 11, 15, 3, 9, 11, 15, ... }
+  a = MD4::hh(a, b, c, d, input.unsafe_get(0), 3)
+  d = MD4::hh(d, a, b, c, input.unsafe_get(8), 9)
+  c = MD4::hh(c, d, a, b, input.unsafe_get(4), 11)
+  b = MD4::hh(b, c, d, a, input.unsafe_get(12), 15)
+  a = MD4::hh(a, b, c, d, input.unsafe_get(2), 3)
+  d = MD4::hh(d, a, b, c, input.unsafe_get(10), 9)
+  c = MD4::hh(c, d, a, b, input.unsafe_get(6), 11)
+  b = MD4::hh(b, c, d, a, input.unsafe_get(14), 15)
+  a = MD4::hh(a, b, c, d, input.unsafe_get(1), 3)
+  d = MD4::hh(d, a, b, c, input.unsafe_get(9), 9)
+  c = MD4::hh(c, d, a, b, input.unsafe_get(5), 11)
+  b = MD4::hh(b, c, d, a, input.unsafe_get(13), 15)
+  a = MD4::hh(a, b, c, d, input.unsafe_get(3), 3)
+  d = MD4::hh(d, a, b, c, input.unsafe_get(11), 9)
+  c = MD4::hh(c, d, a, b, input.unsafe_get(7), 11)
+  b = MD4::hh(b, c, d, a, input.unsafe_get(15), 15)
+
+  state[0] += a
+  state[1] += b
+  state[2] += c
+  state[3] += d
+}
+
+///|
+pub fn MD4::update_from_iter(self : MD4, data : Iter[Byte]) -> Unit {
+  let input = FixedArray::make(16, 0U)
+  data.each(fn(b) {
+    self.buf[self.buf_index] = b
+    self.buf_index += 1
+    if self.buf_index == 64 {
+      self.buf_index = 0
+      self.len += 512UL
+      parse_le_u32x16_into(self.buf, 0, input)
+      MD4::transform(self.reg, input)
+    }
+  })
+}
+
+///|
+pub impl CryptoHasher for MD4 with fn update(self : MD4, data : BytesView) -> Unit {
+  self.update(data)
+}
+
+///|
+/// update the state of given context from new `data`
+pub fn[Data : ByteSource] MD4::update(self : MD4, data : Data) -> Unit {
+  let input = FixedArray::make(16, 0U)
+  let data_len = data.length()
+  let mut offset = 0
+  while offset < data_len {
+    let min_len = @cmp.minimum(64 - self.buf_index, data_len - offset)
+    data.blit_to(
+      self.buf,
+      len=min_len,
+      src_offset=offset,
+      dst_offset=self.buf_index,
+    )
+    self.buf_index += min_len
+    if self.buf_index == 64 {
+      self.len += 512UL
+      self.buf_index = 0
+      parse_le_u32x16_into(self.buf, 0, input)
+      MD4::transform(self.reg, input)
+    }
+    offset += min_len
+  }
+}
+
+///|
+pub fn MD4::finalize(self : MD4) -> FixedArray[Byte] {
+  let ret = FixedArray::make(16, Byte::default())
+  self._finalize_into(ret)
+  ret
+}
+
+///|
+fn MD4::_finalize_into(
+  self : MD4,
+  buffer : FixedArray[Byte],
+  offset? : Int = 0,
+) -> Unit {
+  // Copy data
+  let data = FixedArray::make(64, Byte::default())
+  let input = FixedArray::make(16, 0U)
+  let mut cnt = self.buf_index
+  let len = self.len + 8 * cnt.to_uint64()
+  self.buf.blit_to(data, len=cnt)
+  let reg = self.reg.copy()
+
+  // Padding
+  data[cnt] = b'\x80'
+  cnt += 1
+  if cnt > 56 {
+    parse_le_u32x16_into(data, 0, input)
+    MD4::transform(reg, input)
+    data.fill(0)
+  }
+  // little-endian 64-bit bit length at bytes 56..64
+  data.unsafe_set(56, len.to_byte())
+  data.unsafe_set(57, (len >> 8).to_byte())
+  data.unsafe_set(58, (len >> 16).to_byte())
+  data.unsafe_set(59, (len >> 24).to_byte())
+  data.unsafe_set(60, (len >> 32).to_byte())
+  data.unsafe_set(61, (len >> 40).to_byte())
+  data.unsafe_set(62, (len >> 48).to_byte())
+  data.unsafe_set(63, (len >> 56).to_byte())
+  parse_le_u32x16_into(data, 0, input)
+  MD4::transform(reg, input)
+
+  // Write result to buffer
+  arr_u32_to_u8le_into(reg.iter(), buffer, offset)
+}
+
+///|
+pub impl CryptoHasher for MD4 with fn finalize_into(
+  self : MD4,
+  buffer : FixedArray[Byte],
+  offset~ : Int,
+) -> Unit {
+  self._finalize_into(buffer, offset~)
+}
+
+///|
+/// Compute the MD4 digest of some `data` based on [RFC1320](https://www.ietf.org/rfc/rfc1320.txt).
+/// - Note that MD4 is considered _cryptographically broken_.
+/// Unless mandated, more secure alternatives should be preferred.
+pub fn[Data : ByteSource] md4(data : Data) -> FixedArray[Byte] {
+  MD4::new()..update(data).finalize()
+}
+
+///|
+pub fn md4_from_iter(data : Iter[Byte]) -> FixedArray[Byte] {
+  MD4::new()..update_from_iter(data).finalize()
+}
+
+///|
+test {
+  inspect(
+    bytes_to_hex_string(
+      md4(
+        b"\x61\x62\x63", // abc in utf-8
+      ),
+    ),
+    content="a448017aaf21d8525fc10ae87aa6729d",
+  )
+  inspect(
+    bytes_to_hex_string(md4(b"")),
+    content="31d6cfe0d16ae931b73c59d7e0c089c0",
+  )
+  let hash1 = "a448017aaf21d8525fc10ae87aa6729d"
+  let ctx = MD4::new()
+  ctx.update(b"\x61".to_fixedarray())
+  ctx.update(b"\x62".to_fixedarray())
+  ctx.update(b"\x63".to_fixedarray())
+  assert_eq(hash1, bytes_to_hex_string(ctx.finalize()))
+  let ctx = MD4::new()
+  for i = 0; i < 3; i = i + 1 {
+    ctx.update_from_iter(b"\x61\x62\x63".iter())
+  }
+  inspect(
+    bytes_to_hex_string(ctx.finalize()),
+    content="97cf4baebc21aa502825d9b44dd6e637",
+  )
+}
+
+///|
+test "md4 reentry" {
+  let string = b"abcd"
+  let ctx = MD4::new()
+  ctx.update(string)
+  inspect(
+    bytes_to_hex_string(ctx.finalize()),
+    content="41decd8f579255c5200f86a4bb3ba740",
+  )
+  ctx.update(string)
+  inspect(
+    bytes_to_hex_string(ctx.finalize()),
+    content="820124ba08babea2f3bf961811f2cfd6",
+  )
+  ctx.update(string)
+  inspect(
+    bytes_to_hex_string(ctx.finalize()),
+    content="5d595c82c583af827ffa883ad86a4dab",
+  )
+}
+
+///|
+pub extend MD4 with CryptoHasher::{reset, finalize_into, size, block_size}

--- a/crypto/md5.mbt
+++ b/crypto/md5.mbt
@@ -20,13 +20,11 @@
 ///|
 #alias(MD5Context, deprecated="Use `MD5` instead")
 struct MD5 {
-  mut state : FixedArray[UInt] // state 'a' 'b' 'c' 'd'
-  mut count : FixedArray[UInt]
-  mut buffer : FixedArray[Byte]
+  reg : FixedArray[UInt] // state 'a' 'b' 'c' 'd'
+  mut len : UInt64
+  buf : FixedArray[Byte]
+  mut buf_index : Int
 }
-
-///|
-let padding : FixedArray[Byte] = FixedArray::make(64, Byte::default())
 
 ///|
 #inline
@@ -57,9 +55,13 @@ pub impl CryptoHasher for MD5 with fn block_size(_self : MD5) -> Int {
 
 ///|
 pub impl CryptoHasher for MD5 with fn reset(self : MD5) -> Unit {
-  self.state = [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476]
-  self.count = [0, 0]
-  self.buffer = FixedArray::make(64, Byte::default())
+  self.reg[0] = 0x67452301
+  self.reg[1] = 0xefcdab89
+  self.reg[2] = 0x98badcfe
+  self.reg[3] = 0x10325476
+  self.len = 0
+  self.buf.fill(0)
+  self.buf_index = 0
 }
 
 ///|
@@ -85,45 +87,49 @@ pub impl CryptoHasher for MD5 with fn finalize_into(
   buffer : FixedArray[Byte],
   offset~ : Int,
 ) -> Unit {
-  self.md5_compute().blit_to(buffer, len=16, src_offset=offset)
+  self.md5_compute().blit_to(buffer, len=16, src_offset=0, dst_offset=offset)
 }
 
 ///|
 /// Instantiate a MD5 context
 pub fn MD5::new() -> MD5 {
-  padding[0] = b'\x80'
   {
-    state: [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476],
-    count: [0, 0],
-    buffer: FixedArray::make(64, Byte::default()),
+    reg: [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476],
+    len: 0,
+    buf: FixedArray::make(64, Byte::default()),
+    buf_index: 0,
   }
 }
 
 ///|
 /// compute MD5 digest from given context
 fn MD5::md5_compute(self : MD5) -> FixedArray[Byte] {
-  let idx = ((self.count[0] >> 3) & 0x3f).reinterpret_as_int()
-  let count_low = self.count[0]
-  let count_high = self.count[1]
-  let bytes_slice = if idx < 56 {
-    let bytes_slice = FixedArray::make(56 - idx + 1, Byte::default())
-    padding.blit_to(bytes_slice, len=56 - idx + 1)
-    bytes_slice
-  } else {
-    let bytes_slice = FixedArray::make(120 - idx + 1, Byte::default())
-    padding.blit_to(bytes_slice, len=120 - idx + 1)
-    bytes_slice
+  let data = FixedArray::make(64, Byte::default())
+  let mut cnt = self.buf_index
+  let len = self.len + 8 * cnt.to_uint64()
+  // Build the padded final block(s) on a copy so that `finalize` stays
+  // idempotent and the context remains usable afterwards.
+  self.buf.blit_to(data, len=cnt)
+  let reg = self.reg.copy()
+  data[cnt] = b'\x80'
+  cnt += 1
+  if cnt > 56 {
+    let input = FixedArray::make(16, 0U)
+    load_md5_words(data, input)
+    md5_transform(reg, input)
+    data.fill(0)
   }
-  md5_update(self, bytes_slice)
+  // little-endian 64-bit bit length at bytes 56..64
+  for i in 0..<8 {
+    data.unsafe_set(56 + i, (len >> (8 * i)).to_byte())
+  }
   let input = FixedArray::make(16, 0U)
-  load_md5_words(self.buffer, input)
-  input.unsafe_set(14, count_low)
-  input.unsafe_set(15, count_high)
-  md5_transform(self.state, input)
+  load_md5_words(data, input)
+  md5_transform(reg, input)
   let digest = FixedArray::make(16, Byte::default())
   // The MD5 state and digest have fixed four-word and 16-byte widths.
   for lane in 0..<4 {
-    let word = self.state.unsafe_get(lane)
+    let word = reg.unsafe_get(lane)
     let offset = lane * 4
     digest.unsafe_set(offset, word.to_byte())
     digest.unsafe_set(offset + 1, (word >> 8).to_byte())
@@ -163,29 +169,23 @@ fn MD5::i(x : UInt, y : UInt, z : UInt) -> UInt {
 ///|
 fn[Data : ByteSource] md5_update(ctx : MD5, data : Data) -> Unit {
   let input = FixedArray::make(16, 0U)
-  let mut idx = ((ctx.count[0] >> 3) & 0x3f).reinterpret_as_int()
-  let length = data.length()
-  let mod_length = length.reinterpret_as_uint() << 3
-  ctx.count[0] += mod_length
-  if ctx.count[0] < mod_length {
-    ctx.count[1] += 1
-  }
-  ctx.count[1] += length.reinterpret_as_uint() >> 29
+  let data_len = data.length()
   let mut offset = 0
-  while offset < length {
-    let chunk_length = @cmp.minimum(64 - idx, length - offset)
+  while offset < data_len {
+    let chunk_length = @cmp.minimum(64 - ctx.buf_index, data_len - offset)
     data.blit_to(
-      ctx.buffer,
+      ctx.buf,
       len=chunk_length,
       src_offset=offset,
-      dst_offset=idx,
+      dst_offset=ctx.buf_index,
     )
-    idx += chunk_length
+    ctx.buf_index += chunk_length
     offset += chunk_length
-    if idx == 0x40 {
-      load_md5_words(ctx.buffer, input)
-      md5_transform(ctx.state, input)
-      idx = 0
+    if ctx.buf_index == 64 {
+      ctx.len += 512UL
+      ctx.buf_index = 0
+      load_md5_words(ctx.buf, input)
+      md5_transform(ctx.reg, input)
     }
   }
 }

--- a/crypto/md5_test.mbt
+++ b/crypto/md5_test.mbt
@@ -48,6 +48,34 @@ test "md5_rfc1321" { // testsuites in RFC1321
 }
 
 ///|
+test "md5 finalize_into writes at offset" {
+  let ctx = MD5::new()
+  ctx.update(b"abc".to_fixedarray())
+  let buf = FixedArray::make(32, b'\x00')
+  buf.fill(0xaa)
+  CryptoHasher::finalize_into(ctx, buf, offset=8)
+  inspect(
+    bytes_to_hex_string(buf),
+    content="aaaaaaaaaaaaaaaa900150983cd24fb0d6963f7d28e17f72aaaaaaaaaaaaaaaa",
+  )
+}
+
+///|
+test "md5 finalize is idempotent and reentrant" {
+  let ctx = MD5::new()
+  ctx.update(b"abc".to_fixedarray())
+  let first = bytes_to_hex_string(ctx.finalize())
+  let second = bytes_to_hex_string(ctx.finalize())
+  inspect(first, content="900150983cd24fb0d6963f7d28e17f72")
+  @test.assert_eq(first, second)
+  ctx.update(b"def".to_fixedarray())
+  inspect(
+    bytes_to_hex_string(ctx.finalize()),
+    content="e80b5017098950fc58aad83c8c14978e",
+  )
+}
+
+///|
 test "md5_additional" { // Additional testsuites
   let hash = md5test(
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",

--- a/crypto/pkg.generated.mbti
+++ b/crypto/pkg.generated.mbti
@@ -2,6 +2,14 @@
 package "moonbitlang/x/crypto"
 
 // Values
+pub fn aes_cbc_decrypt(BytesView, BytesView, BytesView) -> Bytes raise CryptoError
+
+pub fn aes_cbc_encrypt(BytesView, BytesView, BytesView) -> Bytes raise CryptoError
+
+pub fn aes_ecb_decrypt(BytesView, BytesView) -> Bytes raise CryptoError
+
+pub fn aes_ecb_encrypt(BytesView, BytesView) -> Bytes raise CryptoError
+
 pub fn[D : ByteSource] bytes_to_hex_string(D) -> String
 
 #deprecated
@@ -15,7 +23,15 @@ pub fn[Data : ByteSource] chacha8(FixedArray[UInt], UInt, Data, nonce? : UInt) -
 
 pub fn[H : CryptoHasher] hmac(H, BytesView, BytesView) -> FixedArray[Byte]
 
+pub fn[Data : ByteSource] md4(Data) -> FixedArray[Byte]
+
+pub fn md4_from_iter(Iter[Byte]) -> FixedArray[Byte]
+
 pub fn[Data : ByteSource] md5(Data) -> FixedArray[Byte]
+
+pub fn[Data : ByteSource] ripemd160(Data) -> FixedArray[Byte]
+
+pub fn ripemd160_from_iter(Iter[Byte]) -> FixedArray[Byte]
 
 pub fn[Data : ByteSource] sha1(Data) -> FixedArray[Byte]
 
@@ -27,6 +43,14 @@ pub fn[Data : ByteSource] sha256(Data) -> FixedArray[Byte]
 
 pub fn sha256_from_iter(Iter[Byte]) -> FixedArray[Byte]
 
+pub fn[Data : ByteSource] sha384(Data) -> FixedArray[Byte]
+
+pub fn sha384_from_iter(Iter[Byte]) -> FixedArray[Byte]
+
+pub fn[Data : ByteSource] sha512(Data) -> FixedArray[Byte]
+
+pub fn sha512_from_iter(Iter[Byte]) -> FixedArray[Byte]
+
 pub fn[Data : ByteSource] sm3(Data) -> FixedArray[Byte]
 
 pub fn sm3_from_iter(Iter[Byte]) -> FixedArray[Byte]
@@ -34,6 +58,14 @@ pub fn sm3_from_iter(Iter[Byte]) -> FixedArray[Byte]
 pub fn uints_to_hex_string(Iter[UInt]) -> String
 
 // Errors
+pub suberror ChaChaError {
+  CounterExhausted
+  InvalidOutputRange
+}
+
+pub suberror CryptoError {
+  InvalidCrypto(msg~ : String)
+}
 
 // Types and methods
 type ChaCha
@@ -41,6 +73,18 @@ pub fn[K : ByteSource, N : ByteSource] ChaCha::chacha12(K, N, counter? : UInt) -
 pub fn[K : ByteSource, N : ByteSource] ChaCha::chacha20(K, N, counter? : UInt) -> Self raise
 pub fn[K : ByteSource, N : ByteSource] ChaCha::chacha8(K, N, counter? : UInt) -> Self raise
 pub fn[D : ByteSource] ChaCha::transform(Self, D, FixedArray[Byte], offset? : Int) -> Unit
+pub fn[D : ByteSource] ChaCha::transform_checked(Self, D, FixedArray[Byte], offset? : Int) -> Unit raise ChaChaError
+
+type MD4
+pub fn MD4::block_size(Self) -> Int
+pub fn MD4::finalize(Self) -> FixedArray[Byte]
+pub fn MD4::finalize_into(Self, FixedArray[Byte], offset~ : Int) -> Unit
+pub fn MD4::new() -> Self
+pub fn MD4::reset(Self) -> Unit
+pub fn MD4::size(Self) -> Int
+pub fn[Data : ByteSource] MD4::update(Self, Data) -> Unit
+pub fn MD4::update_from_iter(Self, Iter[Byte]) -> Unit
+pub impl CryptoHasher for MD4
 
 #alias(MD5Context, deprecated)
 type MD5
@@ -57,6 +101,28 @@ pub fn MD5::size(Self) -> Int
 pub fn[Data : ByteSource] MD5::update(Self, Data) -> Unit
 pub impl CryptoHasher for MD5
 
+type RIPEMD160
+pub fn RIPEMD160::block_size(Self) -> Int
+pub fn RIPEMD160::finalize(Self) -> FixedArray[Byte]
+pub fn RIPEMD160::finalize_into(Self, FixedArray[Byte], offset~ : Int) -> Unit
+pub fn RIPEMD160::new() -> Self
+pub fn RIPEMD160::reset(Self) -> Unit
+pub fn RIPEMD160::size(Self) -> Int
+pub fn[Data : ByteSource] RIPEMD160::update(Self, Data) -> Unit
+pub fn RIPEMD160::update_from_iter(Self, Iter[Byte]) -> Unit
+pub impl CryptoHasher for RIPEMD160
+
+type SHA224
+pub fn SHA224::block_size(Self) -> Int
+pub fn SHA224::finalize(Self) -> FixedArray[Byte]
+pub fn SHA224::finalize_into(Self, FixedArray[Byte], offset~ : Int) -> Unit
+pub fn SHA224::new() -> Self
+pub fn SHA224::reset(Self) -> Unit
+pub fn SHA224::size(Self) -> Int
+pub fn[Data : ByteSource] SHA224::update(Self, Data) -> Unit
+pub fn SHA224::update_from_iter(Self, Iter[Byte]) -> Unit
+pub impl CryptoHasher for SHA224
+
 #alias(Sha256Context, deprecated)
 type SHA256
 #deprecated
@@ -64,6 +130,7 @@ pub fn SHA256::block_size(Self) -> Int
 pub fn SHA256::finalize(Self) -> FixedArray[Byte]
 #deprecated
 pub fn SHA256::finalize_into(Self, FixedArray[Byte], offset~ : Int) -> Unit
+#label_migration(reg, fill=false, msg="The `reg` parameter is deprecated: constructing a SHA-256 hasher with a custom initial state is no longer supported. If you were passing the SHA-224 initial state, use `SHA224::new()` instead.")
 pub fn SHA256::new(reg? : FixedArray[UInt]) -> Self
 #deprecated
 pub fn SHA256::reset(Self) -> Unit
@@ -72,6 +139,17 @@ pub fn SHA256::size(Self) -> Int
 pub fn[Data : ByteSource] SHA256::update(Self, Data) -> Unit
 pub fn SHA256::update_from_iter(Self, Iter[Byte]) -> Unit
 pub impl CryptoHasher for SHA256
+
+type SHA512
+pub fn SHA512::block_size(Self) -> Int
+pub fn SHA512::finalize(Self) -> FixedArray[Byte]
+pub fn SHA512::finalize_into(Self, FixedArray[Byte], offset~ : Int) -> Unit
+pub fn SHA512::new() -> Self
+pub fn SHA512::reset(Self) -> Unit
+pub fn SHA512::size(Self) -> Int
+pub fn[Data : ByteSource] SHA512::update(Self, Data) -> Unit
+pub fn SHA512::update_from_iter(Self, Iter[Byte]) -> Unit
+pub impl CryptoHasher for SHA512
 
 #alias(SM3Context, deprecated)
 type SM3

--- a/crypto/ripemd160.mbt
+++ b/crypto/ripemd160.mbt
@@ -1,0 +1,397 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A RIPEMD-160 message-digest algorithm implementation based on
+// [The RIPEMD-160 page] https://homes.esat.kuleuven.be/~bosselae/ripemd160.html
+// Note that RIPEMD-160 is no longer considered a strong hash;
+// unless mandated, more secure alternatives should be preferred.
+
+///|
+struct RIPEMD160 {
+  reg : FixedArray[UInt] // state h0 h1 h2 h3 h4
+  mut len : UInt64
+  buf : FixedArray[Byte]
+  mut buf_index : Int
+}
+
+///|
+pub impl CryptoHasher for RIPEMD160 with fn size(_self : RIPEMD160) -> Int {
+  20
+}
+
+///|
+pub impl CryptoHasher for RIPEMD160 with fn block_size(_self : RIPEMD160) -> Int {
+  64
+}
+
+///|
+pub impl CryptoHasher for RIPEMD160 with fn reset(self : RIPEMD160) -> Unit {
+  self.reg[0] = 0x67452301
+  self.reg[1] = 0xefcdab89
+  self.reg[2] = 0x98badcfe
+  self.reg[3] = 0x10325476
+  self.reg[4] = 0xc3d2e1f0
+  self.len = 0
+  self.buf.fill(0)
+  self.buf_index = 0
+}
+
+///|
+/// Instantiate a RIPEMD-160 context
+pub fn RIPEMD160::new() -> RIPEMD160 {
+  {
+    reg: [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476, 0xc3d2e1f0],
+    len: 0,
+    buf: FixedArray::make(64, Byte::default()),
+    buf_index: 0,
+  }
+}
+
+// auxiliary functions of the left (f) and right (g) lines
+
+///|
+fn ripemd_f1(x : UInt, y : UInt, z : UInt) -> UInt {
+  x ^ y ^ z
+}
+
+///|
+fn ripemd_f2(x : UInt, y : UInt, z : UInt) -> UInt {
+  (x & y) | (x.lnot() & z)
+}
+
+///|
+fn ripemd_f3(x : UInt, y : UInt, z : UInt) -> UInt {
+  (x | y.lnot()) ^ z
+}
+
+///|
+fn ripemd_f4(x : UInt, y : UInt, z : UInt) -> UInt {
+  (x & z) | (y & z.lnot())
+}
+
+///|
+fn ripemd_f5(x : UInt, y : UInt, z : UInt) -> UInt {
+  x ^ (y | z.lnot())
+}
+
+// message word selection tables of the left (r1) and right (r2) lines
+
+///|
+let ripemd_r1 : FixedArray[Int] = [
+  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 7, 4, 13, 1, 10, 6, 15, 3,
+  12, 0, 9, 5, 2, 14, 11, 8, 3, 10, 14, 4, 9, 15, 8, 1, 2, 7, 0, 6, 13, 11, 5, 12,
+  1, 9, 11, 10, 0, 8, 12, 4, 13, 3, 7, 15, 14, 5, 6, 2, 4, 0, 5, 9, 7, 12, 2, 10,
+  14, 1, 3, 8, 11, 6, 15, 13,
+]
+
+///|
+let ripemd_r2 : FixedArray[Int] = [
+  5, 14, 7, 0, 9, 2, 11, 4, 13, 6, 15, 8, 1, 10, 3, 12, 6, 11, 3, 7, 0, 13, 5, 10,
+  14, 15, 8, 12, 4, 9, 1, 2, 15, 5, 1, 3, 7, 14, 6, 9, 11, 8, 12, 2, 10, 0, 4, 13,
+  8, 6, 4, 1, 3, 11, 15, 0, 5, 12, 2, 13, 9, 7, 10, 14, 12, 15, 10, 4, 1, 5, 8, 7,
+  6, 2, 13, 14, 0, 3, 9, 11,
+]
+
+// rotation tables of the left (s1) and right (s2) lines
+
+///|
+let ripemd_s1 : FixedArray[Int] = [
+  11, 14, 15, 12, 5, 8, 7, 9, 11, 13, 14, 15, 6, 7, 9, 8, 7, 6, 8, 13, 11, 9, 7,
+  15, 7, 12, 15, 9, 11, 7, 13, 12, 11, 13, 6, 7, 14, 9, 13, 15, 14, 8, 13, 6, 5,
+  12, 7, 5, 11, 12, 14, 15, 14, 15, 9, 8, 9, 14, 5, 6, 8, 6, 5, 12, 9, 15, 5, 11,
+  6, 8, 13, 12, 5, 12, 13, 14, 11, 8, 5, 6,
+]
+
+///|
+let ripemd_s2 : FixedArray[Int] = [
+  8, 9, 9, 11, 13, 15, 15, 5, 7, 7, 8, 11, 14, 14, 12, 6, 9, 13, 15, 7, 12, 8, 9,
+  11, 7, 7, 12, 7, 6, 15, 13, 11, 9, 7, 15, 11, 8, 6, 6, 14, 12, 13, 5, 14, 13, 13,
+  7, 5, 15, 5, 8, 11, 14, 14, 6, 14, 6, 9, 12, 9, 12, 5, 15, 8, 8, 5, 12, 9, 12,
+  5, 14, 6, 8, 13, 6, 5, 15, 13, 11, 11,
+]
+
+// round constants of the left (k1) and right (k2) lines
+
+///|
+let ripemd_k1 : FixedArray[UInt] = [
+  0x00000000, 0x5a827999, 0x6ed9eba1, 0x8f1bbcdc, 0xa953fd4e,
+]
+
+///|
+let ripemd_k2 : FixedArray[UInt] = [
+  0x50a28be6, 0x5c4dd124, 0x6d703ef3, 0x7a6d76e9, 0x00000000,
+]
+
+// the left line uses f1..f5 in rounds 0..4, the right line uses them in reverse
+
+///|
+fn ripemd_f_left(round : Int, x : UInt, y : UInt, z : UInt) -> UInt {
+  if round == 0 {
+    ripemd_f1(x, y, z)
+  } else if round == 1 {
+    ripemd_f2(x, y, z)
+  } else if round == 2 {
+    ripemd_f3(x, y, z)
+  } else if round == 3 {
+    ripemd_f4(x, y, z)
+  } else {
+    ripemd_f5(x, y, z)
+  }
+}
+
+///|
+fn ripemd_f_right(round : Int, x : UInt, y : UInt, z : UInt) -> UInt {
+  if round == 0 {
+    ripemd_f5(x, y, z)
+  } else if round == 1 {
+    ripemd_f4(x, y, z)
+  } else if round == 2 {
+    ripemd_f3(x, y, z)
+  } else if round == 3 {
+    ripemd_f2(x, y, z)
+  } else {
+    ripemd_f1(x, y, z)
+  }
+}
+
+///|
+#inline
+fn RIPEMD160::transform(
+  state : FixedArray[UInt],
+  input : FixedArray[UInt],
+) -> Unit {
+  // parse_le_u32x16_into always supplies exactly 16 words; every table
+  // word index used below is therefore in bounds.
+  let mut a1 = state[0]
+  let mut b1 = state[1]
+  let mut c1 = state[2]
+  let mut d1 = state[3]
+  let mut e1 = state[4]
+  let mut a2 = state[0]
+  let mut b2 = state[1]
+  let mut c2 = state[2]
+  let mut d2 = state[3]
+  let mut e2 = state[4]
+  for round in 0..<5 {
+    let k1 = ripemd_k1.unsafe_get(round)
+    let k2 = ripemd_k2.unsafe_get(round)
+    for i in 0..<16 {
+      let idx = round * 16 + i
+      let t1 = rotate_left_u(
+          a1 +
+          ripemd_f_left(round, b1, c1, d1) +
+          input.unsafe_get(ripemd_r1.unsafe_get(idx)) +
+          k1,
+          ripemd_s1.unsafe_get(idx),
+        ) +
+        e1
+      a1 = e1
+      e1 = d1
+      d1 = rotate_left_u(c1, 10)
+      c1 = b1
+      b1 = t1
+      let t2 = rotate_left_u(
+          a2 +
+          ripemd_f_right(round, b2, c2, d2) +
+          input.unsafe_get(ripemd_r2.unsafe_get(idx)) +
+          k2,
+          ripemd_s2.unsafe_get(idx),
+        ) +
+        e2
+      a2 = e2
+      e2 = d2
+      d2 = rotate_left_u(c2, 10)
+      c2 = b2
+      b2 = t2
+    }
+  }
+  let t = state[1] + c1 + d2
+  state[1] = state[2] + d1 + e2
+  state[2] = state[3] + e1 + a2
+  state[3] = state[4] + a1 + b2
+  state[4] = state[0] + b1 + c2
+  state[0] = t
+}
+
+///|
+pub fn RIPEMD160::update_from_iter(self : RIPEMD160, data : Iter[Byte]) -> Unit {
+  let input = FixedArray::make(16, 0U)
+  data.each(fn(b) {
+    self.buf[self.buf_index] = b
+    self.buf_index += 1
+    if self.buf_index == 64 {
+      self.buf_index = 0
+      self.len += 512UL
+      parse_le_u32x16_into(self.buf, 0, input)
+      RIPEMD160::transform(self.reg, input)
+    }
+  })
+}
+
+///|
+pub impl CryptoHasher for RIPEMD160 with fn update(
+  self : RIPEMD160,
+  data : BytesView,
+) -> Unit {
+  self.update(data)
+}
+
+///|
+/// update the state of given context from new `data`
+pub fn[Data : ByteSource] RIPEMD160::update(
+  self : RIPEMD160,
+  data : Data,
+) -> Unit {
+  let input = FixedArray::make(16, 0U)
+  let data_len = data.length()
+  let mut offset = 0
+  while offset < data_len {
+    let min_len = @cmp.minimum(64 - self.buf_index, data_len - offset)
+    data.blit_to(
+      self.buf,
+      len=min_len,
+      src_offset=offset,
+      dst_offset=self.buf_index,
+    )
+    self.buf_index += min_len
+    if self.buf_index == 64 {
+      self.len += 512UL
+      self.buf_index = 0
+      parse_le_u32x16_into(self.buf, 0, input)
+      RIPEMD160::transform(self.reg, input)
+    }
+    offset += min_len
+  }
+}
+
+///|
+pub fn RIPEMD160::finalize(self : RIPEMD160) -> FixedArray[Byte] {
+  let ret = FixedArray::make(20, Byte::default())
+  self._finalize_into(ret)
+  ret
+}
+
+///|
+fn RIPEMD160::_finalize_into(
+  self : RIPEMD160,
+  buffer : FixedArray[Byte],
+  offset? : Int = 0,
+) -> Unit {
+  // Copy data
+  let data = FixedArray::make(64, Byte::default())
+  let input = FixedArray::make(16, 0U)
+  let mut cnt = self.buf_index
+  let len = self.len + 8 * cnt.to_uint64()
+  self.buf.blit_to(data, len=cnt)
+  let reg = self.reg.copy()
+
+  // Padding
+  data[cnt] = b'\x80'
+  cnt += 1
+  if cnt > 56 {
+    parse_le_u32x16_into(data, 0, input)
+    RIPEMD160::transform(reg, input)
+    data.fill(0)
+  }
+  // little-endian 64-bit bit length at bytes 56..64
+  data.unsafe_set(56, len.to_byte())
+  data.unsafe_set(57, (len >> 8).to_byte())
+  data.unsafe_set(58, (len >> 16).to_byte())
+  data.unsafe_set(59, (len >> 24).to_byte())
+  data.unsafe_set(60, (len >> 32).to_byte())
+  data.unsafe_set(61, (len >> 40).to_byte())
+  data.unsafe_set(62, (len >> 48).to_byte())
+  data.unsafe_set(63, (len >> 56).to_byte())
+  parse_le_u32x16_into(data, 0, input)
+  RIPEMD160::transform(reg, input)
+
+  // Write result to buffer
+  arr_u32_to_u8le_into(reg.iter(), buffer, offset)
+}
+
+///|
+pub impl CryptoHasher for RIPEMD160 with fn finalize_into(
+  self : RIPEMD160,
+  buffer : FixedArray[Byte],
+  offset~ : Int,
+) -> Unit {
+  self._finalize_into(buffer, offset~)
+}
+
+///|
+/// Compute the RIPEMD-160 digest of some `data`.
+/// - Note that RIPEMD-160 is no longer considered a strong hash;
+/// unless mandated, more secure alternatives should be preferred.
+pub fn[Data : ByteSource] ripemd160(data : Data) -> FixedArray[Byte] {
+  RIPEMD160::new()..update(data).finalize()
+}
+
+///|
+pub fn ripemd160_from_iter(data : Iter[Byte]) -> FixedArray[Byte] {
+  RIPEMD160::new()..update_from_iter(data).finalize()
+}
+
+///|
+test {
+  inspect(
+    bytes_to_hex_string(
+      ripemd160(
+        b"\x61\x62\x63", // abc in utf-8
+      ),
+    ),
+    content="8eb208f7e05d987a9b044a8e98c6b087f15a0bfc",
+  )
+  inspect(
+    bytes_to_hex_string(ripemd160(b"")),
+    content="9c1185a5c5e9fc54612808977ee8f548b2258d31",
+  )
+  let hash1 = "8eb208f7e05d987a9b044a8e98c6b087f15a0bfc"
+  let ctx = RIPEMD160::new()
+  ctx.update(b"\x61".to_fixedarray())
+  ctx.update(b"\x62".to_fixedarray())
+  ctx.update(b"\x63".to_fixedarray())
+  assert_eq(hash1, bytes_to_hex_string(ctx.finalize()))
+  let ctx = RIPEMD160::new()
+  for i = 0; i < 3; i = i + 1 {
+    ctx.update_from_iter(b"\x61\x62\x63".iter())
+  }
+  inspect(
+    bytes_to_hex_string(ctx.finalize()),
+    content="357caa7408a576d25c8f06853ebb1746565573b7",
+  )
+}
+
+///|
+test "ripemd160 reentry" {
+  let string = b"abcd"
+  let ctx = RIPEMD160::new()
+  ctx.update(string)
+  inspect(
+    bytes_to_hex_string(ctx.finalize()),
+    content="2e7e536fd487deaa943fda5522d917bdb9011b7a",
+  )
+  ctx.update(string)
+  inspect(
+    bytes_to_hex_string(ctx.finalize()),
+    content="f169f36789db8960d94bbced93290098f04b10eb",
+  )
+  ctx.update(string)
+  inspect(
+    bytes_to_hex_string(ctx.finalize()),
+    content="4bcf93042b478aa5c2f41be1d179814b35a88e00",
+  )
+}
+
+///|
+pub extend RIPEMD160 with CryptoHasher::{reset, finalize_into, size, block_size}

--- a/crypto/sha1.mbt
+++ b/crypto/sha1.mbt
@@ -35,7 +35,7 @@ pub fn[Data : ByteSource] sha1(input : Data) -> FixedArray[Byte] {
   let chunk_count = new_length / bytes_per_chunk // `new_length` is a multiple of 512
   let words = FixedArray::make(80, 0U)
   for chunk = 0; chunk < chunk_count; chunk = chunk + 1 {
-    parse_be_u32_block_into(bytes, chunk * bytes_per_chunk, words)
+    parse_be_u32x16_into(bytes, chunk * bytes_per_chunk, words)
     for i = 16; i < 80; i = i + 1 {
       words[i] = rotate_left_u(
         words[i - 3] ^ words[i - 8] ^ words[i - 14] ^ words[i - 16],

--- a/crypto/sha224.mbt
+++ b/crypto/sha224.mbt
@@ -13,28 +13,91 @@
 // limitations under the License.
 
 ///|
-pub fn[Data : ByteSource] sha224(data : Data) -> FixedArray[Byte] {
+/// SHA-224 is a truncated variant of SHA-256 with a distinct initial state,
+/// producing a 28-byte digest. It shares the compression core with SHA-256.
+struct SHA224 {
+  ctx : SHA256
+}
+
+///|
+/// Instantiate a SHA-224 context with the standard initial hash value.
+pub fn SHA224::new() -> SHA224 {
+  SHA224::{
+    ctx: SHA256::new_with_initial_state([
+      0xc1059ed8, 0x367cd507, 0x3070dd17, 0xf70e5939, 0xffc00b31, 0x68581511, 0x64f98fa7,
+      0xbefa4fa4,
+    ]),
+  }
+}
+
+///|
+pub fn[Data : ByteSource] SHA224::update(self : SHA224, data : Data) -> Unit {
+  self.ctx.update(data)
+}
+
+///|
+pub fn SHA224::update_from_iter(self : SHA224, data : Iter[Byte]) -> Unit {
+  self.ctx.update_from_iter(data)
+}
+
+///|
+pub fn SHA224::finalize(self : SHA224) -> FixedArray[Byte] {
   let ret = FixedArray::make(28, Byte::default())
-  SHA256::new(reg=[
-    0xc1059ed8, 0x367cd507, 0x3070dd17, 0xf70e5939, 0xffc00b31, 0x68581511, 0x64f98fa7,
-    0xbefa4fa4,
-  ])
-  ..update(data)
-  ._finalize_into(ret, size=7)
+  self.ctx._finalize_into(ret, size=7)
   ret
 }
 
 ///|
-pub fn sha224_from_iter(data : Iter[Byte]) -> FixedArray[Byte] {
-  let ret = FixedArray::make(28, Byte::default())
-  SHA256::new(reg=[
-    0xc1059ed8, 0x367cd507, 0x3070dd17, 0xf70e5939, 0xffc00b31, 0x68581511, 0x64f98fa7,
-    0xbefa4fa4,
-  ])
-  ..update_from_iter(data)
-  ._finalize_into(ret, size=7)
-  ret
+pub impl CryptoHasher for SHA224 with fn update(self : SHA224, data : BytesView) -> Unit {
+  self.ctx.update(data)
 }
+
+///|
+pub impl CryptoHasher for SHA224 with fn size(_self : SHA224) -> Int {
+  28
+}
+
+///|
+pub impl CryptoHasher for SHA224 with fn block_size(_self : SHA224) -> Int {
+  64
+}
+
+///|
+pub impl CryptoHasher for SHA224 with fn reset(self : SHA224) -> Unit {
+  self.ctx.reg[0] = 0xc1059ed8
+  self.ctx.reg[1] = 0x367cd507
+  self.ctx.reg[2] = 0x3070dd17
+  self.ctx.reg[3] = 0xf70e5939
+  self.ctx.reg[4] = 0xffc00b31
+  self.ctx.reg[5] = 0x68581511
+  self.ctx.reg[6] = 0x64f98fa7
+  self.ctx.reg[7] = 0xbefa4fa4
+  self.ctx.len = 0
+  self.ctx.buf.fill(0)
+  self.ctx.buf_index = 0
+}
+
+///|
+pub impl CryptoHasher for SHA224 with fn finalize_into(
+  self : SHA224,
+  buffer : FixedArray[Byte],
+  offset~ : Int,
+) -> Unit {
+  self.ctx._finalize_into(buffer, size=7, offset~)
+}
+
+///|
+pub fn[Data : ByteSource] sha224(data : Data) -> FixedArray[Byte] {
+  SHA224::new()..update(data).finalize()
+}
+
+///|
+pub fn sha224_from_iter(data : Iter[Byte]) -> FixedArray[Byte] {
+  SHA224::new()..update_from_iter(data).finalize()
+}
+
+///|
+pub extend SHA224 with CryptoHasher::{reset, finalize_into, size, block_size}
 
 ///|
 test {

--- a/crypto/sha224_test.mbt
+++ b/crypto/sha224_test.mbt
@@ -14,36 +14,111 @@
 
 ///|
 test "sha224-additional" {
-  assert_eq(
+  @test.assert_eq(
     sha224test(""),
     "d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f",
   )
-  assert_eq(
+  @test.assert_eq(
     sha224test("a"),
     "3118199937a95dd0dd06a74ac0bf1517e958f08ae87ef9d7e89f139a",
   )
-  assert_eq(
+  @test.assert_eq(
     sha224test("message digest"),
     "dcf41f0075ccc16b44cc9f6d1900a34bbc2841893eaf4bf2f64edf95",
   )
-  assert_eq(
+  @test.assert_eq(
     sha224test("abcdefghijklmnopqrstuvwxyz"),
     "1c3ace1531530751e862592a3fe33e682d7e36c2f9df58a384eb49bd",
   )
-  assert_eq(
+  @test.assert_eq(
     sha224test("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"),
     "eefa179ecbcba0011f77a6ff43815e8b3a92932456b373ed69b639cb",
   )
-  assert_eq(
+  @test.assert_eq(
     sha224test(
       "12345678901234567890123456789012345678901234567890123456789012345678901234567890",
     ),
     "5d0b10a347de663745ae351d996e7d830daaa06379992a6017c9c99e",
   )
-  assert_eq(
+  @test.assert_eq(
     sha224test(
       "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
     ),
     "f029eeb25a211521aeb144cb1b9ad38d2313a8312d13599ca6a8f39a",
   )
+}
+
+///|
+test "sha224 streaming" {
+  let ctx = SHA224::new()
+  ctx.update(b"abc")
+  @test.assert_eq(
+    bytes_to_hex_string(ctx.finalize()),
+    "23097d223405d8228642a477bda255b32aadbce4bda0b3f7e36c9da7",
+  )
+  let chunked = SHA224::new()
+  chunked.update(b"a")
+  chunked.update(b"b")
+  chunked.update(b"c")
+  @test.assert_eq(
+    bytes_to_hex_string(chunked.finalize()),
+    bytes_to_hex_string(sha224(b"abc")),
+  )
+  let iter = SHA224::new()
+  iter.update_from_iter(b"abc".iter())
+  @test.assert_eq(
+    bytes_to_hex_string(iter.finalize()),
+    bytes_to_hex_string(sha224(b"abc")),
+  )
+}
+
+///|
+test "sha224 reset" {
+  let ctx = SHA224::new()
+  ctx.update(b"abc")
+  let first = bytes_to_hex_string(ctx.finalize())
+  ctx.update(b"abc")
+  ctx.reset()
+  ctx.update(b"abc")
+  @test.assert_eq(bytes_to_hex_string(ctx.finalize()), first)
+}
+
+///|
+test "sha224 finalize_into" {
+  let ctx = SHA224::new()
+  ctx.update(b"abc")
+  let digest = ctx.finalize()
+  let buffer = FixedArray::make(32, b'\x00')
+  ctx.finalize_into(buffer, offset=4)
+  for i = 0; i < 28; i = i + 1 {
+    @test.assert_eq(buffer[i + 4], digest[i])
+  }
+  @test.assert_eq(buffer[0], b'\x00')
+  @test.assert_eq(buffer[31], digest[27])
+}
+
+///|
+test "sha224 hmac" {
+  let key = FixedArray::make(20, b'\x0b').unsafe_reinterpret_as_bytes()
+  let message = b"Hi There"
+  @test.assert_eq(
+    bytes_to_hex_string(hmac(SHA224::new(), key, message)),
+    "896fb1128abbdf196832107cd49df33f47b4b1169912ba4f53684b22",
+  )
+}
+
+///|
+#warnings("-deprecated")
+test "sha224 via deprecated initial state" {
+  let ctx = SHA256::new(reg=[
+    0xc1059ed8, 0x367cd507, 0x3070dd17, 0xf70e5939, 0xffc00b31, 0x68581511, 0x64f98fa7,
+    0xbefa4fa4,
+  ])
+  ctx.update(b"abc")
+  let expected = sha224(b"abc")
+  let full = ctx.finalize()
+  @test.assert_eq(full.length(), 32)
+  for i = 0; i < 28; i = i + 1 {
+    @test.assert_eq(full[i], expected[i])
+  }
 }

--- a/crypto/sha256.mbt
+++ b/crypto/sha256.mbt
@@ -22,14 +22,19 @@ struct SHA256 {
 }
 
 ///|
-/// Instantiate a Sha256 context
-/// `reg` is the initial hash value. Defaults to Sha256's.
+/// Instantiate a SHA-256 context with the standard initial hash value.
+#label_migration(reg, fill=false, msg="The `reg` parameter is deprecated: constructing a SHA-256 hasher with a custom initial state is no longer supported. If you were passing the SHA-224 initial state, use `SHA224::new()` instead.")
 pub fn SHA256::new(
   reg? : FixedArray[UInt] = [
     0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab,
     0x5be0cd19,
   ],
 ) -> SHA256 {
+  SHA256::new_with_initial_state(reg)
+}
+
+///|
+fn SHA256::new_with_initial_state(reg : FixedArray[UInt]) -> SHA256 {
   { reg, len: 0, buf: FixedArray::make(64, Byte::default()), buf_index: 0 }
 }
 
@@ -47,10 +52,27 @@ let sha256_t : FixedArray[UInt] = [ // pre calculated
   0xc67178f2,
 ]
 
+// Ch(x,y,z) = (x & y) ^ (~x & z)
+// Maj(x,y,z) = (x & y) ^ (x & z) ^ (y & z)
+
 ///|
-fn SHA256::transform(data : FixedArray[Byte], reg : FixedArray[UInt]) -> Unit {
-  let w = FixedArray::make(16, 0U)
+fn sha256_ch(x : UInt, y : UInt, z : UInt) -> UInt {
+  ((y ^ z) & x) ^ z
+}
+
+///|
+fn sha256_maj(x : UInt, y : UInt, z : UInt) -> UInt {
+  (x & y) | (x & z) | (y & z)
+}
+
+///|
+fn SHA256::transform(
+  data : FixedArray[Byte],
+  reg : FixedArray[UInt],
+  w : FixedArray[UInt],
+) -> Unit {
   guard! reg.length() == 8
+  guard! w.length() == 16
   let mut a = reg.unsafe_get(0)
   let mut b = reg.unsafe_get(1)
   let mut c = reg.unsafe_get(2)
@@ -59,7 +81,7 @@ fn SHA256::transform(data : FixedArray[Byte], reg : FixedArray[UInt]) -> Unit {
   let mut f = reg.unsafe_get(5)
   let mut g = reg.unsafe_get(6)
   let mut h = reg.unsafe_get(7)
-  parse_be_u32_block_into(data, 0, w)
+  parse_be_u32x16_into(data, 0, w)
   for index = 0; index < 64; index = index + 1 {
     let word = if index < 16 {
       w.unsafe_get(index)
@@ -83,11 +105,11 @@ fn SHA256::transform(data : FixedArray[Byte], reg : FixedArray[UInt]) -> Unit {
     let big_sigma_1 = rotate_right_u(e, 6) ^
       rotate_right_u(e, 11) ^
       rotate_right_u(e, 25)
-    let t_1 = h + big_sigma_1 + SM3::gg_1(e, f, g) + sha256_t[index] + word
+    let t_1 = h + big_sigma_1 + sha256_ch(e, f, g) + sha256_t[index] + word
     let big_sigma_0 = rotate_right_u(a, 2) ^
       rotate_right_u(a, 13) ^
       rotate_right_u(a, 22)
-    let t_2 = big_sigma_0 + SM3::ff_1(a, b, c)
+    let t_2 = big_sigma_0 + sha256_maj(a, b, c)
     h = g
     g = f
     f = e
@@ -109,13 +131,14 @@ fn SHA256::transform(data : FixedArray[Byte], reg : FixedArray[UInt]) -> Unit {
 
 ///|
 pub fn SHA256::update_from_iter(self : SHA256, data : Iter[Byte]) -> Unit {
+  let w = FixedArray::make(16, 0U)
   data.each(fn(b) {
     self.buf[self.buf_index] = b
     self.buf_index += 1
     if self.buf_index == 64 {
       self.buf_index = 0
       self.len += 512UL
-      SHA256::transform(self.buf, self.reg)
+      SHA256::transform(self.buf, self.reg, w)
     }
   })
 }
@@ -128,13 +151,11 @@ pub impl CryptoHasher for SHA256 with fn update(self : SHA256, data : BytesView)
 ///|
 /// update the state of given context from new `data` 
 pub fn[Data : ByteSource] SHA256::update(self : SHA256, data : Data) -> Unit {
+  let w = FixedArray::make(16, 0U)
+  let data_len = data.length()
   let mut offset = 0
-  while offset < data.length() {
-    let min_len = if 64 - self.buf_index >= data.length() - offset {
-      data.length() - offset
-    } else {
-      64 - self.buf_index
-    }
+  while offset < data_len {
+    let min_len = @cmp.minimum(64 - self.buf_index, data_len - offset)
     data.blit_to(
       self.buf,
       len=min_len,
@@ -145,7 +166,7 @@ pub fn[Data : ByteSource] SHA256::update(self : SHA256, data : Data) -> Unit {
     if self.buf_index == 64 {
       self.len += 512UL
       self.buf_index = 0
-      SHA256::transform(self.buf, self.reg)
+      SHA256::transform(self.buf, self.reg, w)
     }
     offset += min_len
   }
@@ -168,6 +189,7 @@ fn SHA256::_finalize_into(
 ) -> Unit {
   // Copy data
   let data = FixedArray::make(64, Byte::default())
+  let w = FixedArray::make(16, 0U)
   let mut cnt = self.buf_index
   let len = self.len + 8 * cnt.to_uint64()
   self.buf.blit_to(data, len=cnt)
@@ -177,7 +199,7 @@ fn SHA256::_finalize_into(
   data[cnt] = b'\x80'
   cnt += 1
   if cnt > 56 {
-    SHA256::transform(data, reg)
+    SHA256::transform(data, reg, w)
     data.fill(0)
   }
   data.unsafe_set(56, (len >> 56).to_byte())
@@ -188,7 +210,7 @@ fn SHA256::_finalize_into(
   data.unsafe_set(61, (len >> 16).to_byte())
   data.unsafe_set(62, (len >> 8).to_byte())
   data.unsafe_set(63, (len >> 0).to_byte())
-  SHA256::transform(data, reg)
+  SHA256::transform(data, reg, w)
 
   // Write result to buffer
   arr_u32_to_u8be_into(reg.iter().take(size), buffer, offset)

--- a/crypto/sha256_test.mbt
+++ b/crypto/sha256_test.mbt
@@ -26,33 +26,33 @@ fn sha224test(s : String) -> String {
 
 ///|
 test "sha256-additional" {
-  assert_eq(
+  @test.assert_eq(
     sha256test(""),
     "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   )
-  assert_eq(
+  @test.assert_eq(
     sha256test("a"),
     "ffe9aaeaa2a2d5048174df0b80599ef0197ec024c4b051bc9860cff58ef7f9f3",
   )
-  assert_eq(
+  @test.assert_eq(
     sha256test("message digest"),
     "44911ad1e18f35c0ee9c80582d1aa66c00a18f34a188676ed5f0dc94d05a4fd7",
   )
-  assert_eq(
+  @test.assert_eq(
     sha256test("abcdefghijklmnopqrstuvwxyz"),
     "d79ca8ca68cac4c2d29a4167295303d2a7cf6caae18d1d71bc7566fcb29b5152",
   )
-  assert_eq(
+  @test.assert_eq(
     sha256test("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"),
     "118c908d563bbe9c5b40ad59772cfa520e25dd4299860a59d3280f00e85d4d9d",
   )
-  assert_eq(
+  @test.assert_eq(
     sha256test(
       "12345678901234567890123456789012345678901234567890123456789012345678901234567890",
     ),
     "fb680c13708176267a6b3a9d8ae3691ea6ae30ba0f1c7fc12680bf47618abc7a",
   )
-  assert_eq(
+  @test.assert_eq(
     sha256test(
       "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
     ),

--- a/crypto/sha384.mbt
+++ b/crypto/sha384.mbt
@@ -1,0 +1,57 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A SHA-384 message-digest algorithm implementation based on
+// [FIPS 180-4] https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
+
+///|
+pub fn[Data : ByteSource] sha384(data : Data) -> FixedArray[Byte] {
+  let ret = FixedArray::make(48, Byte::default())
+  SHA512::new_with_initial_state([
+    0xcbbb9d5dc1059ed8UL, 0x629a292a367cd507UL, 0x9159015a3070dd17UL, 0x152fecd8f70e5939UL,
+    0x67332667ffc00b31UL, 0x8eb44a8768581511UL, 0xdb0c2e0d64f98fa7UL, 0x47b5481dbefa4fa4UL,
+  ])
+  ..update(data)
+  ._finalize_into(ret, size=6)
+  ret
+}
+
+///|
+pub fn sha384_from_iter(data : Iter[Byte]) -> FixedArray[Byte] {
+  let ret = FixedArray::make(48, Byte::default())
+  SHA512::new_with_initial_state([
+    0xcbbb9d5dc1059ed8UL, 0x629a292a367cd507UL, 0x9159015a3070dd17UL, 0x152fecd8f70e5939UL,
+    0x67332667ffc00b31UL, 0x8eb44a8768581511UL, 0xdb0c2e0d64f98fa7UL, 0x47b5481dbefa4fa4UL,
+  ])
+  ..update_from_iter(data)
+  ._finalize_into(ret, size=6)
+  ret
+}
+
+///|
+test {
+  // Sha384
+  assert_eq(
+    bytes_to_hex_string(sha384(b"\x61\x62\x63".to_fixedarray())),
+    "cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7",
+  )
+  assert_eq(
+    bytes_to_hex_string(sha384(b"")),
+    "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b",
+  )
+  assert_eq(
+    bytes_to_hex_string(sha384_from_iter(b"abcd".iter())),
+    "1165b3406ff0b52a3d24721f785462ca2276c9f454a116c2b2ba20171a7905ea5a026682eb659c4d5f115c363aa3c79b",
+  )
+}

--- a/crypto/sha512.mbt
+++ b/crypto/sha512.mbt
@@ -1,0 +1,379 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A SHA-512 message-digest algorithm implementation based on
+// [FIPS 180-4] https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
+
+///|
+struct SHA512 {
+  reg : FixedArray[UInt64] // register A B C D E F G H. i.e. digest
+  mut len_high : UInt64
+  mut len_low : UInt64
+  buf : FixedArray[Byte]
+  mut buf_index : Int
+}
+
+///|
+fn SHA512::new_with_initial_state(reg : FixedArray[UInt64]) -> SHA512 {
+  guard! reg.length() == 8
+  {
+    reg,
+    len_high: 0,
+    len_low: 0,
+    buf: FixedArray::make(128, Byte::default()),
+    buf_index: 0,
+  }
+}
+
+///|
+/// Instantiates a SHA-512 context.
+pub fn SHA512::new() -> SHA512 {
+  SHA512::new_with_initial_state([
+    0x6a09e667f3bcc908UL, 0xbb67ae8584caa73bUL, 0x3c6ef372fe94f82bUL, 0xa54ff53a5f1d36f1UL,
+    0x510e527fade682d1UL, 0x9b05688c2b3e6c1fUL, 0x1f83d9abfb41bd6bUL, 0x5be0cd19137e2179UL,
+  ])
+}
+
+///|
+let sha512_t : FixedArray[UInt64] = [ // pre calculated
+  0x428a2f98d728ae22UL, 0x7137449123ef65cdUL, 0xb5c0fbcfec4d3b2fUL, 0xe9b5dba58189dbbcUL,
+  0x3956c25bf348b538UL, 0x59f111f1b605d019UL, 0x923f82a4af194f9bUL, 0xab1c5ed5da6d8118UL,
+  0xd807aa98a3030242UL, 0x12835b0145706fbeUL, 0x243185be4ee4b28cUL, 0x550c7dc3d5ffb4e2UL,
+  0x72be5d74f27b896fUL, 0x80deb1fe3b1696b1UL, 0x9bdc06a725c71235UL, 0xc19bf174cf692694UL,
+  0xe49b69c19ef14ad2UL, 0xefbe4786384f25e3UL, 0x0fc19dc68b8cd5b5UL, 0x240ca1cc77ac9c65UL,
+  0x2de92c6f592b0275UL, 0x4a7484aa6ea6e483UL, 0x5cb0a9dcbd41fbd4UL, 0x76f988da831153b5UL,
+  0x983e5152ee66dfabUL, 0xa831c66d2db43210UL, 0xb00327c898fb213fUL, 0xbf597fc7beef0ee4UL,
+  0xc6e00bf33da88fc2UL, 0xd5a79147930aa725UL, 0x06ca6351e003826fUL, 0x142929670a0e6e70UL,
+  0x27b70a8546d22ffcUL, 0x2e1b21385c26c926UL, 0x4d2c6dfc5ac42aedUL, 0x53380d139d95b3dfUL,
+  0x650a73548baf63deUL, 0x766a0abb3c77b2a8UL, 0x81c2c92e47edaee6UL, 0x92722c851482353bUL,
+  0xa2bfe8a14cf10364UL, 0xa81a664bbc423001UL, 0xc24b8b70d0f89791UL, 0xc76c51a30654be30UL,
+  0xd192e819d6ef5218UL, 0xd69906245565a910UL, 0xf40e35855771202aUL, 0x106aa07032bbd1b8UL,
+  0x19a4c116b8d2d0c8UL, 0x1e376c085141ab53UL, 0x2748774cdf8eeb99UL, 0x34b0bcb5e19b48a8UL,
+  0x391c0cb3c5c95a63UL, 0x4ed8aa4ae3418acbUL, 0x5b9cca4f7763e373UL, 0x682e6ff3d6b2b8a3UL,
+  0x748f82ee5defb2fcUL, 0x78a5636f43172f60UL, 0x84c87814a1f0ab72UL, 0x8cc702081a6439ecUL,
+  0x90befffa23631e28UL, 0xa4506cebde82bde9UL, 0xbef9a3f7b2c67915UL, 0xc67178f2e372532bUL,
+  0xca273eceea26619cUL, 0xd186b8c721c0c207UL, 0xeada7dd6cde0eb1eUL, 0xf57d4f7fee6ed178UL,
+  0x06f067aa72176fbaUL, 0x0a637dc5a2c898a6UL, 0x113f9804bef90daeUL, 0x1b710b35131c471bUL,
+  0x28db77f523047d84UL, 0x32caab7b40c72493UL, 0x3c9ebe0a15c9bebcUL, 0x431d67c49c100d4cUL,
+  0x4cc5d4becb3e42b6UL, 0x597f299cfc657e2aUL, 0x5fcb6fab3ad6faecUL, 0x6c44198c4a475817UL,
+]
+
+// Ch(x,y,z) = (x & y) ^ (~x & z)
+// Maj(x,y,z) = (x & y) ^ (x & z) ^ (y & z)
+
+///|
+fn SHA512::ch(x : UInt64, y : UInt64, z : UInt64) -> UInt64 {
+  (x & y) ^ (x.lnot() & z)
+}
+
+///|
+fn SHA512::maj(x : UInt64, y : UInt64, z : UInt64) -> UInt64 {
+  (x & y) ^ (x & z) ^ (y & z)
+}
+
+///|
+fn SHA512::transform(
+  data : FixedArray[Byte],
+  reg : FixedArray[UInt64],
+  w : FixedArray[UInt64],
+) -> Unit {
+  guard! reg.length() == 8
+  guard! w.length() == 16
+  let mut a = reg.unsafe_get(0)
+  let mut b = reg.unsafe_get(1)
+  let mut c = reg.unsafe_get(2)
+  let mut d = reg.unsafe_get(3)
+  let mut e = reg.unsafe_get(4)
+  let mut f = reg.unsafe_get(5)
+  let mut g = reg.unsafe_get(6)
+  let mut h = reg.unsafe_get(7)
+  parse_be_u64x16_into(data, 0, w)
+  for index = 0; index < 80; index = index + 1 {
+    let word = if index < 16 {
+      w.unsafe_get(index)
+    } else {
+      let sigma_0_source = w.unsafe_get((index + 1) & 15)
+      let sigma_0 = rotate_right_u64(sigma_0_source, 1) ^
+        rotate_right_u64(sigma_0_source, 8) ^
+        (sigma_0_source >> 7)
+      let sigma_1_source = w.unsafe_get((index + 14) & 15)
+      let sigma_1 = rotate_right_u64(sigma_1_source, 19) ^
+        rotate_right_u64(sigma_1_source, 61) ^
+        (sigma_1_source >> 6)
+      let slot = index & 15
+      let word = w.unsafe_get(slot) +
+        sigma_0 +
+        w.unsafe_get((index + 9) & 15) +
+        sigma_1
+      w.unsafe_set(slot, word)
+      word
+    }
+    let big_sigma_1 = rotate_right_u64(e, 14) ^
+      rotate_right_u64(e, 18) ^
+      rotate_right_u64(e, 41)
+    let t_1 = h + big_sigma_1 + SHA512::ch(e, f, g) + sha512_t[index] + word
+    let big_sigma_0 = rotate_right_u64(a, 28) ^
+      rotate_right_u64(a, 34) ^
+      rotate_right_u64(a, 39)
+    let t_2 = big_sigma_0 + SHA512::maj(a, b, c)
+    h = g
+    g = f
+    f = e
+    e = d + t_1
+    d = c
+    c = b
+    b = a
+    a = t_1 + t_2
+  }
+  reg.unsafe_set(0, reg.unsafe_get(0) + a)
+  reg.unsafe_set(1, reg.unsafe_get(1) + b)
+  reg.unsafe_set(2, reg.unsafe_get(2) + c)
+  reg.unsafe_set(3, reg.unsafe_get(3) + d)
+  reg.unsafe_set(4, reg.unsafe_get(4) + e)
+  reg.unsafe_set(5, reg.unsafe_get(5) + f)
+  reg.unsafe_set(6, reg.unsafe_get(6) + g)
+  reg.unsafe_set(7, reg.unsafe_get(7) + h)
+}
+
+///|
+pub fn SHA512::update_from_iter(self : SHA512, data : Iter[Byte]) -> Unit {
+  let w = FixedArray::make(16, 0UL)
+  data.each(fn(b) {
+    self.buf[self.buf_index] = b
+    self.buf_index += 1
+    if self.buf_index == 128 {
+      self.buf_index = 0
+      let previous_len = self.len_low
+      self.len_low += 1024UL
+      if self.len_low < previous_len {
+        self.len_high += 1
+      }
+      SHA512::transform(self.buf, self.reg, w)
+    }
+  })
+}
+
+///|
+pub impl CryptoHasher for SHA512 with fn update(self : SHA512, data : BytesView) -> Unit {
+  self.update(data)
+}
+
+///|
+/// update the state of given context from new `data`
+pub fn[Data : ByteSource] SHA512::update(self : SHA512, data : Data) -> Unit {
+  let w = FixedArray::make(16, 0UL)
+  let data_len = data.length()
+  let mut offset = 0
+  while offset < data_len {
+    let min_len = @cmp.minimum(128 - self.buf_index, data_len - offset)
+    data.blit_to(
+      self.buf,
+      len=min_len,
+      src_offset=offset,
+      dst_offset=self.buf_index,
+    )
+    self.buf_index += min_len
+    if self.buf_index == 128 {
+      let previous_len = self.len_low
+      self.len_low += 1024UL
+      if self.len_low < previous_len {
+        self.len_high += 1
+      }
+      self.buf_index = 0
+      SHA512::transform(self.buf, self.reg, w)
+    }
+    offset += min_len
+  }
+}
+
+///|
+pub fn SHA512::finalize(self : SHA512) -> FixedArray[Byte] {
+  let ret = FixedArray::make(64, Byte::default())
+  self._finalize_into(ret)
+  ret
+}
+
+///|
+/// @param size the size of the output, defaults to 8 (i.e. 64 bytes). 6 for Sha384.
+fn SHA512::_finalize_into(
+  self : SHA512,
+  buffer : FixedArray[Byte],
+  size? : Int = 8,
+  offset? : Int = 0,
+) -> Unit {
+  // Copy data
+  let data = FixedArray::make(128, Byte::default())
+  let w = FixedArray::make(16, 0UL)
+  let mut cnt = self.buf_index
+  let buffered_bits = cnt.to_uint64() * 8UL
+  let len_low = self.len_low + buffered_bits
+  let len_high = self.len_high +
+    (if len_low < self.len_low { 1UL } else { 0UL })
+  self.buf.blit_to(data, len=cnt)
+  let reg = self.reg.copy()
+
+  // Padding
+  data[cnt] = b'\x80'
+  cnt += 1
+  if cnt > 112 {
+    SHA512::transform(data, reg, w)
+    data.fill(0)
+  }
+  // big-endian 128-bit bit length at bytes 112..128
+  data.unsafe_set(112, (len_high >> 56).to_byte())
+  data.unsafe_set(113, (len_high >> 48).to_byte())
+  data.unsafe_set(114, (len_high >> 40).to_byte())
+  data.unsafe_set(115, (len_high >> 32).to_byte())
+  data.unsafe_set(116, (len_high >> 24).to_byte())
+  data.unsafe_set(117, (len_high >> 16).to_byte())
+  data.unsafe_set(118, (len_high >> 8).to_byte())
+  data.unsafe_set(119, len_high.to_byte())
+  data.unsafe_set(120, (len_low >> 56).to_byte())
+  data.unsafe_set(121, (len_low >> 48).to_byte())
+  data.unsafe_set(122, (len_low >> 40).to_byte())
+  data.unsafe_set(123, (len_low >> 32).to_byte())
+  data.unsafe_set(124, (len_low >> 24).to_byte())
+  data.unsafe_set(125, (len_low >> 16).to_byte())
+  data.unsafe_set(126, (len_low >> 8).to_byte())
+  data.unsafe_set(127, len_low.to_byte())
+  SHA512::transform(data, reg, w)
+
+  // Write result to buffer
+  arr_u64_to_u8be_into(reg.iter().take(size), buffer, offset)
+}
+
+///|
+pub impl CryptoHasher for SHA512 with fn size(_self : SHA512) -> Int {
+  64
+}
+
+///|
+pub impl CryptoHasher for SHA512 with fn block_size(_self : SHA512) -> Int {
+  128
+}
+
+///|
+pub impl CryptoHasher for SHA512 with fn reset(self : SHA512) -> Unit {
+  self.reg[0] = 0x6a09e667f3bcc908UL
+  self.reg[1] = 0xbb67ae8584caa73bUL
+  self.reg[2] = 0x3c6ef372fe94f82bUL
+  self.reg[3] = 0xa54ff53a5f1d36f1UL
+  self.reg[4] = 0x510e527fade682d1UL
+  self.reg[5] = 0x9b05688c2b3e6c1fUL
+  self.reg[6] = 0x1f83d9abfb41bd6bUL
+  self.reg[7] = 0x5be0cd19137e2179UL
+  self.len_high = 0
+  self.len_low = 0
+  self.buf.fill(0)
+  self.buf_index = 0
+}
+
+///|
+/// Compute the Sha512 digest from given SHA512 context
+pub impl CryptoHasher for SHA512 with fn finalize_into(
+  self : SHA512,
+  buffer : FixedArray[Byte],
+  offset~ : Int,
+) -> Unit {
+  self._finalize_into(buffer, offset~)
+}
+
+///|
+/// Compute the Sha512 digest in `FixedArray[Byte]` of some `data`. Note that Sha512 is big-endian.
+pub fn[Data : ByteSource] sha512(data : Data) -> FixedArray[Byte] {
+  SHA512::new()..update(data).finalize()
+}
+
+///|
+pub fn sha512_from_iter(data : Iter[Byte]) -> FixedArray[Byte] {
+  SHA512::new()..update_from_iter(data).finalize()
+}
+
+///|
+test {
+  inspect(
+    bytes_to_hex_string(
+      sha512(
+        b"\x61\x62\x63", // abc in utf-8
+      ),
+    ),
+    content="ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f",
+  )
+  inspect(
+    bytes_to_hex_string(sha512(b"")),
+    content="cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e",
+  )
+  let hash1 = "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"
+  let ctx = SHA512::new()
+  ctx.update(b"\x61".to_fixedarray())
+  ctx.update(b"\x62".to_fixedarray())
+  ctx.update(b"\x63".to_fixedarray())
+  assert_eq(hash1, bytes_to_hex_string(ctx.finalize()))
+  let ctx = SHA512::new()
+  let data = b"\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64\x61\x62\x63\x64"
+  for i = 0; i < data.length(); i = i + 1 {
+    ctx.update(FixedArray::make(1, data[i]))
+  }
+  inspect(
+    bytes_to_hex_string(ctx.finalize()),
+    content="f0b5438f3aff13de9b33130a87b2ea33b8610de70971377e8a1a8718e7dd7400b7bfa98e1d1a65b9232e3efd76483dd88b0516b72d61c1054c08efa0861101c7",
+  )
+  let ctx = SHA512::new()
+  for i = 0; i < data.length(); i = i + 4 {
+    ctx.update_from_iter(b"\x61\x62\x63\x64".iter())
+  }
+  inspect(
+    bytes_to_hex_string(ctx.finalize()),
+    content="f0b5438f3aff13de9b33130a87b2ea33b8610de70971377e8a1a8718e7dd7400b7bfa98e1d1a65b9232e3efd76483dd88b0516b72d61c1054c08efa0861101c7",
+  )
+}
+
+///|
+test "sha512 reentry" {
+  let string = b"abcd"
+  let ctx = SHA512::new()
+  ctx.update(string)
+  inspect(
+    bytes_to_hex_string(ctx.finalize()),
+    content="d8022f2060ad6efd297ab73dcc5355c9b214054b0d1776a136a669d26a7d3b14f73aa0d0ebff19ee333368f0164b6419a96da49e3e481753e7e96b716bdccb6f",
+  )
+  ctx.update(string)
+  inspect(
+    bytes_to_hex_string(ctx.finalize()),
+    content="7edbb31279e6b88ac79812e2f77f5b234f817797c7cf98263d557ecfc992f1c43e8b169e11e3aaceb4407da8390517cac5e64f579344e15f589be5c20e7cecc8",
+  )
+  ctx.update(string)
+  inspect(
+    bytes_to_hex_string(ctx.finalize()),
+    content="6a4138ab1f504088a275272ca996c23690ffa201cf1a516cff1e6eb2e70e6a0b4abdf25ab9e9b99778fea957f2ac02ae1874cb287f5250fd4fac10fe9280b220",
+  )
+}
+
+///|
+test "sha512 carries the message length into the high word" {
+  let ctx = SHA512::new()
+  ctx.len_low = 0xfffffffffffffc00UL
+  ctx.update(FixedArray::make(128, b'\x00'))
+  inspect(ctx.len_high, content="1")
+  inspect(ctx.len_low, content="0")
+  let ctx = SHA512::new()
+  ctx.len_high = 1
+  inspect(
+    bytes_to_hex_string(ctx.finalize()),
+    content="4e15588b073f68f07592e9a51190a7e00e2efaaa365fb318f27e82e5c6df94a862d54b825cefcc3bd28977fcefc7fd8cac281f334977797ea395dbff21311a72",
+  )
+}
+
+///|
+pub extend SHA512 with CryptoHasher::{reset, finalize_into, size, block_size}

--- a/crypto/simd.mbt
+++ b/crypto/simd.mbt
@@ -15,7 +15,7 @@
 ///|
 #cfg(any(target="native", target="wasm"))
 #inline
-fn parse_be_u32_block_into(
+fn parse_be_u32x16_into(
   bytes : FixedArray[Byte],
   byte_offset : Int,
   words : FixedArray[UInt],
@@ -36,7 +36,7 @@ fn parse_be_u32_block_into(
 ///|
 #cfg(not(any(target="native", target="wasm")))
 #inline
-fn parse_be_u32_block_into(
+fn parse_be_u32x16_into(
   bytes : FixedArray[Byte],
   byte_offset : Int,
   words : FixedArray[UInt],
@@ -49,6 +49,87 @@ fn parse_be_u32_block_into(
       (bytes.unsafe_get(offset + 1).to_uint() << 16) |
       (bytes.unsafe_get(offset + 2).to_uint() << 8) |
       bytes.unsafe_get(offset + 3).to_uint(),
+    )
+  }
+}
+
+///|
+#cfg(any(target="native", target="wasm"))
+#inline
+fn parse_le_u32x16_into(
+  bytes : FixedArray[Byte],
+  byte_offset : Int,
+  words : FixedArray[UInt],
+) -> Unit {
+  for group in 0..<4 {
+    let value = @v128.v128_load(bytes, byte_offset + group * 16)
+    let word_offset = group * 4
+    words.unsafe_set(word_offset, @v128.i32x4_extract_lane(value, 0))
+    words.unsafe_set(word_offset + 1, @v128.i32x4_extract_lane(value, 1))
+    words.unsafe_set(word_offset + 2, @v128.i32x4_extract_lane(value, 2))
+    words.unsafe_set(word_offset + 3, @v128.i32x4_extract_lane(value, 3))
+  }
+}
+
+///|
+#cfg(not(any(target="native", target="wasm")))
+#inline
+fn parse_le_u32x16_into(
+  bytes : FixedArray[Byte],
+  byte_offset : Int,
+  words : FixedArray[UInt],
+) -> Unit {
+  for word_offset in 0..<16 {
+    let offset = byte_offset + word_offset * 4
+    words.unsafe_set(
+      word_offset,
+      bytes.unsafe_get(offset).to_uint() |
+      (bytes.unsafe_get(offset + 1).to_uint() << 8) |
+      (bytes.unsafe_get(offset + 2).to_uint() << 16) |
+      (bytes.unsafe_get(offset + 3).to_uint() << 24),
+    )
+  }
+}
+
+///|
+#cfg(any(target="native", target="wasm"))
+#inline
+fn parse_be_u64x16_into(
+  bytes : FixedArray[Byte],
+  byte_offset : Int,
+  words : FixedArray[UInt64],
+) -> Unit {
+  for group in 0..<8 {
+    let value = @v128.v128_load(bytes, byte_offset + group * 16)
+    let value = @v128.i8x16_shuffle(
+      value, value, 7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8,
+    )
+    let word_offset = group * 2
+    words.unsafe_set(word_offset, @v128.i64x2_extract_lane(value, 0))
+    words.unsafe_set(word_offset + 1, @v128.i64x2_extract_lane(value, 1))
+  }
+}
+
+///|
+#cfg(not(any(target="native", target="wasm")))
+#inline
+fn parse_be_u64x16_into(
+  bytes : FixedArray[Byte],
+  byte_offset : Int,
+  words : FixedArray[UInt64],
+) -> Unit {
+  for word_offset in 0..<16 {
+    let offset = byte_offset + word_offset * 8
+    words.unsafe_set(
+      word_offset,
+      (bytes.unsafe_get(offset).to_uint64() << 56) |
+      (bytes.unsafe_get(offset + 1).to_uint64() << 48) |
+      (bytes.unsafe_get(offset + 2).to_uint64() << 40) |
+      (bytes.unsafe_get(offset + 3).to_uint64() << 32) |
+      (bytes.unsafe_get(offset + 4).to_uint64() << 24) |
+      (bytes.unsafe_get(offset + 5).to_uint64() << 16) |
+      (bytes.unsafe_get(offset + 6).to_uint64() << 8) |
+      bytes.unsafe_get(offset + 7).to_uint64(),
     )
   }
 }

--- a/crypto/sm3.mbt
+++ b/crypto/sm3.mbt
@@ -108,7 +108,7 @@ fn SM3::transform(
   let mut f = reg.unsafe_get(5)
   let mut g = reg.unsafe_get(6)
   let mut h = reg.unsafe_get(7)
-  parse_be_u32_block_into(data, 0, schedule)
+  parse_be_u32x16_into(data, 0, schedule)
   for index = 16; index < 68; index = index + 1 {
     schedule[index] = SM3::p_1(
         schedule[index - 16] ^
@@ -205,11 +205,7 @@ pub fn[Data : ByteSource] SM3::update(self : SM3, data : Data) -> Unit {
     let schedule = FixedArray::make(68, 0U)
     let mut offset = 0
     while offset < data_len {
-      let min_len = if 64 - self.buf_index >= data_len - offset {
-        data_len - offset
-      } else {
-        64 - self.buf_index
-      }
+      let min_len = @cmp.minimum(64 - self.buf_index, data_len - offset)
       data.blit_to(
         self.buf,
         len=min_len,

--- a/crypto/sm3_test.mbt
+++ b/crypto/sm3_test.mbt
@@ -21,33 +21,33 @@ fn sm3test(s : String) -> String {
 
 ///|
 test "sm3-additional" {
-  assert_eq(
+  @test.assert_eq(
     sm3test(""),
     "1ab21d8355cfa17f8e61194831e81a8f22bec8c728fefb747ed035eb5082aa2b",
   )
-  assert_eq(
+  @test.assert_eq(
     sm3test("a"),
     "f4ccf00ef22555dd42706fd542022232a726a16062134c3c0ffe8fc7fa6cfe83",
   )
-  assert_eq(
+  @test.assert_eq(
     sm3test("message digest"),
     "2f2fba46cd6817494d1451bb2a9e9a82d8c60aa355e8e52889b5f0dd32492f7f",
   )
-  assert_eq(
+  @test.assert_eq(
     sm3test("abcdefghijklmnopqrstuvwxyz"),
     "0470a95f1d8c774444b3d25b23fc064ac928909ddc1dd4766ca9d5e0c6210ba3",
   )
-  assert_eq(
+  @test.assert_eq(
     sm3test("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"),
     "829b71880a21666e5a415d21f7f9fa10b5a8e7ad31f9e013fac1b849820c538b",
   )
-  assert_eq(
+  @test.assert_eq(
     sm3test(
       "12345678901234567890123456789012345678901234567890123456789012345678901234567890",
     ),
     "e9ccf13e608c6a60e2677b932e3713e6bb146b3096aa20a3542ee694e7052474",
   )
-  assert_eq(
+  @test.assert_eq(
     sm3test(
       "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
     ),

--- a/crypto/utils.mbt
+++ b/crypto/utils.mbt
@@ -21,16 +21,16 @@ let hex_digits : FixedArray[String] = [
 ///|
 /// print a sequence of byte in hex representation
 pub fn[D : ByteSource] bytes_to_hex_string(input : D) -> String {
-  let mut ret = ""
-  for i = input.length() - 1; i >= 0; i = i - 1 {
+  let length = input.length()
+  let buffer = StringBuilder::new(size_hint=length * 2)
+  for i in 0..<length {
     let byte = input[i]
     let high = (byte.to_uint() >> 4) & 0xf
     let low = byte.to_int() & 0xf
-    let high_char = hex_digits[high.reinterpret_as_int()]
-    let low_char = hex_digits[low]
-    ret = high_char + low_char + ret
+    buffer.write_string(hex_digits[high.reinterpret_as_int()])
+    buffer.write_string(hex_digits[low])
   }
-  ret
+  buffer.to_string()
 }
 
 ///|
@@ -78,6 +78,48 @@ fn arr_u32_to_u8be_into(
     buffer[idx + 3] = d.to_byte()
     idx += 4
   })
+}
+
+///|
+fn arr_u32_to_u8le_into(
+  x : Iter[UInt],
+  buffer : FixedArray[Byte],
+  offset : Int,
+) -> Unit {
+  let mut idx = offset
+  x.each(fn(d) {
+    buffer[idx + 0] = d.to_byte()
+    buffer[idx + 1] = (d >> 8).to_byte()
+    buffer[idx + 2] = (d >> 16).to_byte()
+    buffer[idx + 3] = (d >> 24).to_byte()
+    idx += 4
+  })
+}
+
+///|
+fn arr_u64_to_u8be_into(
+  x : Iter[UInt64],
+  buffer : FixedArray[Byte],
+  offset : Int,
+) -> Unit {
+  let mut idx = offset
+  x.each(fn(d) {
+    buffer[idx + 0] = (d >> 56).to_byte()
+    buffer[idx + 1] = (d >> 48).to_byte()
+    buffer[idx + 2] = (d >> 40).to_byte()
+    buffer[idx + 3] = (d >> 32).to_byte()
+    buffer[idx + 4] = (d >> 24).to_byte()
+    buffer[idx + 5] = (d >> 16).to_byte()
+    buffer[idx + 6] = (d >> 8).to_byte()
+    buffer[idx + 7] = d.to_byte()
+    idx += 8
+  })
+}
+
+///|
+/// rotate a UInt64 `x` right by `n` bit(s)
+fn rotate_right_u64(x : UInt64, n : Int) -> UInt64 {
+  (x >> n) | (x << (64 - n))
 }
 
 ///|


### PR DESCRIPTION
## Summary

Ports the crypto primitives from the `mbtexcel` (office.mbt) private crypto package into `@crypto` so that project can drop its private copy:

- **MD4**: streaming `MD4` context with `CryptoHasher`, `md4`, and `md4_from_iter` (RFC 1320)
- **RIPEMD-160**: streaming `RIPEMD160` context with `CryptoHasher`, `ripemd160`, and `ripemd160_from_iter`
- **SHA-512 / SHA-384**: streaming `SHA512` context with `CryptoHasher`, `sha512` and `sha384`, plus iterator variants
- **AES-128/192/256**: ECB and CBC modes with no padding, validating key, IV, and data lengths through `CryptoError`
- **Hash plumbing**: internal SIMD parse helpers with scalar fallbacks

The public surface is limited to crypto APIs. AES key schedules and block operations are internal; the mode functions provide the supported AES interface. The `SHA256` and `SHA512` constructors no longer expose custom initial-state parameters, and SHA-224/SHA-384 use package-private constructors.

## Fixes Since Review

- `ChaCha::transform_checked` now rejects invalid output ranges with `ChaChaError::InvalidOutputRange` before writing output or advancing cipher state.
- `ChaCha::transform` now validates the same range before aborting, preventing target-size failures after partial stream consumption.
- Added regression coverage for a short output target, including preservation of both output bytes and cipher position.

## Testing

- RFC/NIST vectors: FIPS 197 Appendix C (AES), RFC 1320 (MD4), RIPEMD-160 specification vectors, FIPS 180-4 (SHA-512/384), and NIST SP 800-38A
- Incremental, byte-at-a-time, and reentry equivalence tests
- AES-128 ECB benchmark verified against OpenSSL
- `moon check crypto`
- `moon test crypto` and `moon test crypto --target js`: 50 passed each
- `moon test`: 571 passed, 0 failed
