### PR TITLE
fix: replace deprecated trait method extension calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed deprecation warnings from trait method extension calls in
+  `@rational`, `@time`, `@path`, `@uuid`, and `@decimal`
+
 ## [0.4.50]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - Fixed deprecation warnings from trait method extension calls in
-  `@rational`, `@time`, `@path`, `@uuid`, and `@decimal`
+  `@rational`, `@time`, `@path`, `@uuid`, and `@decimal` (#302)
 
 ## [0.4.50]
 

--- a/decimal/decimal_test.mbt
+++ b/decimal/decimal_test.mbt
@@ -283,7 +283,7 @@ test "decimal_properties" {
   inspect(abs_d2.to_string(), content="67.89")
 
   // Test neg
-  let neg_d1 = d1.neg()
+  let neg_d1 = Neg::neg(d1)
   inspect(neg_d1.to_string(), content="-123.45")
 }
 
@@ -409,7 +409,7 @@ test "decimal_json_serialization" {
   }
 
   // Test to_json
-  let json = d.to_json()
+  let json = ToJson::to_json(d)
   debug_inspect(
     json,
     content=(

--- a/path/path.mbt
+++ b/path/path.mbt
@@ -120,7 +120,7 @@ pub fn Path::join(lhs : Path, rhs : Path) -> Path {
   if is_windows {
     @win32.Path::join(lhs.0, rhs.0).0
   } else {
-    @posix.Path::join(lhs.0, rhs.0).to_string()
+    Show::to_string(@posix.Path::join(lhs.0, rhs.0))
   }
 }
 
@@ -137,9 +137,9 @@ pub fn Path::join(lhs : Path, rhs : Path) -> Path {
 /// See `@path/posix` and `@path/win32` for separator-specific examples.
 pub fn Path::normalize(path : Path) -> Path {
   if is_windows {
-    @win32.Path::normalize(path.0).to_string()
+    Show::to_string(@win32.Path::normalize(path.0))
   } else {
-    @posix.Path::normalize(path.0).to_string()
+    Show::to_string(@posix.Path::normalize(path.0))
   }
 }
 
@@ -173,9 +173,9 @@ pub fn Path::relative(path : Path, base~ : Path) -> Path {
 ///
 pub fn Path::resolve(path : Path) -> Path {
   if is_windows {
-    @win32.Path::resolve(path.0).to_string()
+    Show::to_string(@win32.Path::resolve(path.0))
   } else {
-    @posix.Path::resolve(path.0).to_string()
+    Show::to_string(@posix.Path::resolve(path.0))
   }
 }
 

--- a/path/posix/README.mbt.md
+++ b/path/posix/README.mbt.md
@@ -108,7 +108,7 @@ test "path joining" {
   inspect(path.join("/absolute"), content="relative/absolute")
   let path : Path = "/"
   let path = path.join("folder").join("file.txt")
-  inspect(path.to_string(), content="/folder/file.txt")
+  inspect(Show::to_string(path), content="/folder/file.txt")
 }
 ```
 

--- a/path/win32/README.mbt.md
+++ b/path/win32/README.mbt.md
@@ -126,7 +126,7 @@ test "path joining" {
   inspect(path.join("\\absolute"), content="relative\\absolute")
   let path : Path = "C:\\"
   inspect(
-    path.join("folder").join("file.txt").to_string(),
+    Show::to_string(path.join("folder").join("file.txt")),
     content="C:\\folder\\file.txt",
   )
 }

--- a/path/win32/path_test.mbt
+++ b/path/win32/path_test.mbt
@@ -504,13 +504,13 @@ fn test_current_dir_for_drive(drive : String) -> Path {
 ///|
 test "resolve drive-relative paths from current directory" {
   let c_cwd = test_current_dir_for_drive("C:")
-  inspect(Path::resolve("C:"), content=c_cwd.to_string())
-  inspect(Path::resolve("C:."), content=c_cwd.to_string())
-  inspect(Path::resolve("C:a"), content=c_cwd.join("a").to_string())
-  inspect(Path::resolve("C:a\\..\\b"), content=c_cwd.join("b").to_string())
+  inspect(Path::resolve("C:"), content=Show::to_string(c_cwd))
+  inspect(Path::resolve("C:."), content=Show::to_string(c_cwd))
+  inspect(Path::resolve("C:a"), content=Show::to_string(c_cwd.join("a")))
+  inspect(Path::resolve("C:a\\..\\b"), content=Show::to_string(c_cwd.join("b")))
   inspect(
     Path::resolve("D:a"),
-    content=test_current_dir_for_drive("D:").join("a").to_string(),
+    content=Show::to_string(test_current_dir_for_drive("D:").join("a")),
   )
 }
 

--- a/rational/README.mbt.md
+++ b/rational/README.mbt.md
@@ -38,7 +38,7 @@ test {
   assert_eq(a <= b, false)
   assert_eq(a > b, true)
   assert_eq(a >= b, true)
-  assert_eq(a.compare(b), 1)
+  assert_eq(Compare::compare(a, b), 1)
 }
 ```
 
@@ -52,7 +52,7 @@ test {
   let a = @rational.new(1L, 2L).unwrap()
   assert_eq(a.floor(), 0)
   assert_eq(a.ceil(), 1)
-  assert_eq(a.fract().to_string(), "1/2")
+  assert_eq(Show::to_string(a.fract()), "1/2")
   assert_eq(a.trunc(), 0)
   assert_eq(a.is_integer(), false)
 }
@@ -67,7 +67,7 @@ The `Rational` type supports the following double operations:
 test {
   let a = @rational.new(1L, 2L).unwrap()
   assert_eq(a.to_double(), 0.5)
-  assert_eq(@rational.from_double(0.5).to_string(), "1/2")
+  assert_eq(Show::to_string(@rational.from_double(0.5)), "1/2")
 }
 ```
 
@@ -79,6 +79,6 @@ The `Rational` type supports the following string operations:
 ///|
 test {
   let a = @rational.new(1L, 2L).unwrap()
-  assert_eq(a.to_string(), "1/2")
+  assert_eq(Show::to_string(a), "1/2")
 }
 ```

--- a/rational/compare.mbt
+++ b/rational/compare.mbt
@@ -172,13 +172,13 @@ pub impl Integral for BigInt with fn compare_fraction(
 /// test {
 ///   let a = @rational.new(1L, 2L).unwrap() // 1/2
 ///   let b = @rational.new(2L, 3L).unwrap() // 2/3
-///   inspect(a.compare(b), content="-1") // 1/2 < 2/3
+///   inspect(Compare::compare(a, b), content="-1") // 1/2 < 2/3
 ///   let c = @rational.new(3L, 4L).unwrap() // 3/4
 ///   let d = @rational.new(3L, 4L).unwrap() // 3/4
-///   inspect(c.compare(d), content="0") // 3/4 == 3/4
+///   inspect(Compare::compare(c, d), content="0") // 3/4 == 3/4
 ///   let e = @rational.new(5L, 6L).unwrap() // 5/6
 ///   let f = @rational.new(1L, 2L).unwrap() // 1/2
-///   inspect(e.compare(f), content="1") // 5/6 > 1/2
+///   inspect(Compare::compare(e, f), content="1") // 5/6 > 1/2
 /// }
 /// ```
 ///

--- a/rational/rational.mbt
+++ b/rational/rational.mbt
@@ -339,10 +339,10 @@ pub fn[T : Integral] Rational::reciprocal_checked(
 /// test {
 ///   let positive = @rational.new(3L, 4L).unwrap()
 ///   let negative = -positive
-///   inspect(negative.to_string(), content="-3/4")
+///   inspect(Show::to_string(negative), content="-3/4")
 ///   let negative_original = @rational.new(-5L, 2L).unwrap()
 ///   let positive_result = -negative_original
-///   inspect(positive_result.to_string(), content="5/2")
+///   inspect(Show::to_string(positive_result), content="5/2")
 /// }
 /// ```
 ///
@@ -755,7 +755,7 @@ pub impl[T : Integral] Show for Rational[T] with fn output(self, logger) {
 
 ///|
 pub impl[T : Integral] Debug for Rational[T] with fn to_repr(self) {
-  Repr::literal(self.to_string())
+  Repr::literal(Show::to_string(self))
 }
 
 ///|

--- a/rational/rational_test.mbt
+++ b/rational/rational_test.mbt
@@ -209,11 +209,11 @@ test "compare no overflow (int64 max denom)" {
   let max = 9223372036854775807L
   let a = @rational.new(1L, max).unwrap()
   let b = @rational.new(2L, max).unwrap()
-  @test.assert_eq(a.compare(b), -1)
+  @test.assert_eq(Compare::compare(a, b), -1)
 
   let x = @rational.new(-43L, 3689348814741910693L).unwrap()
   let y = @rational.new(5L, -43L).unwrap()
-  assert_true(x.compare(y) > 0)
+  assert_true(Compare::compare(x, y) > 0)
 }
 
 ///|
@@ -221,17 +221,17 @@ test "compare fixed-width boundary values" {
   let int_max = @int.MAX_VALUE
   let a = @rational.new(1, int_max).unwrap()
   let b = @rational.new(2, int_max).unwrap()
-  @test.assert_eq(a.compare(b), -1)
+  @test.assert_eq(Compare::compare(a, b), -1)
 
   let int64_max = @int64.MAX_VALUE
   let large_negative = @rational.new(@int64.MIN_VALUE, 1L).unwrap()
   let half_large_negative = @rational.new(-int64_max, 2L).unwrap()
-  @test.assert_eq(large_negative.compare(half_large_negative), -1)
-  @test.assert_eq(half_large_negative.compare(large_negative), 1)
+  @test.assert_eq(Compare::compare(large_negative, half_large_negative), -1)
+  @test.assert_eq(Compare::compare(half_large_negative, large_negative), 1)
 
   let positive = @rational.new(int64_max - 1L, int64_max).unwrap()
   let negative = @rational.new(-1L, int64_max).unwrap()
-  @test.assert_eq(positive.compare(negative), 1)
+  @test.assert_eq(Compare::compare(positive, negative), 1)
 }
 
 ///|
@@ -271,8 +271,8 @@ test "int64 comparison matches bigint" {
             BigInt::from_int64(denominator2),
           ).unwrap()
           @test.assert_eq(
-            rational1.compare(rational2).compare(0),
-            big_rational1.compare(big_rational2).compare(0),
+            Compare::compare(Compare::compare(rational1, rational2), 0),
+            Compare::compare(Compare::compare(big_rational1, big_rational2), 0),
           )
         }
       }

--- a/rational/rational_wbtest.mbt
+++ b/rational/rational_wbtest.mbt
@@ -280,17 +280,17 @@ test "fract" {
 test "to_string" {
   // 1/2 -> "1/2"
   let a = new_unchecked(1L, 2L)
-  let b = a.to_string()
+  let b = Show::to_string(a)
   assert_eq(b, "1/2")
 
   // 4/4 -> "1"
   let a = new_unchecked(4L, 4L)
-  let b = a.to_string()
+  let b = Show::to_string(a)
   assert_eq(b, "1")
 
   // 0/1 -> "0"
   let a = new_unchecked(0L, 1L)
-  let b = a.to_string()
+  let b = Show::to_string(a)
   assert_eq(b, "0")
 }
 
@@ -318,26 +318,26 @@ test "eq and compare" {
   // 1/2 < 2/3
   let a = new_unchecked(1L, 2L)
   let b = new_unchecked(2L, 3L)
-  assert_eq(a.compare(b), -1)
+  assert_eq(Compare::compare(a, b), -1)
   assert_true(a != b)
 
   // -1/2 > -2/3
   let a = new_unchecked(-1L, 2L)
   let b = new_unchecked(-2L, 3L)
-  assert_eq(a.compare(b), 1)
+  assert_eq(Compare::compare(a, b), 1)
   assert_true(a != b)
 
   // 1/2 == 1/2
   let a = new_unchecked(1L, 2L)
   let b = new_unchecked(1L, 2L)
-  assert_eq(a.compare(b), 0)
+  assert_eq(Compare::compare(a, b), 0)
   assert_true(a == b)
 }
 
 ///|
 test "compare no overflow" {
   let p = new_unchecked(-3L, -9223372036854775808L)
-  assert_true(p.compare(-p) > 0)
+  assert_true(Compare::compare(p, -p) > 0)
 }
 
 ///|

--- a/time/duration_test.mbt
+++ b/time/duration_test.mbt
@@ -14,18 +14,25 @@
 
 ///|
 test "from_str" {
-  inspect(@time.Duration::from_str("PT0S"), content="PT0S")
+  inspect((@string.FromStr::from_str("PT0S") : @time.Duration), content="PT0S")
   inspect(
-    @time.Duration::from_str("PT1H2M3.456789S"),
+    (@string.FromStr::from_str("PT1H2M3.456789S") : @time.Duration),
     content="PT1H2M3.456789S",
   )
   inspect(
-    @time.Duration::from_str("PT-1H-2M-3.456789S"),
+    (@string.FromStr::from_str("PT-1H-2M-3.456789S") : @time.Duration),
     content="PT-1H-2M-3.456789S",
   )
-  inspect(@time.Duration::from_str("PT0.45S"), content="PT0.45S")
-  @test.assert_raise(() => @time.Duration::from_str("PT0.000.45S"))
-  @test.assert_raise(() => @time.Duration::from_str("P1Y2M3DT4H5M6S"))
+  inspect(
+    (@string.FromStr::from_str("PT0.45S") : @time.Duration),
+    content="PT0.45S",
+  )
+  @test.assert_raise(() => {
+    (@string.FromStr::from_str("PT0.000.45S") : @time.Duration)
+  })
+  @test.assert_raise(() => {
+    (@string.FromStr::from_str("P1Y2M3DT4H5M6S") : @time.Duration)
+  })
 }
 
 ///|

--- a/time/plain_date.mbt
+++ b/time/plain_date.mbt
@@ -119,7 +119,7 @@ pub impl Show for PlainDate with fn output(self : PlainDate, logger : &Logger) {
 
 ///|
 pub impl Eq for PlainDate with fn equal(self : PlainDate, other : PlainDate) -> Bool {
-  self.compare(other) == 0
+  Compare::compare(self, other) == 0
 }
 
 ///|

--- a/time/plain_date_test.mbt
+++ b/time/plain_date_test.mbt
@@ -43,15 +43,35 @@ test "from_year_ord" {
 
 ///|
 test "from_str" {
-  inspect(@time.PlainDate::from_str("9999-01-01"), content="9999-01-01")
-  inspect(@time.PlainDate::from_str("0000-01-01"), content="0000-01-01")
-  inspect(@time.PlainDate::from_str("0001-01-01"), content="0001-01-01")
-  inspect(@time.PlainDate::from_str("-9999-01-01"), content="-9999-01-01")
-  @test.assert_raise(() => @time.PlainDate::from_str("10000-01-01"))
-  @test.assert_raise(() => @time.PlainDate::from_str("-10000-01-01"))
-  @test.assert_raise(() => @time.PlainDate::from_str("-01-01"))
-  @test.assert_raise(() => @time.PlainDate::from_str("12-31"))
-  @test.assert_raise(() => @time.PlainDate::from_str("-01"))
+  inspect(
+    (@string.FromStr::from_str("9999-01-01") : @time.PlainDate),
+    content="9999-01-01",
+  )
+  inspect(
+    (@string.FromStr::from_str("0000-01-01") : @time.PlainDate),
+    content="0000-01-01",
+  )
+  inspect(
+    (@string.FromStr::from_str("0001-01-01") : @time.PlainDate),
+    content="0001-01-01",
+  )
+  inspect(
+    (@string.FromStr::from_str("-9999-01-01") : @time.PlainDate),
+    content="-9999-01-01",
+  )
+  @test.assert_raise(() => {
+    (@string.FromStr::from_str("10000-01-01") : @time.PlainDate)
+  })
+  @test.assert_raise(() => {
+    (@string.FromStr::from_str("-10000-01-01") : @time.PlainDate)
+  })
+  @test.assert_raise(() => {
+    (@string.FromStr::from_str("-01-01") : @time.PlainDate)
+  })
+  @test.assert_raise(() => {
+    (@string.FromStr::from_str("12-31") : @time.PlainDate)
+  })
+  @test.assert_raise(() => (@string.FromStr::from_str("-01") : @time.PlainDate))
 }
 
 ///|

--- a/time/plain_date_time_test.mbt
+++ b/time/plain_date_time_test.mbt
@@ -78,26 +78,38 @@ test "from_unix_second" {
 ///|
 test "from_str" {
   inspect(
-    @time.PlainDateTime::from_str("0000-01-01T00:00:00"),
+    (@string.FromStr::from_str("0000-01-01T00:00:00") : @time.PlainDateTime),
     content="0000-01-01T00:00:00",
   )
   inspect(
-    @time.PlainDateTime::from_str("9999-12-31T23:59:59"),
+    (@string.FromStr::from_str("9999-12-31T23:59:59") : @time.PlainDateTime),
     content="9999-12-31T23:59:59",
   )
   inspect(
-    @time.PlainDateTime::from_str("-9999-12-31T23:59:59"),
+    (@string.FromStr::from_str("-9999-12-31T23:59:59") : @time.PlainDateTime),
     content="-9999-12-31T23:59:59",
   )
   inspect(
-    @time.PlainDateTime::from_str("2000-01-01T00:00:00.12345"),
+    (
+      @string.FromStr::from_str("2000-01-01T00:00:00.12345") :
+      @time.PlainDateTime),
     content="2000-01-01T00:00:00.12345",
   )
-  @test.assert_raise(() => @time.PlainDateTime::from_str("9999-12-31T23:59:60"))
-  @test.assert_raise(() => @time.PlainDateTime::from_str("10000-12-31T23:59:60"))
-  @test.assert_raise(() => @time.PlainDateTime::from_str("2000-01-01 00:00:00"))
-  @test.assert_raise(() => @time.PlainDateTime::from_str("2000-01-01"))
-  @test.assert_raise(() => @time.PlainDateTime::from_str("00:00:00"))
+  @test.assert_raise(() => {
+    (@string.FromStr::from_str("9999-12-31T23:59:60") : @time.PlainDateTime)
+  })
+  @test.assert_raise(() => {
+    (@string.FromStr::from_str("10000-12-31T23:59:60") : @time.PlainDateTime)
+  })
+  @test.assert_raise(() => {
+    (@string.FromStr::from_str("2000-01-01 00:00:00") : @time.PlainDateTime)
+  })
+  @test.assert_raise(() => {
+    (@string.FromStr::from_str("2000-01-01") : @time.PlainDateTime)
+  })
+  @test.assert_raise(() => {
+    (@string.FromStr::from_str("00:00:00") : @time.PlainDateTime)
+  })
 }
 
 ///|

--- a/time/plain_time_test.mbt
+++ b/time/plain_time_test.mbt
@@ -26,21 +26,44 @@ test "of" {
 
 ///|
 test "from_str" {
-  inspect(@time.PlainTime::from_str("00:00"), content="00:00:00")
-  inspect(@time.PlainTime::from_str("23:59"), content="23:59:00")
-  inspect(@time.PlainTime::from_str("24:00"), content="24:00:00")
-  inspect(@time.PlainTime::from_str("23:59:59"), content="23:59:59")
-  inspect(@time.PlainTime::from_str("01:00:00.123"), content="01:00:00.123")
   inspect(
-    @time.PlainTime::from_str("01:00:00.0000123"),
+    (@string.FromStr::from_str("00:00") : @time.PlainTime),
+    content="00:00:00",
+  )
+  inspect(
+    (@string.FromStr::from_str("23:59") : @time.PlainTime),
+    content="23:59:00",
+  )
+  inspect(
+    (@string.FromStr::from_str("24:00") : @time.PlainTime),
+    content="24:00:00",
+  )
+  inspect(
+    (@string.FromStr::from_str("23:59:59") : @time.PlainTime),
+    content="23:59:59",
+  )
+  inspect(
+    (@string.FromStr::from_str("01:00:00.123") : @time.PlainTime),
+    content="01:00:00.123",
+  )
+  inspect(
+    (@string.FromStr::from_str("01:00:00.0000123") : @time.PlainTime),
     content="01:00:00.0000123",
   )
-  @test.assert_raise(() => @time.PlainTime::from_str("1:00"))
-  @test.assert_raise(() => @time.PlainTime::from_str("10:0"))
-  @test.assert_raise(() => @time.PlainTime::from_str("100000"))
-  @test.assert_raise(() => @time.PlainTime::from_str("123:00:00"))
-  @test.assert_raise(() => @time.PlainTime::from_str("10:00:00.123zzz"))
-  @test.assert_raise(() => @time.PlainTime::from_str("z1:00:00"))
+  @test.assert_raise(() => (@string.FromStr::from_str("1:00") : @time.PlainTime))
+  @test.assert_raise(() => (@string.FromStr::from_str("10:0") : @time.PlainTime))
+  @test.assert_raise(() => {
+    (@string.FromStr::from_str("100000") : @time.PlainTime)
+  })
+  @test.assert_raise(() => {
+    (@string.FromStr::from_str("123:00:00") : @time.PlainTime)
+  })
+  @test.assert_raise(() => {
+    (@string.FromStr::from_str("10:00:00.123zzz") : @time.PlainTime)
+  })
+  @test.assert_raise(() => {
+    (@string.FromStr::from_str("z1:00:00") : @time.PlainTime)
+  })
 }
 
 ///|

--- a/uuid/uuid_test.mbt
+++ b/uuid/uuid_test.mbt
@@ -35,8 +35,8 @@ test "ops" {
   let u1x = @uuid.from_hex(hex)
   let u2 = @uuid.from_hex("8e325b13-2bf1-d7f6-d2b0-c85a371c1878")
   inspect(u1 == u1x, content="true")
-  inspect(u1.compare(u2), content="1")
-  inspect(u2.compare(u1), content="-1")
-  inspect(u1.compare(u1x), content="0")
+  inspect(Compare::compare(u1, u2), content="1")
+  inspect(Compare::compare(u2, u1), content="-1")
+  inspect(Compare::compare(u1, u1x), content="0")
   assert_eq(u1, u1x)
 }


### PR DESCRIPTION
## Why

Commit `d0738da` deprecated the trait method extension syntax (e.g.
`Rational::compare`, `Path::to_string`, `PlainDate::from_str`, `Decimal::neg`,
`UUID::compare`) in favor of explicit trait method calls. After that change,
`moon check` reported 79 `Warning (deprecated)` diagnostics from the library's
own sources, doc examples, and tests.

## What

Replace every deprecated call site with the non-deprecated trait method form:

- `x.compare(y)` -> `Compare::compare(x, y)` (`@rational`, `@uuid`,
  `@time.PlainDate`)
- `x.to_string()` -> `Show::to_string(x)` (`@rational`, `@path` and its
  `posix`/`win32` subpackages)
- `Type::from_str(s)` -> `@string.FromStr::from_str(s)` with a type ascription
  (`@time` `Duration`/`PlainDate`/`PlainDateTime`/`PlainTime`)
- `x.neg()` -> `Neg::neg(x)`, `x.to_json()` -> `ToJson::to_json(x)`
  (`@decimal`)

Changes cover implementation code, doc comments, `README.mbt.md` examples, and
test suites.

## Verification

- `moon check`: no warnings, no errors
- `moon test`: 551 passed, 0 failed
- `moon info` / `moon fmt`: no `pkg.generated.mbti` changes