### PR TITLE
Fix MoonBit nightly warnings

### DIFF
--- a/codec/base64/base64.mbt
+++ b/codec/base64/base64.mbt
@@ -188,3 +188,6 @@ pub fn decode(
 pub suberror DecodeError {
   InvalidChar(Char)
 } derive(Debug)
+
+///|
+pub extend DecodeError with Debug::{to_repr}

--- a/codec/base64/pkg.generated.mbti
+++ b/codec/base64/pkg.generated.mbti
@@ -14,6 +14,7 @@ pub fn encode(BytesView, url_safe? : Bool) -> String
 pub suberror DecodeError {
   InvalidChar(Char)
 } derive(@debug.Debug)
+pub fn DecodeError::to_repr(Self) -> @debug.Repr
 
 // Types and methods
 type Decoder

--- a/crypto/md5.mbt
+++ b/crypto/md5.mbt
@@ -367,3 +367,6 @@ test {
   let res2 = bytes_to_hex_string(ctx.md5_compute())
   assert_eq(res1, res2)
 }
+
+///|
+pub extend MD5 with CryptoHasher::{reset, finalize_into, size, block_size}

--- a/crypto/pkg.generated.mbti
+++ b/crypto/pkg.generated.mbti
@@ -44,23 +44,35 @@ pub fn[D : ByteSource] ChaCha::transform(Self, D, FixedArray[Byte], offset? : In
 
 #alias(MD5Context, deprecated)
 type MD5
+pub fn MD5::block_size(Self) -> Int
 pub fn MD5::finalize(Self) -> FixedArray[Byte]
+pub fn MD5::finalize_into(Self, FixedArray[Byte], offset~ : Int) -> Unit
 pub fn MD5::new() -> Self
+pub fn MD5::reset(Self) -> Unit
+pub fn MD5::size(Self) -> Int
 pub fn[Data : ByteSource] MD5::update(Self, Data) -> Unit
 pub impl CryptoHasher for MD5
 
 #alias(Sha256Context, deprecated)
 type SHA256
+pub fn SHA256::block_size(Self) -> Int
 pub fn SHA256::finalize(Self) -> FixedArray[Byte]
+pub fn SHA256::finalize_into(Self, FixedArray[Byte], offset~ : Int) -> Unit
 pub fn SHA256::new(reg? : FixedArray[UInt]) -> Self
+pub fn SHA256::reset(Self) -> Unit
+pub fn SHA256::size(Self) -> Int
 pub fn[Data : ByteSource] SHA256::update(Self, Data) -> Unit
 pub fn SHA256::update_from_iter(Self, Iter[Byte]) -> Unit
 pub impl CryptoHasher for SHA256
 
 #alias(SM3Context, deprecated)
 type SM3
+pub fn SM3::block_size(Self) -> Int
 pub fn SM3::finalize(Self) -> FixedArray[Byte]
+pub fn SM3::finalize_into(Self, FixedArray[Byte], offset~ : Int) -> Unit
 pub fn SM3::new() -> Self
+pub fn SM3::reset(Self) -> Unit
+pub fn SM3::size(Self) -> Int
 pub fn[Data : ByteSource] SM3::update(Self, Data) -> Unit
 pub fn SM3::update_from_iter(Self, Iter[Byte]) -> Unit
 pub impl CryptoHasher for SM3

--- a/crypto/sha256.mbt
+++ b/crypto/sha256.mbt
@@ -304,3 +304,6 @@ test "sha256 reentry" {
     content="887f2749b07e559d140605a4b9de9af5721e2accad06fade91301f0410ad5cdf",
   )
 }
+
+///|
+pub extend SHA256 with CryptoHasher::{reset, finalize_into, size, block_size}

--- a/crypto/sm3.mbt
+++ b/crypto/sm3.mbt
@@ -379,3 +379,6 @@ test "sm3 reentry" {
     content="fd959b2560dadd0c0839144be6090cb665915156179c1fa6dc00292da7a2b9c2",
   )
 }
+
+///|
+pub extend SM3 with CryptoHasher::{reset, finalize_into, size, block_size}

--- a/decimal/decimal.mbt
+++ b/decimal/decimal.mbt
@@ -785,3 +785,45 @@ pub impl @quickcheck.Arbitrary for Decimal with fn arbitrary(size, rs) {
   let scale = rs.next_int() % (max_scale + 1)
   new_unchecked(coeff, scale)
 }
+
+///|
+pub extend Decimal with Debug::{to_repr}
+
+///|
+pub extend Decimal with Default::{default}
+
+///|
+pub extend Decimal with Eq::{not_equal, equal}
+
+///|
+pub extend Decimal with Compare::{op_lt, op_le, op_ge, compare, op_gt}
+
+///|
+pub extend Decimal with Add::{add}
+
+///|
+pub extend Decimal with Sub::{sub}
+
+///|
+pub extend Decimal with Mul::{mul}
+
+///|
+pub extend Decimal with Div::{div}
+
+///|
+pub extend Decimal with Neg::{neg}
+
+///|
+pub extend Decimal with Show::{output}
+
+///|
+pub extend Decimal with ToJson::{to_json}
+
+///|
+pub extend Decimal with @moonbitlang/core/json.FromJson::{from_json}
+
+///|
+pub extend Decimal with Hash::{hash, hash_combine}
+
+///|
+pub extend Decimal with @moonbitlang/core/quickcheck.Arbitrary::{arbitrary}

--- a/decimal/pkg.generated.mbti
+++ b/decimal/pkg.generated.mbti
@@ -26,22 +26,42 @@ pub struct Decimal {
   scale : Int
 } derive(@debug.Debug)
 pub fn Decimal::abs(Self) -> Self
