### PR TITLE
feat(rational): expose rational components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added `Rational::numerator` and `Rational::denominator` to access rational components.
+- Added `Rational::numerator` and `Rational::denominator` to access rational components. (#314)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `Rational::numerator` and `Rational::denominator` to access rational components.
+
 ### Changed
 
 - Changed `@fs.read_dir` to return `ArrayView[String]`; use `to_owned()` when a mutable array is needed.

--- a/json5/moon.pkg
+++ b/json5/moon.pkg
@@ -1,5 +1,4 @@
 import {
-  "moonbitlang/core/debug",
   "moonbitlang/core/double",
   "moonbitlang/core/string",
   "moonbitlang/x/unicode",
@@ -7,4 +6,5 @@ import {
 
 import {
   "moonbitlang/core/test",
+  "moonbitlang/core/debug",
 } for "test"

--- a/path/posix/moon.pkg
+++ b/path/posix/moon.pkg
@@ -1,6 +1,5 @@
 import {
   "moonbitlang/core/env",
-  "moonbitlang/core/json",
   "moonbitlang/core/cmp",
 }
 

--- a/path/win32/moon.pkg
+++ b/path/win32/moon.pkg
@@ -1,6 +1,5 @@
 import {
   "moonbitlang/core/env",
-  "moonbitlang/core/json",
   "moonbitlang/core/cmp",
   "moonbitlang/x/unicode",
 }

--- a/rational/moon.pkg
+++ b/rational/moon.pkg
@@ -1,5 +1,4 @@
 import {
-  "moonbitlang/core/debug",
   "moonbitlang/core/int",
   "moonbitlang/core/int64",
   "moonbitlang/core/quickcheck",
@@ -11,3 +10,7 @@ import {
   "moonbitlang/core/quickcheck",
   "moonbitlang/core/test",
 } for "test"
+
+import {
+  "moonbitlang/core/debug",
+} for "wbtest"

--- a/rational/pkg.generated.mbti
+++ b/rational/pkg.generated.mbti
@@ -39,6 +39,7 @@ pub fn[T : Integral] Rational::arbitrary(Int, @splitmix.RandomState) -> Self[T]
 pub fn[T : Integral] Rational::ceil(Self[T]) -> T
 #deprecated
 pub fn[T : Integral] Rational::compare(Self[T], Self[T]) -> Int
+pub fn[T] Rational::denominator(Self[T]) -> T
 #deprecated
 pub fn[T : Integral] Rational::div(Self[T], Self[T]) -> Self[T]
 #as_free_fn
@@ -57,6 +58,7 @@ pub fn[T : Integral] Rational::mul(Self[T], Self[T]) -> Self[T]
 pub fn[T : Integral] Rational::neg(Self[T]) -> Self[T]
 #deprecated
 pub fn[T : Eq] Rational::not_equal(Self[T], Self[T]) -> Bool
+pub fn[T] Rational::numerator(Self[T]) -> T
 #deprecated
 pub fn[T : Integral] Rational::op_ge(Self[T], Self[T]) -> Bool
 #deprecated

--- a/rational/rational_test.mbt
+++ b/rational/rational_test.mbt
@@ -24,6 +24,13 @@ test "new" {
 }
 
 ///|
+test "numerator and denominator" {
+  let rational = @rational.new(6L, -9L).unwrap()
+  assert_eq(rational.numerator(), -2L)
+  assert_eq(rational.denominator(), 3L)
+}
+
+///|
 test "addition" {
   let a = @rational.new(1L, 2L).unwrap()
   let b = @rational.new(1L, 3L).unwrap()

--- a/rational/types.mbt
+++ b/rational/types.mbt
@@ -24,6 +24,18 @@ struct Rational[T] {
 } derive(Eq)
 
 ///|
+/// Returns the numerator of this rational number.
+pub fn[T] Rational::numerator(self : Rational[T]) -> T {
+  self.numerator
+}
+
+///|
+/// Returns the denominator of this rational number.
+pub fn[T] Rational::denominator(self : Rational[T]) -> T {
+  self.denominator
+}
+
+///|
 trait Integral: Add + Sub + Mul + Div + Neg + Mod + Show + Eq + Compare + @quickcheck.Arbitrary {
   fn from_int(Int) -> Self
   fn signum(self : Self) -> Int

--- a/time/moon.pkg
+++ b/time/moon.pkg
@@ -6,7 +6,6 @@ import {
 
 import {
   "moonbitlang/core/test",
-  "moonbitlang/core/debug",
 } for "wbtest"
 
 import {


### PR DESCRIPTION
Adds public `Rational::numerator` and `Rational::denominator` methods.

Closes #313.