### PR TITLE
refactor: migrate StringBuilder usages to constructor syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Migrated internal `StringBuilder` usages to the constructor syntax `StringBuilder()`.
+
 ## [0.5.1]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Migrated internal `StringBuilder` usages to the constructor syntax `StringBuilder()`.
+- Migrated internal `StringBuilder` usages to the constructor syntax `StringBuilder()` (#307).
 
 ## [0.5.1]
 

--- a/codec/base64/base64.mbt
+++ b/codec/base64/base64.mbt
@@ -106,7 +106,7 @@ pub fn Encoder::encode_to(
 ///|
 /// Encode binary to ascii text following  defined in RFC 4648
 pub fn encode(bytes : BytesView, url_safe? : Bool = false) -> String {
-  let builder = StringBuilder::new()
+  let builder = StringBuilder()
   let encoder = Encoder::new()
   encoder.encode_to(
     bytes,

--- a/crypto/utils.mbt
+++ b/crypto/utils.mbt
@@ -22,7 +22,7 @@ let hex_digits : FixedArray[String] = [
 /// print a sequence of byte in hex representation
 pub fn[D : ByteSource] bytes_to_hex_string(input : D) -> String {
   let length = input.length()
-  let buffer = StringBuilder::new(size_hint=length * 2)
+  let buffer = StringBuilder(size_hint=length * 2)
   for i in 0..<length {
     let byte = input[i]
     let high = (byte.to_uint() >> 4) & 0xf
@@ -39,7 +39,7 @@ const HEX_DIGITS = "0123456789abcdef"
 ///|
 /// convert a sequence of `UInt` to hex representation
 pub fn uints_to_hex_string(input : Iter[UInt]) -> String {
-  let buffer = StringBuilder::new()
+  let buffer = StringBuilder()
   let rems : FixedArray[Int] = FixedArray::make(8, 0)
   for x in input {
     let mut value = x

--- a/encoding/decoding.mbt
+++ b/encoding/decoding.mbt
@@ -113,7 +113,7 @@ pub fn Decoder::decode(
   }
 
   // TODO: Estimate size_hint based on input and encoding more accurately
-  let builder = StringBuilder::new(size_hint=input.length())
+  let builder = StringBuilder(size_hint=input.length())
 
   // drive decoder to decode
   for state = self.decode_() {
@@ -159,7 +159,7 @@ pub fn Decoder::decode(
 /// ```moonbit check
 /// test {
 ///   let decoder = decoder(UTF8)
-///   let buf = StringBuilder::new()
+///   let buf = StringBuilder()
 ///   decoder.decode_to(b"Hello", buf)
 ///   inspect(buf.to_string(), content="Hello")
 /// }

--- a/encoding/decoding_test.mbt
+++ b/encoding/decoding_test.mbt
@@ -28,7 +28,7 @@ test "streaming decoding UTF8 rabbit" {
 test "decode_to/UTF8/stream" {
   let inputs = [b"abc", b"\xf0", b"\x9f\x90\xb0"] // UTF8(🐰) == <F09F 90B0>
   let decoder = @encoding.decoder(UTF8)
-  let acc = StringBuilder::new()
+  let acc = StringBuilder()
   decoder.decode_to(inputs[0], acc, stream=true)
   inspect(acc, content="abc")
   decoder.decode_to(inputs[1], acc, stream=true)
@@ -60,7 +60,7 @@ test "decode_to/UTF16LE/stream" {
     b"\x3D", b"\xD8\x30\xDC", b"\x3D\xD8", b"\x30\xDC", b"\x3D\xD8\x30", b"\xDC",
   ]
   let decoder = @encoding.decoder(UTF16LE)
-  let acc = StringBuilder::new()
+  let acc = StringBuilder()
   decoder.decode_to(inputs[0], acc, stream=true)
   inspect(acc, content="")
   decoder.decode_to(inputs[1], acc, stream=true)
@@ -245,7 +245,7 @@ test "decode_to/UTF16LE" {
   let buf = Buffer(size_hint=@encoding.encode(UTF16, src).length())
   buf.write_bytes(@encoding.encode(UTF16, src))
   let decoder = @encoding.decoder(UTF16LE)
-  let acc = StringBuilder::new()
+  let acc = StringBuilder()
   decoder.decode_to(buf.to_bytes(), acc)
   inspect(acc.to_string(), content="你好👀")
 }
@@ -305,7 +305,7 @@ test "decode_to/UTF16" {
   buf.write_bytes(b"\x36\x18")
   buf.write_bytes(b"\x20\x18")
   let decoder = @encoding.decoder(UTF16)
-  let acc = StringBuilder::new()
+  let acc = StringBuilder()
   decoder.decode_to(buf.to_bytes(), acc)
   inspect(acc.to_string(), content="ᡥᠠᡳᡤᡳᠶᠠ")
 }
@@ -334,7 +334,7 @@ test "decode_to/UTF16BE" {
   buf.write_bytes(b"\xd8\x3d\xdc\x07")
   buf.write_bytes(b"\xd8\x3d\xdc\x30")
   let decoder = @encoding.decoder(UTF16BE)
-  let acc = StringBuilder::new()
+  let acc = StringBuilder()
   decoder.decode_to(buf.to_bytes(), acc)
   inspect(acc.to_string(), content="🐈🐱🐇🐰")
 }
@@ -358,7 +358,7 @@ test "decode_to/UTF8" {
   buf.write_bytes(b"\xe5\xa5\xbd") // 好
   buf.write_bytes(b"\xf0\x9f\x91\x80") // 👀
   let decoder = @encoding.decoder(UTF8)
-  let acc = StringBuilder::new()
+  let acc = StringBuilder()
   decoder.decode_to(buf.to_bytes(), acc)
   inspect(acc.to_string(), content="你好👀")
 }
@@ -406,7 +406,7 @@ test "decode_to/UTF16LE-UTF8/MalformedError" {
   let buf = Buffer(size_hint=10)
   buf.write_string_utf16le(src)
   let decoder = @encoding.decoder(UTF8)
-  let acc = StringBuilder::new()
+  let acc = StringBuilder()
   debug_inspect(
     @test.expect_error(() => decoder.decode_to(buf.to_bytes(), acc)),
     content="MalformedError(<Bytes: [0xd8, 0xc3]>)",
@@ -421,7 +421,7 @@ test "decode_to/UTF16LE-UTF8/TruncatedError" {
   let bytes = buf.to_bytes()
   let bytes_view : Bytes = [..bytes[:bytes.length() - 1]]
   let decoder = @encoding.decoder(UTF16LE)
-  let acc = StringBuilder::new()
+  let acc = StringBuilder()
   let result = @test.expect_error(() => decoder.decode_to(bytes_view, acc))
   debug_inspect(
     result,
@@ -437,7 +437,7 @@ test "decode_to/UTF16LE-UTF8/stream" {
   let bytes = buf.to_bytes()
   let bytes_view : Bytes = [..bytes[:bytes.length() - 1]]
   let decoder = @encoding.decoder(UTF16LE)
-  let acc = StringBuilder::new()
+  let acc = StringBuilder()
   decoder.decode_to(bytes_view, acc, stream=true)
   inspect(acc.to_string(), content="跑步🏃游泳")
   decoder.decode_to([bytes[bytes.length() - 1]], acc, stream=true)
@@ -446,7 +446,7 @@ test "decode_to/UTF16LE-UTF8/stream" {
 
 ///|
 test "decode_to/empty" {
-  let acc = StringBuilder::new()
+  let acc = StringBuilder()
   let decoder = @encoding.decoder(UTF8)
   decoder.decode_to(b"", acc)
   inspect(acc.to_string(), content="")
@@ -478,7 +478,7 @@ test "decode_to/UTF8-UTF16LE" {
   let buf = Buffer(size_hint=10)
   buf.write_string_utf8(src)
   let decoder = @encoding.decoder(UTF16LE)
-  let acc = StringBuilder::new()
+  let acc = StringBuilder()
   decoder.decode_to(buf.to_bytes(), acc)
   // NOTE: Happens to be legal UTF16LE
   inspect(acc.to_string(), content="럨ꖭ鿰莏룦뎳鿰誏")
@@ -505,7 +505,7 @@ test "decode_to/UTF16BE-UTF8" {
   let buf = Buffer(size_hint=10)
   buf.write_string_utf16be(src)
   let decoder = @encoding.decoder(UTF8)
-  let acc = StringBuilder::new()
+  let acc = StringBuilder()
   debug_inspect(
     @test.expect_error(() => decoder.decode_to(buf.to_bytes(), acc)),
     content="MalformedError(<Bytes: [0x8d]>)",
@@ -549,7 +549,7 @@ test "decode_to/UTF8-UTF16BE" {
   let buf = Buffer(size_hint=10)
   buf.write_string_utf8(src)
   let decoder = @encoding.decoder(UTF16BE)
-  let acc = StringBuilder::new()
+  let acc = StringBuilder()
   decoder.decode_to(buf.to_bytes(), acc)
   // NOTE: Happens to be legal UTF16BE
   inspect(acc.to_string(), content="釦궥较룦뎳辊")
@@ -579,7 +579,7 @@ test "decode_to/UTF16LE-UTF16BE" {
   let buf = Buffer(size_hint=10)
   buf.write_string_utf16le(src)
   let decoder = @encoding.decoder(UTF16BE)
-  let acc = StringBuilder::new()
+  let acc = StringBuilder()
   decoder.decode_to(buf.to_bytes(), acc)
   // NOTE: Happens to be legal UTF16BE
   inspect(acc.to_string(), content="톍敫㳘쏟㡮㳘쫟")
@@ -609,7 +609,7 @@ test "decode_to/UTF16BE-UTF16LE" {
   let buf = Buffer(size_hint=10)
   buf.write_string_utf16be(src)
   let decoder = @encoding.decoder(UTF16LE)
-  let acc = StringBuilder::new()
+  let acc = StringBuilder()
   decoder.decode_to(buf.to_bytes(), acc)
   // NOTE: Happens to be legal UTF16LE
   inspect(acc.to_string(), content="톍敫㳘쏟㡮㳘쫟")
@@ -638,7 +638,7 @@ test "decode_lossy_to/UTF16LE-UTF8" {
   let buf = Buffer(size_hint=10)
   buf.write_string_utf16le(src)
   let decoder = @encoding.decoder(UTF8)
-  let acc = StringBuilder::new()
+  let acc = StringBuilder()
   decoder.decode_lossy_to(buf.to_bytes(), acc)
   inspect(acc.to_string(), content="эek<��n��")
 }
@@ -662,7 +662,7 @@ test "decode_lossy_to/UTF16LE" {
   let src = b"\x00\xD8"
   assert_eq(src, b"\x00\xd8")
   let decoder = @encoding.decoder(UTF16LE)
-  let acc = StringBuilder::new()
+  let acc = StringBuilder()
   decoder.decode_lossy_to(src, acc)
   inspect(acc.to_string(), content="�")
 }
@@ -686,7 +686,7 @@ test "decode_lossy_to/UTF16" {
   let src = b"\x00\xD8"
   assert_eq(src, b"\x00\xd8")
   let decoder = @encoding.decoder(UTF16)
-  let acc = StringBuilder::new()
+  let acc = StringBuilder()
   decoder.decode_lossy_to(src, acc)
   inspect(acc.to_string(), content="�")
 }
@@ -710,7 +710,7 @@ test "decode_lossy_to/UTF16BE" {
   let src = b"\xD8\x00"
   assert_eq(src, b"\xd8\x00")
   let decoder = @encoding.decoder(UTF16BE)
-  let acc = StringBuilder::new()
+  let acc = StringBuilder()
   decoder.decode_lossy_to(src, acc)
   inspect(acc.to_string(), content="�")
 }
@@ -737,7 +737,7 @@ test "decode_lossy_to/UTF16BE_2" {
   let src = b"\xD8\x00\x00\x48"
   assert_eq(src, b"\xd8\x00\x00\x48")
   let decoder = @encoding.decoder(UTF16BE)
-  let acc = StringBuilder::new()
+  let acc = StringBuilder()
   decoder.decode_lossy_to(src, acc)
 
   // NOTE(jinser): should decode as many characters as possible
@@ -766,14 +766,14 @@ test "decode_lossy_to/UTF8" {
   buf.write_bytes(b"\xE0\x9F\x80")
   assert_eq(buf.to_bytes(), b"\xe0\x9f\x80")
   let decoder = @encoding.decoder(UTF8)
-  let acc = StringBuilder::new()
+  let acc = StringBuilder()
   decoder.decode_lossy_to(buf.to_bytes(), acc)
   inspect(acc.to_string(), content="�")
 }
 
 ///|
 test "decode_lossy_to/empty" {
-  let acc = StringBuilder::new()
+  let acc = StringBuilder()
   let decoder = @encoding.decoder(UTF8)
   decoder.decode_lossy_to(b"", acc)
   inspect(acc.to_string(), content="")

--- a/fs/fs_wasm.mbt
+++ b/fs/fs_wasm.mbt
@@ -55,7 +55,7 @@ fn finish_read_string(handle : XStringReadHandle) = "__moonbit_fs_unstable" "fin
 
 ///|
 fn string_from_extern(e : XExternString) -> String {
-  let buf = StringBuilder::new()
+  let buf = StringBuilder()
   let handle = begin_read_string(e)
   while true {
     let ch = string_read_char(handle)

--- a/json5/lex_prop.mbt
+++ b/json5/lex_prop.mbt
@@ -31,7 +31,7 @@ fn lex_property_name(ctx : ParseContext) -> Token raise ParseError {
       let c = Int::unsafe_to_char(c)
       if c is ('$' | '_' | 'a'..='z' | 'A'..='Z' | '0'..='9') ||
         (c > '\u{7f}' && @unicode.non_ascii_id_start.contains(c)) {
-        let buffer = StringBuilder::new()
+        let buffer = StringBuilder()
         buffer.write_char(c)
         let s = lex_ident(ctx, ctx.offset, buffer~)
         String(s)
@@ -57,7 +57,7 @@ fn lex_property_name(ctx : ParseContext) -> Token raise ParseError {
 fn lex_ident(
   ctx : ParseContext,
   start : Int,
-  buffer? : StringBuilder = StringBuilder::new(),
+  buffer? : StringBuilder = StringBuilder(),
 ) -> String raise ParseError {
   let mut start = start
   fn flush(end : Int) {

--- a/json5/lex_string.mbt
+++ b/json5/lex_string.mbt
@@ -14,7 +14,7 @@
 
 ///|
 fn lex_string(ctx : ParseContext, quote : Char) -> String raise ParseError {
-  let buf = StringBuilder::new()
+  let buf = StringBuilder()
   let mut start = ctx.offset
   fn flush(end : Int) {
     if start > 0 && end > start {

--- a/path/win32/path.mbt
+++ b/path/win32/path.mbt
@@ -390,7 +390,7 @@ fn relative_resolved_paths(from_orig : String, to_orig : String) -> Path {
     ..to_parts[common:],
   ]
   guard !components.is_empty() else { "" }
-  let builder = StringBuilder::new()
+  let builder = StringBuilder()
   for i in 0..<components.length() {
     if i > 0 {
       builder.write_char('\\')

--- a/time/duration.mbt
+++ b/time/duration.mbt
@@ -66,7 +66,7 @@ fn Duration::parse_str(str : StringView) -> Duration raise Error {
   let mut minutes = 0L
   let mut seconds = 0L
   let mut nanoseconds = 0L
-  let buf = StringBuilder::new(size_hint=0)
+  let buf = StringBuilder(size_hint=0)
   for i = 2; i < str.length(); i = i + 1 {
     match str.code_unit_at(i) {
       '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '.' | '-' =>
@@ -126,7 +126,7 @@ pub fn Duration::to_string(self : Duration) -> String {
   if self.is_zero() {
     return "PT0S"
   }
-  let buf = StringBuilder::new(size_hint=0)
+  let buf = StringBuilder(size_hint=0)
   buf.write_string("PT")
   let total_secs = self.secs
   let hours = total_secs / seconds_per_hour

--- a/time/period.mbt
+++ b/time/period.mbt
@@ -43,7 +43,7 @@ pub fn Period::from_string(str : String) -> Period raise Error {
   if str.code_unit_at(0) != 'P' {
     fail(invalid_period_err)
   }
-  let buf = StringBuilder::new(size_hint=0)
+  let buf = StringBuilder(size_hint=0)
   let mut years = 0
   let mut months = 0
   let mut days = 0
@@ -76,7 +76,7 @@ pub fn Period::to_string(self : Period) -> String {
   if self.is_zero() {
     return "P0D"
   }
-  let buf = StringBuilder::new(size_hint=0)
+  let buf = StringBuilder(size_hint=0)
   buf.write_char('P')
   if self.years != 0 {
     buf.write_string(self.years.to_string())

--- a/time/plain_date.mbt
+++ b/time/plain_date.mbt
@@ -100,7 +100,7 @@ pub impl @string.FromStr for PlainDate with fn from_str(str) {
 ///|
 /// Returns a string representing the date.
 pub fn PlainDate::to_string(self : PlainDate) -> String {
-  let buf = StringBuilder::new(size_hint=11)
+  let buf = StringBuilder(size_hint=11)
   if self.year < 0 {
     buf.write_char('-')
   }

--- a/time/plain_date_time.mbt
+++ b/time/plain_date_time.mbt
@@ -100,7 +100,7 @@ pub impl @string.FromStr for PlainDateTime with fn from_str(str) {
 ///|
 /// Returns a string representing the datetime.
 pub fn PlainDateTime::to_string(self : PlainDateTime) -> String {
-  let buf = StringBuilder::new(size_hint=18)
+  let buf = StringBuilder(size_hint=18)
   buf.write_string(self.date.to_string())
   buf.write_char('T')
   buf.write_string(self.time.to_string())

--- a/time/plain_time.mbt
+++ b/time/plain_time.mbt
@@ -85,7 +85,7 @@ pub impl @string.FromStr for PlainTime with fn from_str(str) {
 ///|
 /// Returns a string representing the time.
 pub fn PlainTime::to_string(self : PlainTime) -> String {
-  let buf = StringBuilder::new(size_hint=8)
+  let buf = StringBuilder(size_hint=8)
   buf.write_string(add_prefix_zero(self.hour.to_string(), 2))
   buf.write_char(':')
   buf.write_string(add_prefix_zero(self.minute.to_string(), 2))

--- a/time/util.mbt
+++ b/time/util.mbt
@@ -14,7 +14,7 @@
 
 ///|
 fn add_prefix_zero(s : String, len : Int) -> String {
-  let buf = StringBuilder::new(size_hint=len)
+  let buf = StringBuilder(size_hint=len)
   for i = s.length(); i < len; i = i + 1 {
     buf.write_char('0')
   }
@@ -72,7 +72,7 @@ test "remove_suffix_zero && format_nanos" {
 
 ///|
 fn add_suffix_zero(s : StringView, len : Int) -> String {
-  let buf = StringBuilder::new(size_hint=len)
+  let buf = StringBuilder(size_hint=len)
   buf.write_stringview(s)
   for i = s.length(); i < len; i = i + 1 {
     buf.write_char('0')

--- a/time/zone.mbt
+++ b/time/zone.mbt
@@ -137,7 +137,7 @@ fn to_int_be(b : FixedArray[Byte], start : Int) -> Int {
 ///|
 /// Helper function to convert a null-terminated ASCII string to a MoonBit String.
 fn ascii_to_string(b : FixedArray[Byte], start : Int) -> String {
-  let result = StringBuilder::new()
+  let result = StringBuilder()
   let mut start = start
   while b[start] != 0 {
     result.write_char(Int::unsafe_to_char(b[start].to_int()))

--- a/time/zone_offset.mbt
+++ b/time/zone_offset.mbt
@@ -133,7 +133,7 @@ fn create_id(secs : Int) -> String {
     seconds_per_hour.to_int() /
     seconds_per_minute.to_int()
   let offset_secs = abs_secs % seconds_per_minute.to_int()
-  let buf = StringBuilder::new(size_hint=9)
+  let buf = StringBuilder(size_hint=9)
   buf.write_char(if secs < 0 { '-' } else { '+' })
   buf.write_string(add_prefix_zero(offset_hours.to_string(), 2))
   buf.write_char(':')

--- a/time/zoned_date_time.mbt
+++ b/time/zoned_date_time.mbt
@@ -107,7 +107,7 @@ pub fn ZonedDateTime::from_unix_second(
 ///|
 /// Returns a string representing this datetime, like "2008-08-08T20:00:00+8:00[Asia/Beijing]"
 pub fn ZonedDateTime::to_string(self : ZonedDateTime) -> String {
-  let buf = StringBuilder::new(size_hint=0)
+  let buf = StringBuilder(size_hint=0)
   buf.write_string(self.datetime.to_string())
   buf.write_string(self.offset.to_string())
   if self.zone != utc_zone {


### PR DESCRIPTION
Mechanical migration of `StringBuilder::new()` to the constructor syntax `StringBuilder()` across `@codec`, `@crypto`, `@encoding`, `@fs`, `@json5`, `@path`, and `@time`. No behavior change; all 583 tests pass.