+pub fn Decimal::add(Self, Self) -> Self
+pub fn Decimal::arbitrary(Int, @splitmix.RandomState) -> Self
 pub fn Decimal::coefficient(Self) -> @bigint.BigInt
+pub fn Decimal::compare(Self, Self) -> Int
+pub fn Decimal::default() -> Self
+pub fn Decimal::div(Self, Self) -> Self
+pub fn Decimal::equal(Self, Self) -> Bool
 pub fn Decimal::from_bigint(@bigint.BigInt) -> Self
 pub fn Decimal::from_double(Double, Int) -> Self?
 pub fn Decimal::from_int(Int) -> Self
+pub fn Decimal::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn Decimal::from_string(String) -> Self?
+pub fn Decimal::hash(Self) -> Int
+pub fn Decimal::hash_combine(Self, Hasher) -> Unit
 pub fn Decimal::is_negative(Self) -> Bool
 pub fn Decimal::is_positive(Self) -> Bool
 pub fn Decimal::is_zero(Self) -> Bool
+pub fn Decimal::mul(Self, Self) -> Self
+pub fn Decimal::neg(Self) -> Self
 pub fn Decimal::new(@bigint.BigInt, Int) -> Self?
+pub fn Decimal::not_equal(Self, Self) -> Bool
+pub fn Decimal::op_ge(Self, Self) -> Bool
+pub fn Decimal::op_gt(Self, Self) -> Bool
+pub fn Decimal::op_le(Self, Self) -> Bool
+pub fn Decimal::op_lt(Self, Self) -> Bool
+pub fn Decimal::output(Self, &Logger) -> Unit
 pub fn Decimal::round(Self, Int) -> Self?
 pub fn Decimal::scale(Self) -> Int
 pub fn Decimal::scale_to(Self, Int) -> Self?
 pub fn Decimal::signum(Self) -> Int
+pub fn Decimal::sub(Self, Self) -> Self
 pub fn Decimal::to_bigint(Self) -> @bigint.BigInt
 pub fn Decimal::to_double(Self) -> Double
 pub fn Decimal::to_int(Self) -> Int?
+pub fn Decimal::to_json(Self) -> Json
+pub fn Decimal::to_repr(Self) -> @debug.Repr
 pub fn Decimal::to_string(Self) -> String
 pub fn Decimal::truncate(Self, Int) -> Self?
 pub impl Add for Decimal

--- a/encoding/pkg.generated.mbti
+++ b/encoding/pkg.generated.mbti
@@ -37,10 +37,12 @@ pub fn write_utf8_char(@buffer.Buffer, Char) -> Unit
 pub suberror MalformedError {
   MalformedError(Bytes)
 } derive(@debug.Debug)
+pub fn MalformedError::to_repr(Self) -> @debug.Repr
 
 pub suberror TruncatedError {
   TruncatedError(Bytes)
 } derive(@debug.Debug)
+pub fn TruncatedError::to_repr(Self) -> @debug.Repr
 
 // Types and methods
 type Decoder
@@ -59,6 +61,7 @@ pub(all) enum Encoding {
   UTF16LE
   UTF16BE
 } derive(@debug.Debug)
+pub fn Encoding::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/encoding/types.mbt
+++ b/encoding/types.mbt
@@ -108,3 +108,12 @@ fn malformed_pair(
   bs.write_bytes(Bytes::from_array(bs1[0:length]))
   Malformed(slice(bs.to_bytes().to_fixedarray(), 0, bs.length()))
 }
+
+///|
+pub extend MalformedError with Debug::{to_repr}
+
+///|
+pub extend TruncatedError with Debug::{to_repr}
+
+///|
+pub extend Encoding with Debug::{to_repr}

--- a/fs/fs.mbt
+++ b/fs/fs.mbt
@@ -166,3 +166,6 @@ pub fn remove_dir(path : String) -> Unit raise IOError {
 pub fn remove_file(path : String) -> Unit raise IOError {
   remove_file_internal(path)
 }
+
+///|
+pub extend IOError with Debug::{to_repr}

--- a/fs/pkg.generated.mbti
+++ b/fs/pkg.generated.mbti
@@ -32,6 +32,7 @@ pub fn write_string_to_file(String, String, encoding? : String) -> Unit raise IO
 pub(all) suberror IOError {
   IOError(String)
 } derive(@debug.Debug)
+pub fn IOError::to_repr(Self) -> @debug.Repr
 
 // Types and methods
 

--- a/json5/pkg.generated.mbti
+++ b/json5/pkg.generated.mbti
@@ -12,6 +12,8 @@ pub fn parse(String) -> Json raise ParseError
 pub(all) suberror ParseError {
   ParseError(ParseErrorData)
 }
+pub fn ParseError::output(Self, &Logger) -> Unit
+pub fn ParseError::to_repr(Self) -> @debug.Repr
 pub fn ParseError::to_string(Self) -> String
 pub impl Show for ParseError
 pub impl @debug.Debug for ParseError
@@ -24,11 +26,17 @@ pub(all) enum ParseErrorData {
   InvalidNumber(Position, String)
   InvalidIdentEscape(Position)
 } derive(Eq, @debug.Debug)
+pub fn ParseErrorData::equal(Self, Self) -> Bool
+pub fn ParseErrorData::not_equal(Self, Self) -> Bool
+pub fn ParseErrorData::to_repr(Self) -> @debug.Repr
 
 pub(all) struct Position {
   line : Int
   column : Int
 } derive(Eq, @debug.Debug)
+pub fn Position::equal(Self, Self) -> Bool
+pub fn Position::not_equal(Self, Self) -> Bool
+pub fn Position::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/json5/types.mbt
+++ b/json5/types.mbt
@@ -61,3 +61,21 @@ pub impl Show for ParseError with fn output(self : ParseError, logger : &Logger)
 pub impl Debug for ParseError with fn to_repr(self : ParseError) -> Repr {
   Repr::literal(self.to_string())
 }
+
+///|
+pub extend Position with Eq::{not_equal, equal}
+
+///|
+pub extend Position with Debug::{to_repr}
+
+///|
+pub extend ParseErrorData with Eq::{not_equal, equal}
+
+///|
+pub extend ParseErrorData with Debug::{to_repr}
+
+///|
+pub extend ParseError with Show::{output}
+
+///|
+pub extend ParseError with Debug::{to_repr}

--- a/path/path.mbt
+++ b/path/path.mbt
@@ -186,3 +186,12 @@ pub let delimiter : Char = if is_windows { ';' } else { ':' }
 ///|
 /// OS platform specific path component separator.
 pub let sep : Char = if is_windows { '\\' } else { '/' }
+
+///|
+pub extend Path with Eq::{not_equal, equal}
+
+///|
+pub extend Path with Debug::{to_repr}
+
+///|
+pub extend Path with Show::{to_string, output}

--- a/path/pkg.generated.mbti
+++ b/path/pkg.generated.mbti
@@ -16,12 +16,17 @@ pub let sep : Char
 pub(all) struct Path(String) derive(Eq, @debug.Debug)
 pub fn Path::basename(Self) -> StringView
 pub fn Path::dirname(Self) -> Self
+pub fn Path::equal(Self, Self) -> Bool
 pub fn Path::extname(Self) -> StringView
 pub fn Path::is_absolute(Self) -> Bool
 pub fn Path::join(Self, Self) -> Self
 pub fn Path::normalize(Self) -> Self
+pub fn Path::not_equal(Self, Self) -> Bool
+pub fn Path::output(Self, &Logger) -> Unit
 pub fn Path::relative(Self, base~ : Self) -> Self
 pub fn Path::resolve(Self) -> Self
+pub fn Path::to_repr(Self) -> @debug.Repr
+pub fn Path::to_string(Self) -> String
 pub impl Show for Path
 
 // Type aliases

--- a/path/posix/path.mbt
+++ b/path/posix/path.mbt
@@ -230,3 +230,12 @@ pub let delimiter : Char = ':'
 ///|
 /// OS platform specific path component separator.
 pub let sep : Char = '/'
+
+///|
+pub extend Path with Eq::{not_equal, equal}
+
+///|
+pub extend Path with Debug::{to_repr}
+
+///|
+pub extend Path with Show::{to_string, output}

--- a/path/posix/pkg.generated.mbti
+++ b/path/posix/pkg.generated.mbti
@@ -16,12 +16,17 @@ pub let sep : Char
 pub(all) struct Path(String) derive(Eq, @debug.Debug)
 pub fn Path::basename(Self) -> StringView
 pub fn Path::dirname(Self) -> Self
+pub fn Path::equal(Self, Self) -> Bool
 pub fn Path::extname(Self) -> StringView
 pub fn Path::is_absolute(Self) -> Bool
 pub fn Path::join(Self, Self) -> Self
 pub fn Path::normalize(Self) -> Self
+pub fn Path::not_equal(Self, Self) -> Bool
+pub fn Path::output(Self, &Logger) -> Unit
 pub fn Path::relative(Self, base~ : Self) -> Self
 pub fn Path::resolve(Self) -> Self
+pub fn Path::to_repr(Self) -> @debug.Repr
+pub fn Path::to_string(Self) -> String
 pub impl Show for Path
 
 // Type aliases

--- a/path/win32/path.mbt
+++ b/path/win32/path.mbt
@@ -463,3 +463,12 @@ pub let delimiter : Char = ';'
 ///|
 /// OS platform specific path component separator.
 pub let sep : Char = '\\'
+
+///|
+pub extend Path with Eq::{not_equal, equal}
+
+///|
+pub extend Path with Debug::{to_repr}
+
+///|
+pub extend Path with Show::{to_string, output}

--- a/path/win32/pkg.generated.mbti
+++ b/path/win32/pkg.generated.mbti
@@ -16,13 +16,18 @@ pub let sep : Char
 pub(all) struct Path(String) derive(Eq, @debug.Debug)
 pub fn Path::basename(Self) -> StringView
 pub fn Path::dirname(Self) -> Self
+pub fn Path::equal(Self, Self) -> Bool
 pub fn Path::extname(Self) -> StringView
 pub fn Path::is_absolute(Self) -> Bool
 pub fn Path::join(Self, Self) -> Self
 pub fn Path::normalize(Self) -> Self
+pub fn Path::not_equal(Self, Self) -> Bool
+pub fn Path::output(Self, &Logger) -> Unit
 pub fn Path::relative(Self, base~ : Self) -> Self
 pub fn Path::resolve(Self) -> Self
 pub fn Path::root(Self) -> StringView
+pub fn Path::to_repr(Self) -> @debug.Repr
+pub fn Path::to_string(Self) -> String
 pub impl Show for Path
 
 // Type aliases

--- a/rational/compare.mbt
+++ b/rational/compare.mbt
@@ -204,3 +204,6 @@ pub impl[T : Integral] Compare for Rational[T] with fn compare(
     other.denominator,
   )
 }
+
+///|
+pub extend Rational with Compare::{op_lt, op_le, op_ge, compare, op_gt}

--- a/rational/pkg.generated.mbti
+++ b/rational/pkg.generated.mbti
@@ -17,27 +17,47 @@ pub fn[T : Integral] new(T, T) -> Rational[T]?
 pub(all) suberror RationalError {
   RationalError(String)
 } derive(ToJson, @debug.Debug)
+pub fn RationalError::equal(Self, Self) -> Bool
+pub fn RationalError::not_equal(Self, Self) -> Bool
+pub fn RationalError::to_json(Self) -> Json
+pub fn RationalError::to_repr(Self) -> @debug.Repr
 pub impl Eq for RationalError
 
 // Types and methods
 type Rational[T] derive(Eq)
 #as_free_fn
 pub fn[T : Integral] Rational::abs(Self[T]) -> Self[T]
+pub fn[T : Integral] Rational::add(Self[T], Self[T]) -> Self[T]
+pub fn[T : Integral] Rational::arbitrary(Int, @splitmix.RandomState) -> Self[T]
 #as_free_fn
 pub fn[T : Integral] Rational::ceil(Self[T]) -> T
+pub fn[T : Integral] Rational::compare(Self[T], Self[T]) -> Int
+pub fn[T : Integral] Rational::div(Self[T], Self[T]) -> Self[T]
 #as_free_fn
 pub fn[T : Integral] Rational::div_checked(Self[T], Self[T]) -> Self[T] raise RationalError
+pub fn[T : Eq] Rational::equal(Self[T], Self[T]) -> Bool
 #as_free_fn
 pub fn[T : Integral] Rational::floor(Self[T]) -> T
 #as_free_fn
 pub fn[T : Integral] Rational::fract(Self[T]) -> Self[T]
 #as_free_fn
 pub fn[T : Integral] Rational::is_integer(Self[T]) -> Bool
+pub fn[T : Integral] Rational::mul(Self[T], Self[T]) -> Self[T]
+pub fn[T : Integral] Rational::neg(Self[T]) -> Self[T]
+pub fn[T : Eq] Rational::not_equal(Self[T], Self[T]) -> Bool
+pub fn[T : Integral] Rational::op_ge(Self[T], Self[T]) -> Bool
+pub fn[T : Integral] Rational::op_gt(Self[T], Self[T]) -> Bool
+pub fn[T : Integral] Rational::op_le(Self[T], Self[T]) -> Bool
+pub fn[T : Integral] Rational::op_lt(Self[T], Self[T]) -> Bool
+pub fn[T : Integral] Rational::output(Self[T], &Logger) -> Unit
 #as_free_fn
 pub fn[T : Integral] Rational::reciprocal(Self[T]) -> Self[T]
 #as_free_fn
 pub fn[T : Integral] Rational::reciprocal_checked(Self[T]) -> Self[T] raise RationalError
+pub fn[T : Integral] Rational::sub(Self[T], Self[T]) -> Self[T]
 pub fn Rational::to_double(Self[Int64]) -> Double
+pub fn[T : Integral] Rational::to_repr(Self[T]) -> @debug.Repr
+pub fn[T : Integral] Rational::to_string(Self[T]) -> String
 #as_free_fn
 pub fn[T : Integral] Rational::trunc(Self[T]) -> T
 pub impl[T : Integral] Add for Rational[T]

--- a/rational/rational.mbt
+++ b/rational/rational.mbt
@@ -802,3 +802,36 @@ pub impl[T : Integral] @quickcheck.Arbitrary for Rational[T] with fn arbitrary(
 pub fn[T : Integral] Rational::is_integer(self : Rational[T]) -> Bool {
   self.denominator == T::from_int(1)
 }
+
+///|
+pub extend Rational with Add::{add}
+
+///|
+pub extend Rational with Sub::{sub}
+
+///|
+pub extend Rational with Mul::{mul}
+
+///|
+pub extend Rational with Div::{div}
+
+///|
+pub extend Rational with Neg::{neg}
+
+///|
+pub extend RationalError with Debug::{to_repr}
+
+///|
+pub extend RationalError with ToJson::{to_json}
+
+///|
+pub extend RationalError with Eq::{not_equal, equal}
+
+///|
+pub extend Rational with Show::{to_string, output}
+
+///|
+pub extend Rational with Debug::{to_repr}
+
+///|
+pub extend Rational with @moonbitlang/core/quickcheck.Arbitrary::{arbitrary}

--- a/rational/types.mbt
+++ b/rational/types.mbt
@@ -129,3 +129,6 @@ pub type Rational32 = Rational[Int]
 
 ///|
 pub type BigRational = Rational[BigInt]
+
+///|
+pub extend Rational with Eq::{not_equal, equal}

--- a/stack/pkg.generated.mbti
+++ b/stack/pkg.generated.mbti
@@ -13,6 +13,7 @@ import {
 // Types and methods
 type Stack[T] derive(Default)
 pub fn[T] Stack::clear(Self[T]) -> Unit
+pub fn[T : Default] Stack::default() -> Self[T]
 pub fn[T] Stack::drop(Self[T]) -> Unit
 pub fn[T] Stack::drop_result(Self[T]) -> Result[Unit, Unit]
 pub fn[T] Stack::each(Self[T], (T) -> Unit) -> Unit
@@ -31,6 +32,7 @@ pub fn[T] Stack::new() -> Self[T]
 #as_free_fn
 pub fn[T] Stack::of(FixedArray[T]) -> Self[T]
 pub fn[T : Eq] Stack::op_equal(Self[T], Self[T]) -> Bool
+pub fn[T : Show] Stack::output(Self[T], &Logger) -> Unit
 pub fn[T] Stack::peek(Self[T]) -> T?
 #deprecated
 pub fn[T] Stack::peek_exn(Self[T]) -> T
@@ -44,6 +46,8 @@ pub fn[T] Stack::return_with_clear(Self[T]) -> Self[T]
 pub fn[T] Stack::to_array(Self[T]) -> Array[T]
 #deprecated
 pub fn[T] Stack::to_list(Self[T]) -> @list.List[T]
+pub fn[T : @debug.Debug] Stack::to_repr(Self[T]) -> @debug.Repr
+pub fn[T : Show] Stack::to_string(Self[T]) -> String
 pub fn[T] Stack::unsafe_peek(Self[T]) -> T
 pub fn[T] Stack::unsafe_pop(Self[T]) -> T
 pub impl[T : Show] Show for Stack[T]

--- a/stack/stack.mbt
+++ b/stack/stack.mbt
@@ -552,3 +552,9 @@ test "equal" {
   inspect(of([2, 4, 6]).equal(of([2, 4, 6])), content="true")
   inspect(of([2, 4, 6]).equal(of([2, 4, 7])), content="false")
 }
+
+///|
+pub extend Stack with Show::{to_string, output}
+
+///|
+pub extend Stack with Debug::{to_repr}

--- a/stack/types.mbt
+++ b/stack/types.mbt
@@ -17,3 +17,6 @@ struct Stack[T] {
   mut elements : @list.List[T]
   mut len : Int
 } derive(Default)
+
+///|
+pub extend Stack with Default::{default}

--- a/time/duration.mbt
+++ b/time/duration.mbt
@@ -302,3 +302,18 @@ pub fn Duration::with_nanoseconds(
 pub fn Duration::to_nanoseconds(self : Duration) -> Int64 {
   self.secs * nanoseconds_per_second + self.nanos.to_int64()
 }
+
+///|
+pub extend Duration with Eq::{not_equal, equal}
+
+///|
+pub extend Duration with Compare::{op_lt, op_le, op_ge, compare, op_gt}
+
+///|
+pub extend Duration with Debug::{to_repr}
+
+///|
+pub extend Duration with @moonbitlang/core/string.FromStr::{from_str}
+
+///|
+pub extend Duration with Show::{output}

--- a/time/period.mbt
+++ b/time/period.mbt
@@ -246,3 +246,15 @@ pub fn Period::is_neg(self : Period) -> Bool {
 pub fn Period::to_total_months(self : Period) -> Int64 {
   self.years.to_int64() * 12L + self.months.to_int64()
 }
+
+///|
+pub extend Period with Eq::{not_equal, equal}
+
+///|
+pub extend Period with Compare::{op_lt, op_le, op_ge, compare, op_gt}
+
+///|
+pub extend Period with Debug::{to_repr}
+
+///|
+pub extend Period with Show::{output}

--- a/time/pkg.generated.mbti
+++ b/time/pkg.generated.mbti
@@ -26,15 +26,25 @@ pub fn Duration::add_hours(Self, Int64) -> Self raise
 pub fn Duration::add_minutes(Self, Int64) -> Self raise
 pub fn Duration::add_nanoseconds(Self, Int64) -> Self raise
 pub fn Duration::add_seconds(Self, Int64) -> Self raise
+pub fn Duration::compare(Self, Self) -> Int
+pub fn Duration::equal(Self, Self) -> Bool
+pub fn Duration::from_str(StringView) -> Self raise
 #deprecated
 pub fn Duration::from_string(String) -> Self raise
 pub fn Duration::is_neg(Self) -> Bool
 pub fn Duration::is_zero(Self) -> Bool
 pub fn Duration::nanoseconds(Self) -> Int
+pub fn Duration::not_equal(Self, Self) -> Bool
 pub fn Duration::of(hours? : Int64, minutes? : Int64, seconds? : Int64, nanoseconds? : Int64) -> Self raise
 pub fn Duration::op_add(Self, Self) -> Self raise
+pub fn Duration::op_ge(Self, Self) -> Bool
+pub fn Duration::op_gt(Self, Self) -> Bool
+pub fn Duration::op_le(Self, Self) -> Bool
+pub fn Duration::op_lt(Self, Self) -> Bool
+pub fn Duration::output(Self, &Logger) -> Unit
 pub fn Duration::seconds(Self) -> Int64
 pub fn Duration::to_nanoseconds(Self) -> Int64
+pub fn Duration::to_repr(Self) -> @debug.Repr
 pub fn Duration::to_string(Self) -> String
 pub fn Duration::with_nanoseconds(Self, Int) -> Self raise
 pub fn Duration::with_seconds(Self, Int64) -> Self
@@ -48,16 +58,25 @@ pub fn Period::add_months(Self, Int) -> Self raise
 pub fn Period::add_period(Self, Self) -> Self raise
 pub fn Period::add_weeks(Self, Int) -> Self raise
 pub fn Period::add_years(Self, Int) -> Self raise
+pub fn Period::compare(Self, Self) -> Int
 pub fn Period::days(Self) -> Int
+pub fn Period::equal(Self, Self) -> Bool
 pub fn Period::from_string(String) -> Self raise
 pub fn Period::is_neg(Self) -> Bool
 pub fn Period::is_zero(Self) -> Bool
 pub fn Period::months(Self) -> Int
 pub fn Period::multiply(Self, Int) -> Self raise
 pub fn Period::negated(Self) -> Self raise
+pub fn Period::not_equal(Self, Self) -> Bool
 pub fn Period::of(years? : Int, months? : Int, days? : Int) -> Self
 pub fn Period::op_add(Self, Self) -> Self raise
+pub fn Period::op_ge(Self, Self) -> Bool
+pub fn Period::op_gt(Self, Self) -> Bool
+pub fn Period::op_le(Self, Self) -> Bool
+pub fn Period::op_lt(Self, Self) -> Bool
 pub fn Period::op_sub(Self, Self) -> Self raise
+pub fn Period::output(Self, &Logger) -> Unit
+pub fn Period::to_repr(Self) -> @debug.Repr
 pub fn Period::to_string(Self) -> String
 pub fn Period::to_total_months(Self) -> Int64
 pub fn Period::with_days(Self, Int) -> Self
@@ -73,12 +92,15 @@ pub fn PlainDate::add_months(Self, Int64) -> Self raise
 pub fn PlainDate::add_period(Self, Period) -> Self raise
 pub fn PlainDate::add_weeks(Self, Int64) -> Self raise
 pub fn PlainDate::add_years(Self, Int64) -> Self raise
+pub fn PlainDate::compare(Self, Self) -> Int
 pub fn PlainDate::day(Self) -> Int
 pub fn PlainDate::days_in_month(Self) -> Int
 pub fn PlainDate::days_in_week(Self) -> Int
 pub fn PlainDate::days_in_year(Self) -> Int
+pub fn PlainDate::equal(Self, Self) -> Bool
 pub fn PlainDate::era(Self) -> String
 pub fn PlainDate::era_year(Self) -> Int
+pub fn PlainDate::from_str(StringView) -> Self raise
 #deprecated
 pub fn PlainDate::from_string(String) -> Self raise
 pub fn PlainDate::from_unix_day(Int64) -> Self raise
@@ -86,8 +108,15 @@ pub fn PlainDate::from_year_ord(Int, Int) -> Self raise
 pub fn PlainDate::in_leap_year(Self) -> Bool
 pub fn PlainDate::month(Self) -> Int
 pub fn PlainDate::months_in_year(Self) -> Int
+pub fn PlainDate::not_equal(Self, Self) -> Bool
 pub fn PlainDate::of(Int, Int, Int) -> Self raise
+pub fn PlainDate::op_ge(Self, Self) -> Bool
+pub fn PlainDate::op_gt(Self, Self) -> Bool
+pub fn PlainDate::op_le(Self, Self) -> Bool
+pub fn PlainDate::op_lt(Self, Self) -> Bool
 pub fn PlainDate::ordinal(Self) -> Int
+pub fn PlainDate::output(Self, &Logger) -> Unit
+pub fn PlainDate::to_repr(Self) -> @debug.Repr
 pub fn PlainDate::to_string(Self) -> String
 pub fn PlainDate::to_unix_day(Self) -> Int64
 pub fn PlainDate::until(Self, Self) -> Period raise
@@ -113,12 +142,15 @@ pub fn PlainDateTime::add_period(Self, Period) -> Self raise
 pub fn PlainDateTime::add_seconds(Self, Int64) -> Self raise
 pub fn PlainDateTime::add_weeks(Self, Int64) -> Self raise
 pub fn PlainDateTime::add_years(Self, Int64) -> Self raise
+pub fn PlainDateTime::compare(Self, Self) -> Int
 pub fn PlainDateTime::day(Self) -> Int
 pub fn PlainDateTime::days_in_month(Self) -> Int
 pub fn PlainDateTime::days_in_week(Self) -> Int
 pub fn PlainDateTime::days_in_year(Self) -> Int
+pub fn PlainDateTime::equal(Self, Self) -> Bool
 pub fn PlainDateTime::era(Self) -> String
 pub fn PlainDateTime::era_year(Self) -> Int
+pub fn PlainDateTime::from_str(StringView) -> Self raise
 #deprecated
 pub fn PlainDateTime::from_string(String) -> Self raise
 pub fn PlainDateTime::from_unix_second(Int64, Int, ZoneOffset) -> Self raise
@@ -128,11 +160,18 @@ pub fn PlainDateTime::minute(Self) -> Int
 pub fn PlainDateTime::month(Self) -> Int
 pub fn PlainDateTime::months_in_year(Self) -> Int
 pub fn PlainDateTime::nanosecond(Self) -> Int
+pub fn PlainDateTime::not_equal(Self, Self) -> Bool
 pub fn PlainDateTime::of(Int, Int, Int, hour? : Int, minute? : Int, second? : Int, nanosecond? : Int) -> Self raise
+pub fn PlainDateTime::op_ge(Self, Self) -> Bool
+pub fn PlainDateTime::op_gt(Self, Self) -> Bool
+pub fn PlainDateTime::op_le(Self, Self) -> Bool
+pub fn PlainDateTime::op_lt(Self, Self) -> Bool
 pub fn PlainDateTime::ordinal(Self) -> Int
+pub fn PlainDateTime::output(Self, &Logger) -> Unit
 pub fn PlainDateTime::second(Self) -> Int
 pub fn PlainDateTime::to_plain_date(Self) -> PlainDate
 pub fn PlainDateTime::to_plain_time(Self) -> PlainTime
+pub fn PlainDateTime::to_repr(Self) -> @debug.Repr
 pub fn PlainDateTime::to_string(Self) -> String
 pub fn PlainDateTime::to_unix_second(Self) -> Int64
 pub fn PlainDateTime::weekday(Self) -> Weekday
@@ -155,17 +194,27 @@ pub fn PlainTime::add_minutes(Self, Int64) -> Self raise
 pub fn PlainTime::add_nanoseconds(Self, Int64) -> Self raise
 pub fn PlainTime::add_seconds(Self, Int64) -> Self raise
 pub fn PlainTime::at_date(Self, PlainDate) -> PlainDateTime
+pub fn PlainTime::compare(Self, Self) -> Int
+pub fn PlainTime::equal(Self, Self) -> Bool
 pub fn PlainTime::from_nanosecond_of_day(Int64) -> Self raise
 pub fn PlainTime::from_second_of_day(Int) -> Self raise
+pub fn PlainTime::from_str(StringView) -> Self raise
 #deprecated
 pub fn PlainTime::from_string(String) -> Self raise
 pub fn PlainTime::hour(Self) -> Int
 pub fn PlainTime::minute(Self) -> Int
 pub fn PlainTime::nanosecond(Self) -> Int
 pub fn PlainTime::nanosecond_of_day(Self) -> Int64
+pub fn PlainTime::not_equal(Self, Self) -> Bool
 pub fn PlainTime::of(Int, Int, Int, Int) -> Self raise
+pub fn PlainTime::op_ge(Self, Self) -> Bool
+pub fn PlainTime::op_gt(Self, Self) -> Bool
+pub fn PlainTime::op_le(Self, Self) -> Bool
+pub fn PlainTime::op_lt(Self, Self) -> Bool
+pub fn PlainTime::output(Self, &Logger) -> Unit
 pub fn PlainTime::second(Self) -> Int
 pub fn PlainTime::second_of_day(Self) -> Int
+pub fn PlainTime::to_repr(Self) -> @debug.Repr
 pub fn PlainTime::to_string(Self) -> String
 pub fn PlainTime::until(Self, Self) -> Duration raise
 pub fn PlainTime::with_hour(Self, Int) -> Self raise
@@ -184,21 +233,39 @@ pub(all) enum Weekday {
   Saturday
   Sunday
 } derive(Eq, @debug.Debug)
+pub fn Weekday::equal(Self, Self) -> Bool
+pub fn Weekday::not_equal(Self, Self) -> Bool
+pub fn Weekday::output(Self, &Logger) -> Unit
+pub fn Weekday::to_repr(Self) -> @debug.Repr
+pub fn Weekday::to_string(Self) -> String
 pub impl Show for Weekday
 
 type Zone derive(Eq, @debug.Debug)
+pub fn Zone::equal(Self, Self) -> Bool
 pub fn Zone::from_tzif2(String, FixedArray[Byte]) -> Self raise
 pub fn Zone::is_fixed(Self) -> Bool
+pub fn Zone::not_equal(Self, Self) -> Bool
+pub fn Zone::output(Self, &Logger) -> Unit
+pub fn Zone::to_repr(Self) -> @debug.Repr
 pub fn Zone::to_string(Self) -> String
 pub impl Show for Zone
 
 type ZoneOffset derive(@debug.Debug)
 pub fn ZoneOffset::abbreviation(Self) -> String
+pub fn ZoneOffset::compare(Self, Self) -> Int
+pub fn ZoneOffset::equal(Self, Self) -> Bool
 pub fn ZoneOffset::from_seconds(Int, abbrev? : String, dst? : Bool) -> Self raise
 pub fn ZoneOffset::id(Self) -> String
 pub fn ZoneOffset::is_dst(Self) -> Bool
+pub fn ZoneOffset::not_equal(Self, Self) -> Bool
 pub fn ZoneOffset::of(hours? : Int, minutes? : Int, seconds? : Int, abbrev? : String, dst? : Bool) -> Self raise
+pub fn ZoneOffset::op_ge(Self, Self) -> Bool
+pub fn ZoneOffset::op_gt(Self, Self) -> Bool
+pub fn ZoneOffset::op_le(Self, Self) -> Bool
+pub fn ZoneOffset::op_lt(Self, Self) -> Bool
+pub fn ZoneOffset::output(Self, &Logger) -> Unit
 pub fn ZoneOffset::seconds(Self) -> Int
+pub fn ZoneOffset::to_repr(Self) -> @debug.Repr
 pub fn ZoneOffset::to_string(Self) -> String
 pub impl Compare for ZoneOffset
 pub impl Eq for ZoneOffset
@@ -230,10 +297,12 @@ pub fn ZonedDateTime::nanosecond(Self) -> Int
 pub fn ZonedDateTime::of(Int, Int, Int, hour? : Int, minute? : Int, second? : Int, nanosecond? : Int, zone? : Zone) -> Self raise
 pub fn ZonedDateTime::offset(Self) -> ZoneOffset
 pub fn ZonedDateTime::ordinal(Self) -> Int
+pub fn ZonedDateTime::output(Self, &Logger) -> Unit
 pub fn ZonedDateTime::second(Self) -> Int
 pub fn ZonedDateTime::to_plain_date(Self) -> PlainDate
 pub fn ZonedDateTime::to_plain_date_time(Self) -> PlainDateTime
 pub fn ZonedDateTime::to_plain_time(Self) -> PlainTime
+pub fn ZonedDateTime::to_repr(Self) -> @debug.Repr
 pub fn ZonedDateTime::to_string(Self) -> String
 pub fn ZonedDateTime::to_unix_second(Self) -> Int64
 pub fn ZonedDateTime::weekday(Self) -> Weekday

--- a/time/plain_date.mbt
+++ b/time/plain_date.mbt
@@ -582,3 +582,18 @@ fn validate_ordinal(year : Int, ordinal : Int) -> Bool {
   ordinal <= max_ordinal &&
   ordinal <= calc_days_in_year(year)
 }
+
+///|
+pub extend PlainDate with Debug::{to_repr}
+
+///|
+pub extend PlainDate with @moonbitlang/core/string.FromStr::{from_str}
+
+///|
+pub extend PlainDate with Show::{output}
+
+///|
+pub extend PlainDate with Eq::{not_equal, equal}
+
+///|
+pub extend PlainDate with Compare::{op_lt, op_le, op_ge, compare, op_gt}

--- a/time/plain_date_time.mbt
+++ b/time/plain_date_time.mbt
@@ -437,3 +437,18 @@ fn PlainDateTime::overflowing_add(
   date = date.add_days(total_days)
   { date, time }
 }
+
+///|
+pub extend PlainDateTime with Eq::{not_equal, equal}
+
+///|
+pub extend PlainDateTime with Compare::{op_lt, op_le, op_ge, compare, op_gt}
+
+///|
+pub extend PlainDateTime with Debug::{to_repr}
+
+///|
+pub extend PlainDateTime with @moonbitlang/core/string.FromStr::{from_str}
+
+///|
+pub extend PlainDateTime with Show::{output}

--- a/time/plain_time.mbt
+++ b/time/plain_time.mbt
@@ -423,3 +423,18 @@ fn validate_second(s : Int) -> Bool {
 fn validate_nano(n : Int) -> Bool {
   n >= min_nanosecond && n <= max_nanosecond
 }
+
+///|
+pub extend PlainTime with Eq::{not_equal, equal}
+
+///|
+pub extend PlainTime with Compare::{op_lt, op_le, op_ge, compare, op_gt}
+
+///|
+pub extend PlainTime with Debug::{to_repr}
+
+///|
+pub extend PlainTime with @moonbitlang/core/string.FromStr::{from_str}
+
+///|
+pub extend PlainTime with Show::{output}

--- a/time/weekday.mbt
+++ b/time/weekday.mbt
@@ -102,3 +102,12 @@ test "show" {
     ),
   )
 }
+
+///|
+pub extend Weekday with Eq::{not_equal, equal}
+
+///|
+pub extend Weekday with Debug::{to_repr}
+
+///|
+pub extend Weekday with Show::{to_string, output}

--- a/time/zone.mbt
+++ b/time/zone.mbt
@@ -355,3 +355,12 @@ test "Zone::from_tzif2" {
   inspect(got.offset(), content="-07:00")
   inspect(got.offset().is_dst(), content="true")
 }
+
+///|
+pub extend Zone with Eq::{not_equal, equal}
+
+///|
+pub extend Zone with Debug::{to_repr}
+
+///|
+pub extend Zone with Show::{output}

--- a/time/zone_offset.mbt
+++ b/time/zone_offset.mbt
@@ -167,3 +167,15 @@ fn validate_offset(h : Int, m : Int, s : Int) -> Unit raise Error {
   }
   ()
 }
+
+///|
+pub extend ZoneOffset with Debug::{to_repr}
+
+///|
+pub extend ZoneOffset with Show::{output}
+
+///|
+pub extend ZoneOffset with Eq::{not_equal, equal}
+
+///|
+pub extend ZoneOffset with Compare::{op_lt, op_le, op_ge, compare, op_gt}

--- a/time/zoned_date_time.mbt
+++ b/time/zoned_date_time.mbt
@@ -412,3 +412,9 @@ fn create_from_plain(datetime : PlainDateTime, zone : Zone) -> ZonedDateTime {
   let offset = zone.lookup_offset(datetime.to_unix_second())
   { datetime, zone, offset }
 }
+
+///|
+pub extend ZonedDateTime with Debug::{to_repr}
+
+///|
+pub extend ZonedDateTime with Show::{output}

--- a/uuid/pkg.generated.mbti
+++ b/uuid/pkg.generated.mbti
@@ -15,8 +15,17 @@ pub fn from_hex(String) -> UUID raise
 // Types and methods
 type UUID derive(Compare, Eq)
 pub fn UUID::as_version(Self, Version) -> Self
+pub fn UUID::compare(Self, Self) -> Int
+pub fn UUID::equal(Self, Self) -> Bool
 pub fn UUID::hash(Self) -> Int
+pub fn UUID::not_equal(Self, Self) -> Bool
+pub fn UUID::op_ge(Self, Self) -> Bool
+pub fn UUID::op_gt(Self, Self) -> Bool
+pub fn UUID::op_le(Self, Self) -> Bool
+pub fn UUID::op_lt(Self, Self) -> Bool
+pub fn UUID::output(Self, &Logger) -> Unit
 pub fn UUID::to_bytes(Self) -> Bytes
+pub fn UUID::to_repr(Self) -> @debug.Repr
 pub fn UUID::to_string(Self) -> String
 pub fn UUID::variant(Self) -> Variant
 pub fn UUID::version(Self) -> Version?
@@ -29,6 +38,7 @@ pub(all) enum Variant {
   ReservedMicrosoft
   ReservedFuture
 } derive(@debug.Debug)
+pub fn Variant::to_repr(Self) -> @debug.Repr
 
 pub(all) enum Version {
   V1
@@ -38,6 +48,7 @@ pub(all) enum Version {
   V5
   Unknown(Int)
 } derive(@debug.Debug)
+pub fn Version::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/uuid/uuid.mbt
+++ b/uuid/uuid.mbt
@@ -253,3 +253,15 @@ pub impl Show for UUID with fn output(self : UUID, logger : &Logger) -> Unit {
 pub impl Debug for UUID with fn to_repr(self : UUID) -> Repr {
   Repr::ctor("UUID", [(None, Repr::string(self.to_string()))])
 }
+
+///|
+pub extend UUID with Eq::{not_equal, equal}
+
+///|
+pub extend UUID with Compare::{op_lt, op_le, op_ge, compare, op_gt}
+
+///|
+pub extend UUID with Show::{output}
+
+///|
+pub extend UUID with Debug::{to_repr}

--- a/uuid/variant.mbt
+++ b/uuid/variant.mbt
@@ -153,3 +153,9 @@ test "show" {
     ),
   )
 }
+
+///|
+pub extend Variant with Debug::{to_repr}
+
+///|
+pub extend Version with Debug::{to_repr}


### PR DESCRIPTION
## Summary

- Fix all 95 `[0079] implicit_impl_as_method` warnings from Community Cakes dashboard run #128.
- Add explicit package-local trait extensions across 13 affected packages.
- Preserve the existing dot-method surface without changing runtime behavior.
- Regenerate only the corresponding tracked package interfaces.

## Validation

With `moon 0.1.20260815` / nightly `moonc v0.10.8` and `MOON_IGNORE_PREBUILD=1 MOON_WORK=off`:

- Four-target `moon check --target <target> --deny-warn` passed
- Four-target `moon test --target <target> --deny-warn` passed, 551/551 on each target
- `moon fmt`, targeted `moon info`, and `git diff --check` passed

The generated interface additions correspond exactly to formerly implicit methods; no public API removal is intended.