### PR TITLE
feat(jwt): add typed HS256 encoding and decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `moonbitlang/x/jwt` for signing and verifying HS256 JWTs with explicit
+  algorithm selection, typed claims, expiration checks, and issuer/audience
+  validation. (#318)
+
 ## [0.5.2]
 
 ### Added

--- a/jwt/README.mbt.md
+++ b/jwt/README.mbt.md
@@ -1,0 +1,52 @@
+# JWT
+
+Sign and verify compact JSON Web Tokens with an explicitly selected algorithm.
+The initial implementation supports `HS256` (HMAC-SHA-256).
+
+Claims are fields in the JWT payload, which must be a JSON object. The header
+describes how the token is signed.
+
+```mbt check
+///|
+struct LoginClaims {
+  username : String
+  exp : Double
+} derive(ToJson, @json.FromJson, Eq, Debug)
+
+///|
+test "encode and decode a JWT" {
+  // A deterministic test key. Applications must supply a random secret key.
+  let key = b"0123456789abcdef0123456789abcdef"
+  // env.now() returns milliseconds. JWT timestamps use seconds.
+  let now = @env.now().to_double() / 1000.0
+  let claims : LoginClaims = { username: "alice", exp: now + 3600.0, }
+  let token = @jwt.encode(claims, key~, algorithm=HS256)
+  let decoded : LoginClaims = @jwt.decode(token, key~, algorithm=HS256)
+  assert_eq(decoded, claims)
+}
+```
+
+Custom claims such as `username` can contain any JSON value, including nested
+objects, arrays and `null`. Standard claims have defined meanings and types:
+
+- [`exp`](https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.4): expiration time. The token is rejected at or after this time.
+- [`nbf`](https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.5): not before. The token is rejected before this time.
+- [`iat`](https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.6): issued at. Records when the token was issued. This package checks its type without limiting the token's age.
+- [`iss`](https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.1): issuer. A string identifying who issued the token.
+- [`sub`](https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.2): subject. A string identifying who or what the token is about, such as a user ID.
+- [`jti`](https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.7): JWT ID. A unique string identifying the token. Applications can track it to detect replay.
+- [`aud`](https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.3): audience. Identifies the intended recipients as a string or an array of strings.
+
+When present, `exp`, `nbf` and `iat` must be finite numbers of seconds since the
+Unix epoch. Fractional seconds are allowed.
+
+`encode` requires your type's `ToJson` result to be an object satisfying these
+rules. `decode` validates the complete claims object before converting it to
+your requested type through `FromJson`.
+
+The JWT standard makes `exp` optional. This package requires it by default when
+decoding. Set `require_exp=false` to allow it to be absent. An existing `exp`
+is still checked. To omit `exp` in this example, also remove it from `LoginClaims`.
+
+Applications provide the secret key, then apply their account and authorization
+rules to the verified claims. JWT payloads are encoded, not encrypted.

--- a/jwt/README.md
+++ b/jwt/README.md
@@ -1,0 +1,1 @@
+README.mbt.md

--- a/jwt/claims.mbt
+++ b/jwt/claims.mbt
@@ -1,0 +1,92 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn validate_claim_types(claims : Json) -> Unit raise JwtError {
+  // TODO: improve the moonfmt
+  guard claims
+    is {
+      "exp"? : None
+      | Some(Number(_, ..)),
+      "nbf"? : None
+      | Some(Number(_, ..)),
+      "iat"? : None
+      | Some(Number(_, ..)),
+      "iss"? : None
+      | Some(String(_)),
+      "sub"? : None
+      | Some(String(_)),
+      "jti"? : None
+      | Some(String(_)),
+      "aud"? : None
+      | Some(String(_) | [..]),
+      ..
+    } else {
+    raise InvalidToken(
+      "JWT claims must be an object with valid standard claim types",
+    )
+  }
+  match claims {
+    { "exp": Number(date, ..), .. } if date.is_nan() || date.is_inf() =>
+      raise InvalidToken("JWT claim 'exp' must be finite")
+    { "nbf": Number(date, ..), .. } if date.is_nan() || date.is_inf() =>
+      raise InvalidToken("JWT claim 'nbf' must be finite")
+    { "iat": Number(date, ..), .. } if date.is_nan() || date.is_inf() =>
+      raise InvalidToken("JWT claim 'iat' must be finite")
+    { "aud": [.. audiences], .. } if !audiences.all(value => value is String(_)) =>
+      raise InvalidToken("JWT claim 'aud' must contain only strings")
+    _ => ()
+  }
+}
+
+///|
+fn validate_claims(
+  claims : Json,
+  now : Double,
+  leeway : Int,
+  require_exp : Bool,
+  issuer : String?,
+  audience : String?,
+) -> Unit raise JwtError {
+  validate_claim_types(claims)
+  if require_exp && !(claims is { "exp": _, .. }) {
+    raise InvalidToken("JWT is missing the required 'exp' claim")
+  }
+  if issuer is Some(expected) {
+    guard claims is { "iss": String(actual), .. } && actual == expected else {
+      raise InvalidToken("JWT issuer does not match")
+    }
+  }
+  if audience is Some(expected) {
+    let matches = match claims {
+      { "aud": String(actual), .. } => actual == expected
+      { "aud": [.. audiences], .. } =>
+        audiences.any(value => value is String(actual) && actual == expected)
+      _ => false
+    }
+    if !matches {
+      raise InvalidToken("JWT audience does not match")
+    }
+  } else if claims is { "aud": _, .. } {
+    raise InvalidToken("JWT with an 'aud' claim requires an expected audience")
+  }
+  // Complete the non-time JWT checks before returning a time error.
+  let skew = leeway.to_double()
+  if claims is { "exp": Number(exp, ..), .. } && now - skew >= exp {
+    raise Expired
+  }
+  if claims is { "nbf": Number(nbf, ..), .. } && now + skew < nbf {
+    raise NotYetValid(not_before=nbf)
+  }
+}

--- a/jwt/codec.mbt
+++ b/jwt/codec.mbt
@@ -1,0 +1,56 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn encode_segment(bytes : Bytes) -> String {
+  @base64.encode(bytes, padding=false)
+  .replace_all(old="+", new="-")
+  .replace_all(old="/", new="_")
+}
+
+///|
+fn decode_base64url(segment : StringView) -> Bytes raise JwtError {
+  // decode_at checks the token's alphabet before splitting it into segments.
+  let standard = segment
+    .to_owned()
+    .replace_all(old="-", new="+")
+    .replace_all(old="_", new="/")
+  @base64.decode(standard) catch {
+    _ => raise InvalidToken("JWT segment is not valid Base64URL")
+  }
+}
+
+///|
+fn is_valid_utf16(text : String) -> Bool {
+  // MoonBit strings can contain unpaired UTF-16 surrogates. The native UTF-8
+  // encoder assumes well-formed UTF-16, so reject malformed input first.
+  for units = text.code_units() {
+    match units {
+      [] => break true
+      [0xD800..=0xDBFF, 0xDC00..=0xDFFF, .. rest] => continue rest
+      [0xD800..=0xDFFF, ..] => break false
+      [_, .. rest] => continue rest
+    }
+  }
+}
+
+///|
+fn parse_jwt_json(bytes : Bytes) -> Json raise JwtError {
+  let text = @utf8.decode(bytes, ignore_bom=false) catch {
+    _ => raise InvalidToken("JWT JSON is not valid UTF-8")
+  }
+  @json.parse(text) catch {
+    _ => raise InvalidToken("JWT contains invalid JSON")
+  }
+}

--- a/jwt/jwt.mbt
+++ b/jwt/jwt.mbt
@@ -1,0 +1,228 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Algorithms supported for HMAC-signed JWTs.
+pub(all) enum HmacAlgorithm {
+  HS256
+} derive(Eq, Debug)
+
+///|
+/// Errors from encoding or decoding a JWT.
+///
+/// `InvalidArgument` reports invalid keys, claims to encode, or validation options.
+/// `InvalidToken` reports failed verification or claims conversion.
+///
+/// `Expired` means the token has expired. `NotYetValid` means its `nbf` time
+/// has not been reached, allowing for leeway. `not_before` is that Unix timestamp
+/// in seconds.
+///
+/// Time errors follow signature and other JWT checks, but precede type conversion.
+/// String messages are diagnostics, not stable error codes.
+pub suberror JwtError {
+  InvalidArgument(String)
+  InvalidToken(String)
+  Expired
+  NotYetValid(not_before~ : Double)
+} derive(Debug)
+
+///|
+/// Signs claims as a compact JWT. No claims are added automatically.
+///
+/// * `claims`: must serialize to a JSON object through `ToJson`.
+/// * `key`: a random secret of at least 32 bytes for HS256.
+/// * `algorithm`: the signing algorithm. Currently supports HS256.
+///
+/// Use `Double` (Unix seconds) for `exp`, `nbf`, and `iat` fields:
+/// 64-bit integers serialize as JSON strings.
+/// Invalid keys or claims raise `InvalidArgument`. Tokens are limited to 64 KiB.
+///
+/// ```mbt check
+/// test {
+///   // Example key. Use a random secret in applications.
+///   let key = b"0123456789abcdef0123456789abcdef"
+///   let exp = @env.now().to_double() / 1000.0 + 3600.0
+///   let claims : Json = { "sub": "alice", "exp": exp }
+///   let _token = @jwt.encode(claims, key~, algorithm=HS256)
+/// }
+/// ```
+pub fn[T : ToJson] encode(
+  claims : T,
+  key~ : Bytes,
+  algorithm~ : HmacAlgorithm,
+) -> String raise JwtError {
+  if key.length() < 32 {
+    raise InvalidArgument("HS256 requires a key of at least 32 bytes")
+  }
+  let text = claims.to_json().stringify()
+  if !is_valid_utf16(text) {
+    raise InvalidArgument("JWT claims contain invalid UTF-16")
+  }
+  let payload_bytes = try {
+    // Validate the serialized claims because Json numbers may override their repr.
+    validate_claim_types(@json.parse(text))
+    @utf8.encode(text)
+  } catch {
+    // Claims come from the caller here, rather than an untrusted token.
+    InvalidToken(message) => raise InvalidArgument(message)
+    _ => raise InvalidArgument("JWT claims contain invalid JSON")
+  }
+  let header_text = match algorithm {
+    HS256 => "{\"alg\":\"HS256\",\"typ\":\"JWT\"}"
+  }
+  let header = encode_segment(@utf8.encode(header_text))
+  let payload = encode_segment(payload_bytes)
+  let signing_input = "\{header}.\{payload}"
+  // A HS256 signature occupies 43 Base64URL characters plus one dot.
+  if signing_input.length() > 65536 - 44 {
+    raise InvalidArgument("JWT exceeds the 64 KiB size limit")
+  }
+  let signature = match algorithm {
+    HS256 =>
+      @crypto.hmac(@crypto.SHA256::new(), key, @utf8.encode(signing_input))
+  }
+  "\{signing_input}.\{encode_segment(signature.unsafe_reinterpret_as_bytes())}"
+}
+
+///|
+/// Verifies a compact JWT, then converts its claims using `FromJson`.
+/// Use `Json` as the result type to keep all claims.
+///
+/// * `token`: a compact JWT of at most 64 KiB.
+/// * `key`: the raw verification key. HS256 requires at least 32 bytes.
+/// * `algorithm`: the expected algorithm. Must match the token's `alg`.
+/// * `leeway`: nonnegative clock tolerance in seconds. Defaults to zero.
+/// * `require_exp`: requires `exp` by default. Set to `false` to allow it to be absent.
+///   An existing `exp` is still checked.
+/// * `issuer`: requires an equal `iss` claim when supplied.
+/// * `audience`: must match the `aud` string or one of its array entries.
+///   Required when the token contains `aud`. Supplying it also requires `aud`.
+///
+/// Time checks use the system clock. An existing `nbf` is always checked.
+/// Raises `JwtError` on failure, including `InvalidToken` for type conversion errors.
+///
+/// ```mbt check
+/// test {
+///   // Example key. Use a random secret in applications.
+///   let key = b"0123456789abcdef0123456789abcdef"
+///   let exp = @env.now().to_double() / 1000.0 + 3600.0
+///   let claims : Json = { "sub": "alice", "exp": exp, "aud": "api" }
+///   let token = @jwt.encode(claims, key~, algorithm=HS256)
+///   let decoded : Json = @jwt.decode(token, key~, algorithm=HS256, audience="api")
+///   assert_eq(decoded, claims)
+/// }
+/// ```
+pub fn[T : @json.FromJson] decode(
+  token : String,
+  key~ : Bytes,
+  algorithm~ : HmacAlgorithm,
+  leeway? : Int = 0,
+  require_exp? : Bool = true,
+  issuer? : String,
+  audience? : String,
+) -> T raise JwtError {
+  decode_at(
+    token,
+    key~,
+    algorithm~,
+    now=@env.now().to_double() / 1000.0,
+    leeway~,
+    require_exp~,
+    issuer?,
+    audience?,
+  )
+}
+
+///|
+fn[T : @json.FromJson] decode_at(
+  token : String,
+  key~ : Bytes,
+  algorithm~ : HmacAlgorithm,
+  now~ : Double,
+  leeway? : Int = 0,
+  require_exp? : Bool = true,
+  issuer? : String,
+  audience? : String,
+) -> T raise JwtError {
+  if key.length() < 32 {
+    raise InvalidArgument("HS256 requires a key of at least 32 bytes")
+  }
+  if leeway < 0 {
+    raise InvalidArgument("JWT leeway must be nonnegative")
+  }
+  if token.length() > 65536 {
+    raise InvalidToken("JWT exceeds the 64 KiB size limit")
+  }
+  // Check code units before slicing or UTF-8 encoding, which assume valid
+  // UTF-16. JWT compact serialization is ASCII even when its claims are not.
+  for unit in token.code_units() {
+    guard unit is ('A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' | '.') else {
+      raise InvalidToken("JWT contains invalid characters")
+    }
+  }
+  let parts = token.split(".").to_array()
+  guard parts is [header_segment, payload_segment, signature_segment] else {
+    raise InvalidToken("JWT must contain exactly three segments")
+  }
+  let header = parse_jwt_json(decode_base64url(header_segment))
+  let expected_algorithm = match algorithm {
+    HS256 => "HS256"
+  }
+  guard header is { "alg": String(actual_algorithm), .. } &&
+    actual_algorithm == expected_algorithm else {
+    raise InvalidToken(
+      "JWT header must specify the expected \{expected_algorithm} algorithm",
+    )
+  }
+  match header {
+    { "b64": true, "crit": ["b64"], .. } => ()
+    { "crit": _, .. } =>
+      raise InvalidToken(
+        "JWT header has unsupported or invalid critical extensions",
+      )
+    { "b64": true, .. } => ()
+    { "b64": _, .. } => raise InvalidToken("JWT header 'b64' must be true")
+    _ => ()
+  }
+  if header is { "typ": typ, .. } {
+    guard typ is String(['J' | 'j', 'W' | 'w', 'T' | 't']) else {
+      raise InvalidToken("JWT header typ must be JWT")
+    }
+  }
+
+  let signature = decode_base64url(signature_segment)
+  if signature.length() != 32 {
+    raise InvalidToken("HS256 signature must contain 32 bytes")
+  }
+  let payload_bytes = decode_base64url(payload_segment)
+  // Authenticate exactly the received bytes, including JSON whitespace/order.
+  let signing_input = @utf8.encode("\{header_segment}.\{payload_segment}")
+  let expected = match algorithm {
+    HS256 => @crypto.hmac(@crypto.SHA256::new(), key, signing_input)
+  }
+  // Compare every byte without stopping at the first differing signature byte.
+  // Generated machine code is not guaranteed constant-time on every backend.
+  let mut difference = 0
+  for index, byte in expected {
+    difference = difference | (byte.to_int() ^ signature[index].to_int())
+  }
+  if difference != 0 {
+    raise InvalidToken("JWT signature verification failed")
+  }
+  let claims = parse_jwt_json(payload_bytes)
+  validate_claims(claims, now, leeway, require_exp, issuer, audience)
+  @json.from_json(claims) catch {
+    _ => raise InvalidToken("JWT claims do not match the requested type")
+  }
+}

--- a/jwt/jwt_test.mbt
+++ b/jwt/jwt_test.mbt
@@ -1,0 +1,338 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let integration_key : Bytes = b"0123456789abcdef0123456789abcdef"
+
+///|
+struct TypedClaims {
+  username : String
+  exp : Double
+  iss : String
+  aud : Array[String]
+  roles : Array[String]
+} derive(ToJson, FromJson, Eq, Debug)
+
+///|
+struct OutboundClaims {
+  username : String
+  exp : Double
+} derive(ToJson)
+
+///|
+struct IdentityClaims {
+  username : String
+} derive(FromJson, Eq, Debug)
+
+///|
+struct ConversionProbe {
+  username : String
+} derive(Eq, Debug)
+
+///|
+let conversion_calls : Ref[Int] = Ref(0)
+
+///|
+impl @json.FromJson for ConversionProbe with fn from_json(json, path) {
+  conversion_calls.val += 1
+  if json is { "reject": true, .. } {
+    raise @json.JsonDecodeError(
+      (
+        path.add_key("schema-private-path"),
+        "schema-private-message: caller data must not escape the decoder",
+      ),
+    )
+  }
+  let identity : IdentityClaims = @json.from_json(json, path~)
+  { username: identity.username, }
+}
+
+///|
+test "public decoding uses the current system clock" {
+  let now = @env.now().to_double() / 1000.0
+  let valid_claims : Json = { "username": "alice", "exp": now + 3600.0 }
+  let valid = @jwt.encode(valid_claims, key=integration_key, algorithm=HS256)
+  let decoded : Json = @jwt.decode(valid, key=integration_key, algorithm=HS256)
+  assert_eq(decoded, valid_claims)
+  let expired_claims : Json = { "username": "alice", "exp": now - 3600.0 }
+  let expired = @jwt.encode(
+    expired_claims,
+    key=integration_key,
+    algorithm=HS256,
+  )
+  try
+    (@jwt.decode(expired, key=integration_key, algorithm=HS256) : Json)
+  catch {
+    error => assert_true(error is @jwt.Expired)
+  } noraise {
+    _ => fail("expected the current clock to reject the expired token")
+  }
+}
+
+///|
+test "derived claims encode and decode as the application type" {
+  let now = @env.now().to_double() / 1000.0
+  let claims : TypedClaims = {
+    username: "alice",
+    exp: now + 3600.0,
+    iss: "registry",
+    aud: ["web", "api"],
+    roles: ["maintainer"],
+  }
+  let token = @jwt.encode(claims, key=integration_key, algorithm=HS256)
+  let decoded : TypedClaims = @jwt.decode(
+    token,
+    key=integration_key,
+    algorithm=HS256,
+    issuer="registry",
+    audience="api",
+  )
+  assert_eq(decoded, claims)
+}
+
+///|
+test "encoding only requires ToJson and decoding only requires FromJson" {
+  let now = @env.now().to_double() / 1000.0
+  let claims : OutboundClaims = { username: "alice", exp: now + 3600.0, }
+  let token = @jwt.encode(claims, key=integration_key, algorithm=HS256)
+  let decoded : IdentityClaims = @jwt.decode(
+    token,
+    key=integration_key,
+    algorithm=HS256,
+  )
+  assert_eq(decoded.username, "alice")
+  let raw : Json = @jwt.decode(token, key=integration_key, algorithm=HS256)
+  assert_eq(raw, ({ "username": "alice", "exp": claims.exp } : Json))
+}
+
+///|
+test "partial application claims cannot bypass expiration issuer or audience validation" {
+  let now = @env.now().to_double() / 1000.0
+  let claims : Json = {
+    "username": "alice",
+    "exp": now + 3600.0,
+    "iss": "registry",
+    "aud": "api",
+    "extra": true,
+  }
+  let valid = @jwt.encode(claims, key=integration_key, algorithm=HS256)
+  let identity : IdentityClaims = @jwt.decode(
+    valid,
+    key=integration_key,
+    algorithm=HS256,
+    issuer="registry",
+    audience="api",
+  )
+  assert_eq(identity.username, "alice")
+  let cases : Array[(Json, (@jwt.JwtError) -> Bool)] = [
+    (
+      {
+        "username": "alice",
+        "exp": now - 3600.0,
+        "iss": "registry",
+        "aud": "api",
+      },
+      error => error is @jwt.Expired,
+    ),
+    (
+      { "username": "alice", "iss": "registry", "aud": "api" },
+      error => error is @jwt.InvalidToken(_),
+    ),
+    (
+      { "username": "alice", "exp": now + 3600.0, "iss": "other", "aud": "api" },
+      error => error is @jwt.InvalidToken(_),
+    ),
+    (
+      {
+        "username": "alice",
+        "exp": now + 3600.0,
+        "iss": "registry",
+        "aud": "other",
+      },
+      error => error is @jwt.InvalidToken(_),
+    ),
+  ]
+  for (claims, expected) in cases {
+    let token = @jwt.encode(claims, key=integration_key, algorithm=HS256)
+    try
+      (
+        @jwt.decode(
+          token,
+          key=integration_key,
+          algorithm=HS256,
+          issuer="registry",
+          audience="api",
+        ) : IdentityClaims)
+    catch {
+      error => assert_true(expected(error))
+    } noraise {
+      _ => fail("partial application claims must still satisfy JWT validation")
+    }
+  }
+}
+
+///|
+test "missing and mistyped application fields become invalid-token errors" {
+  let now = @env.now().to_double() / 1000.0
+  let cases : Array[Json] = [
+    { "exp": now + 3600.0 },
+    { "username": 42, "exp": now + 3600.0 },
+  ]
+  for claims in cases {
+    let token = @jwt.encode(claims, key=integration_key, algorithm=HS256)
+    try
+      (@jwt.decode(token, key=integration_key, algorithm=HS256) : IdentityClaims)
+    catch {
+      error =>
+        assert_true(error is @jwt.InvalidToken(message) && !message.is_empty())
+    } noraise {
+      _ => fail("expected the application schema to reject the claims")
+    }
+  }
+}
+
+///|
+test "application conversion runs after JWT validation and its diagnostics stay private" {
+  let now = @env.now().to_double() / 1000.0
+  let not_before = now + 1800.0
+  let claims : Json = {
+    "username": "alice",
+    "exp": now + 3600.0,
+    "iss": "registry",
+    "aud": "api",
+  }
+  let valid = @jwt.encode(claims, key=integration_key, algorithm=HS256)
+  let forged = @jwt.encode(claims, key=Bytes::make(32, b'x'), algorithm=HS256)
+  let rejected : Array[(String, (@jwt.JwtError) -> Bool)] = [
+    ("not-a-jwt", error => error is @jwt.InvalidToken(_)),
+    (forged, error => error is @jwt.InvalidToken(_)),
+  ]
+  let invalid_claims : Array[(Json, (@jwt.JwtError) -> Bool)] = [
+    (
+      { "username": "alice", "iss": "registry", "aud": "api" },
+      error => error is @jwt.InvalidToken(_),
+    ),
+    (
+      { "username": "alice", "exp": now + 3600.0, "iss": "other", "aud": "api" },
+      error => error is @jwt.InvalidToken(_),
+    ),
+    (
+      {
+        "username": "alice",
+        "exp": now + 3600.0,
+        "iss": "registry",
+        "aud": "other",
+      },
+      error => error is @jwt.InvalidToken(_),
+    ),
+    (
+      {
+        "username": "alice",
+        "exp": now - 3600.0,
+        "iss": "registry",
+        "aud": "api",
+      },
+      error => error is @jwt.Expired,
+    ),
+    (
+      {
+        "username": "alice",
+        "exp": now + 3600.0,
+        "nbf": not_before,
+        "iss": "registry",
+        "aud": "api",
+      },
+      error => {
+        error is @jwt.NotYetValid(not_before=actual) && actual == not_before
+      },
+    ),
+  ]
+  for (claims, expected) in invalid_claims {
+    rejected.push(
+      (@jwt.encode(claims, key=integration_key, algorithm=HS256), expected),
+    )
+  }
+  for (token, expected) in rejected {
+    conversion_calls.val = 0
+    try
+      (
+        @jwt.decode(
+          token,
+          key=integration_key,
+          algorithm=HS256,
+          issuer="registry",
+          audience="api",
+        ) : ConversionProbe)
+    catch {
+      error => assert_true(expected(error))
+    } noraise {
+      _ => fail("expected JWT validation to reject the token")
+    }
+    assert_eq(conversion_calls.val, 0)
+  }
+  conversion_calls.val = 0
+  try
+    (@jwt.decode(valid, key=b"short", algorithm=HS256) : ConversionProbe)
+  catch {
+    error => assert_true(error is @jwt.InvalidArgument(_))
+  } noraise {
+    _ => fail("expected the decoder to reject a short key")
+  }
+  assert_eq(conversion_calls.val, 0)
+  let decoded : ConversionProbe = @jwt.decode(
+    valid,
+    key=integration_key,
+    algorithm=HS256,
+    issuer="registry",
+    audience="api",
+  )
+  assert_eq(decoded.username, "alice")
+  assert_eq(conversion_calls.val, 1)
+  let schema_claims : Json = {
+    "username": "alice",
+    "exp": now + 3600.0,
+    "iss": "registry",
+    "aud": "api",
+    "reject": true,
+  }
+  let rejected_by_schema = @jwt.encode(
+    schema_claims,
+    key=integration_key,
+    algorithm=HS256,
+  )
+  conversion_calls.val = 0
+  try
+    (
+      @jwt.decode(
+        rejected_by_schema,
+        key=integration_key,
+        algorithm=HS256,
+        issuer="registry",
+        audience="api",
+      ) : ConversionProbe)
+  catch {
+    error => {
+      guard error is @jwt.InvalidToken(message) else {
+        fail("expected schema failure to become an invalid-token error")
+      }
+      assert_false(message.is_empty())
+      assert_false(message.contains("schema-private-path"))
+      assert_false(message.contains("schema-private-message"))
+      assert_false(message.contains("caller data must not escape the decoder"))
+    }
+  } noraise {
+    _ => fail("expected the custom application decoder to reject the claims")
+  }
+  assert_eq(conversion_calls.val, 1)
+}

--- a/jwt/jwt_wbtest.mbt
+++ b/jwt/jwt_wbtest.mbt
@@ -1,0 +1,813 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+// Fixed test key, used as 32 raw UTF-8 bytes.
+let test_key : Bytes = b"0123456789abcdef0123456789abcdef"
+
+///|
+// Fixtures verified with python-jose 3.4.0, test_key and now=1000.
+// Claims: {"test":"basic","exp":1001}
+const BasicFixture : String = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0ZXN0IjoiYmFzaWMiLCJleHAiOjEwMDF9.2shPeSExv7oZ7gn1Yp5shg1RCf2mwH56ydmf7aSYids"
+
+///|
+// Claims: {"test":"null","value":null,"exp":1001}
+const NullFixture : String = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0ZXN0IjoibnVsbCIsInZhbHVlIjpudWxsLCJleHAiOjEwMDF9.WqhL-u0q3ncCMq6LK9_lkxeLhcgaN5MBpsVCWGt1Aug"
+
+///|
+// Claims: {"test":"unicode","value":"你好🌙","exp":1001}
+const UnicodeFixture : String = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0ZXN0IjoidW5pY29kZSIsInZhbHVlIjoiXHU0ZjYwXHU1OTdkXHVkODNjXHVkZjE5IiwiZXhwIjoxMDAxfQ.xgqKpNLxwxy0RCTej6z27-tTLxy3ja1WYOnBET3Y4Ek"
+
+///|
+// Claims: {"exp":1001,"test":"basic"}, with CRLF and spaces in the JSON.
+const WhitespaceFixture : String = "ew0KICJ0eXAiOiJKV1QiLCAiYWxnIjoiSFMyNTYiDQp9.ew0KICJleHAiOjEwMDEsICJ0ZXN0IjoiYmFzaWMiDQp9.v2ky1Oupx8WXJ-Hme67gM4N7DV1S6U2GUVpCMwCvDIs"
+
+///|
+fn base64url(bytes : Bytes) -> String {
+  @base64.encode(bytes, padding=false)
+  .replace_all(old="+", new="-")
+  .replace_all(old="/", new="_")
+}
+
+///|
+// Sign arbitrary encoded segments so invalid JSON/encoding can be tested with
+// a valid MAC, independently of encode()'s validation and serialization.
+fn signed_segments(header : String, payload : String) -> String {
+  let input = "\{header}.\{payload}"
+  let signature = @crypto.hmac(
+    @crypto.SHA256::new(),
+    test_key,
+    @utf8.encode(input),
+  )
+  "\{input}.\{base64url(Bytes::from_array(signature[:]))}"
+}
+
+///|
+fn raw_token(header : String, payload : String) -> String {
+  signed_segments(
+    base64url(@utf8.encode(header)),
+    base64url(@utf8.encode(payload)),
+  )
+}
+
+///|
+fn expect_decode_error(
+  token : String,
+  expected? : (JwtError) -> Bool,
+  key? : Bytes = test_key,
+  now? : Double = 1000.0,
+  leeway? : Int = 0,
+  require_exp? : Bool = true,
+  issuer? : String,
+  audience? : String,
+) -> Unit raise {
+  try
+    (
+      decode_at(
+        token,
+        key~,
+        algorithm=HS256,
+        now~,
+        leeway~,
+        require_exp~,
+        issuer?,
+        audience?,
+      ) : Json)
+  catch {
+    error =>
+      if expected is Some(check) {
+        assert_true(check(error), msg="unexpected JWT error category")
+      } else {
+        assert_true(error is InvalidToken(message) && !message.is_empty())
+      }
+  } noraise {
+    _ => fail("expected JWT decoding to fail")
+  }
+}
+
+///|
+fn expect_encode_error(claims : Json) -> Unit raise {
+  try encode(claims, key=test_key, algorithm=HS256) catch {
+    error =>
+      assert_true(error is InvalidArgument(message) && !message.is_empty())
+  } noraise {
+    _ => fail("expected JWT encoding to fail")
+  }
+}
+
+///|
+test "Python fixtures preserve custom claims and null values" {
+  json_inspect(
+    (decode_at(BasicFixture, key=test_key, algorithm=HS256, now=1000) : Json),
+    content={ "test": "basic", "exp": 1001 },
+  )
+  json_inspect(
+    (decode_at(NullFixture, key=test_key, algorithm=HS256, now=1000) : Json),
+    content={ "test": "null", "value": null, "exp": 1001 },
+  )
+}
+
+///|
+test "Python JSON escapes and original whitespace are authenticated without reserialization" {
+  json_inspect(
+    (decode_at(UnicodeFixture, key=test_key, algorithm=HS256, now=1000) : Json),
+    content={ "test": "unicode", "value": "你好🌙", "exp": 1001 },
+  )
+  json_inspect(
+    (
+      decode_at(WhitespaceFixture, key=test_key, algorithm=HS256, now=1000) :
+      Json),
+    content={ "exp": 1001, "test": "basic" },
+  )
+}
+
+///|
+test "HS256 encoding reproduces the independently verified Python fixture" {
+  let claims : Json = { "test": "basic", "exp": 1001 }
+  assert_eq(encode(claims, key=test_key, algorithm=HS256), BasicFixture)
+  // Encode does not mutate, insert, or normalize application claims.
+  json_inspect(claims, content={ "test": "basic", "exp": 1001 })
+}
+
+///|
+test "RFC 7515 Appendix A.1 HMAC SHA-256 example decodes" {
+  // Public test vector: https://www.rfc-editor.org/rfc/rfc7515#appendix-A.1
+  let key = @base64.decode(
+    "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ+EstJQLr/T+1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow",
+  )
+  let token = "eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ.dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+  json_inspect(
+    (
+      decode_at(token, key~, algorithm=HS256, now=1300819379, issuer="joe") :
+      Json),
+    content={
+      "iss": "joe",
+      "exp": 1300819380,
+      "http://example.com/is_root": true,
+    },
+  )
+}
+
+///|
+test "raw keys at the minimum length and above the HMAC block size roundtrip" {
+  let claims : Json = { "exp": 1001, "data": [null, true, "🌙"] }
+  for length in [32, 33, 64, 65, 128] {
+    let key = Bytes::make(length, b'\xAB')
+    let token = encode(claims, key~, algorithm=HS256)
+    assert_eq(
+      (decode_at(token, key~, algorithm=HS256, now=1000) : Json),
+      claims,
+    )
+  }
+  for length in [0, 1, 16, 31] {
+    let key = Bytes::make(length, b'a')
+    try encode(claims, key~, algorithm=HS256) catch {
+      error =>
+        assert_true(error is InvalidArgument(message) && !message.is_empty())
+    } noraise {
+      _ => fail("expected a short signing key to be rejected")
+    }
+    expect_decode_error(BasicFixture, key~, expected=error => {
+      error is InvalidArgument(message) && !message.is_empty()
+    })
+  }
+}
+
+///|
+test "a different key and every modified signature byte are rejected" {
+  expect_decode_error(BasicFixture, key=Bytes::make(32, b'x'))
+  guard BasicFixture.split(".").to_array() is [header, payload, signature] else {
+    fail("fixture must have three segments")
+  }
+  let decoded = @base64.decode(
+    signature
+    .to_owned()
+    .replace_all(old="-", new="+")
+    .replace_all(old="_", new="/"),
+  )
+  for index in 0..<32 {
+    let changed = decoded.to_fixedarray()
+    changed[index] = (changed[index].to_int() ^ 1).to_byte()
+    expect_decode_error(
+      "\{header}.\{payload}.\{base64url(Bytes::from_array(changed[:]))}",
+    )
+  }
+  let changed_payload = base64url(b"{\"test\":\"changed\",\"exp\":1001}")
+  expect_decode_error("\{header}.\{changed_payload}.\{signature}")
+}
+
+///|
+test "token algorithm never overrides the caller's HS256 selection" {
+  for algorithm in ["none", "HS384", "HS512", "RS256", "hs256", "unknown"] {
+    let token = raw_token("{\"alg\":\"\{algorithm}\"}", "{\"exp\":1001}")
+    expect_decode_error(token)
+  }
+}
+
+///|
+test "JWT header structure and optional media type are validated" {
+  for header in ["{}", "[]", "null", "{\"alg\":null}", "{\"alg\":256}"] {
+    expect_decode_error(raw_token(header, "{\"exp\":1001}"))
+  }
+  for typ in ["null", "true", "123", "[]", "\"JWS\""] {
+    expect_decode_error(
+      raw_token("{\"alg\":\"HS256\",\"typ\":\{typ}}", "{\"exp\":1001}"),
+    )
+  }
+  for
+    header in [
+      "{\"alg\":\"HS256\"}", "{\"alg\":\"HS256\",\"typ\":\"jwt\"}", "{\"alg\":\"HS256\",\"typ\":\"JwT\",\"kid\":\"unused-test-key\"}",
+    ] {
+    json_inspect(
+      (
+        decode_at(
+          raw_token(header, "{\"exp\":1001}"),
+          key=test_key,
+          algorithm=HS256,
+          now=1000,
+        ) : Json),
+      content={ "exp": 1001 },
+    )
+  }
+}
+
+///|
+test "explicit b64 true uses ordinary payload encoding" {
+  for
+    header in [
+      "{\"alg\":\"HS256\",\"b64\":true}", "{\"alg\":\"HS256\",\"b64\":true,\"crit\":[\"b64\"]}",
+    ] {
+    let token = raw_token(header, "{\"exp\":1001,\"sub\":\"alice\"}")
+    json_inspect(
+      (decode_at(token, key=test_key, algorithm=HS256, now=1000) : Json),
+      content={ "exp": 1001, "sub": "alice" },
+    )
+    expect_decode_error(token, key=b"1123456789abcdef0123456789abcdef")
+  }
+  expect_decode_error(
+    raw_token(
+      "{\"alg\":\"HS256\",\"b64\":true,\"crit\":[\"example\"],\"example\":true}",
+      "{\"exp\":1001}",
+    ),
+  )
+}
+
+///|
+test "unsupported critical extensions and invalid b64 values are rejected" {
+  for
+    (name, value) in [
+      ("crit", "[]"),
+      ("crit", "[\"example\"]"),
+      ("crit", "null"),
+      ("b64", "false"),
+      ("b64", "null"),
+      ("b64", "0"),
+      ("b64", "\"true\""),
+      ("b64", "[]"),
+      ("b64", "{}"),
+    ] {
+    expect_decode_error(
+      raw_token("{\"alg\":\"HS256\",\"\{name}\":\{value}}", "{\"exp\":1001}"),
+    )
+  }
+  for
+    crit in [
+      "[]", "null", "\"b64\"", "[\"b64\",\"b64\"]", "[\"b64\",null]", "[\"b64\",\"example\"]",
+    ] {
+    expect_decode_error(
+      raw_token(
+        "{\"alg\":\"HS256\",\"b64\":true,\"crit\":\{crit}}",
+        "{\"exp\":1001}",
+      ),
+    )
+  }
+  for b64 in ["false", "null", "\"true\""] {
+    expect_decode_error(
+      raw_token(
+        "{\"alg\":\"HS256\",\"b64\":\{b64},\"crit\":[\"b64\"]}",
+        "{\"exp\":1001}",
+      ),
+    )
+  }
+  expect_decode_error(
+    raw_token("{\"alg\":\"HS256\",\"crit\":[\"b64\"]}", "{\"exp\":1001}"),
+  )
+}
+
+///|
+test "compact token requires three nonempty unpadded Base64URL segments" {
+  let header = base64url(b"{\"alg\":\"HS256\"}")
+  let payload = base64url(b"{\"exp\":1001}")
+  for token in ["", ".", "..", "a.b", "a.b.c.d", ".a.b", "a..b", "a.b."] {
+    expect_decode_error(token)
+  }
+  for
+    invalid in ["=", "A", "AA=", "AA==", "AA+", "AA/", "AA ", "AA\n", "AA🌙"] {
+    expect_decode_error(signed_segments(invalid, payload))
+    expect_decode_error(signed_segments(header, invalid))
+  }
+  let valid = raw_token("{\"alg\":\"HS256\"}", "{\"exp\":1001}")
+  guard valid.split(".").to_array() is [_, _, signature] else {
+    fail("test token must have three segments")
+  }
+  for
+    invalid_signature in [
+      "",
+      "A",
+      "\{signature}=",
+      "\{signature} ",
+      "+\{signature}",
+      "/\{signature}",
+    ] {
+    expect_decode_error("\{header}.\{payload}.\{invalid_signature}")
+  }
+}
+
+///|
+test "signature length is checked separately from valid Base64URL syntax" {
+  let header = base64url(b"{\"alg\":\"HS256\"}")
+  let payload = base64url(b"{\"exp\":1001}")
+  for length in [1, 16, 31, 33, 64] {
+    let signature = base64url(Bytes::make(length, b'\x00'))
+    expect_decode_error("\{header}.\{payload}.\{signature}")
+  }
+}
+
+///|
+test "noncanonical Base64URL trailing bits are rejected" {
+  // e30 is {}, while e31 has the same decoded bytes with nonzero unused bits.
+  expect_decode_error(signed_segments("e31", "e30"))
+  let header = base64url(b"{\"alg\":\"HS256\"}")
+  expect_decode_error(signed_segments(header, "e31"))
+  // 32 zero bytes encode to 43 As; changing the last sextet to B changes only
+  // its two unused bits, which must still be rejected before MAC comparison.
+  expect_decode_error("\{header}.e30.\{"A".repeat(42)}B")
+}
+
+///|
+test "authenticated malformed JSON and invalid UTF-8 fail without exposing claims" {
+  let header = base64url(b"{\"alg\":\"HS256\"}")
+  for
+    invalid in [
+      "{", "{\"exp\":}", "{\"exp\":1001} trailing", "{\"x\":\"\\uZZZZ\"}",
+    ] {
+    expect_decode_error(raw_token(invalid, "{\"exp\":1001}"))
+    expect_decode_error(raw_token("{\"alg\":\"HS256\"}", invalid))
+  }
+  for bytes in [b"\xFF", b"\xC0\xAF", b"\xED\xA0\x80", b"\xEF\xBB\xBF{}"] {
+    let invalid = base64url(bytes)
+    expect_decode_error(signed_segments(invalid, "e30"))
+    expect_decode_error(signed_segments(header, invalid))
+  }
+  for payload in ["null", "true", "1", "\"claims\"", "[]"] {
+    expect_decode_error(raw_token("{\"alg\":\"HS256\"}", payload))
+  }
+}
+
+///|
+test "duplicate JSON members consistently use their final value" {
+  let accepted = raw_token(
+    "{\"alg\":\"none\",\"alg\":\"HS256\"}", "{\"exp\":1,\"exp\":1001,\"username\":\"old\",\"username\":\"new\"}",
+  )
+  json_inspect(
+    (decode_at(accepted, key=test_key, algorithm=HS256, now=1000) : Json),
+    content={ "exp": 1001, "username": "new" },
+  )
+  expect_decode_error(
+    raw_token("{\"alg\":\"HS256\",\"alg\":\"none\"}", "{\"exp\":1001}"),
+  )
+  expect_decode_error(
+    raw_token("{\"alg\":\"HS256\"}", "{\"exp\":1001,\"exp\":1}"),
+    expected=error => error is Expired,
+  )
+}
+
+///|
+test "expiration is required by default and checked even when it is optional" {
+  let no_exp = encode(
+    ({ "username": "alice" } : Json),
+    key=test_key,
+    algorithm=HS256,
+  )
+  expect_decode_error(no_exp)
+  json_inspect(
+    (
+      decode_at(
+        no_exp,
+        key=test_key,
+        algorithm=HS256,
+        now=1000,
+        require_exp=false,
+      ) : Json),
+    content={ "username": "alice" },
+  )
+  let expired = encode(({ "exp": 999 } : Json), key=test_key, algorithm=HS256)
+  expect_decode_error(expired, require_exp=false, expected=error => {
+    error is Expired
+  })
+  expect_decode_error(
+    raw_token("{\"alg\":\"HS256\"}", "{\"exp\":null}"),
+    require_exp=false,
+  )
+}
+
+///|
+test "expiration boundary and fractional NumericDates retain precision" {
+  for expiration in [999.5, 1000.0] {
+    let token = encode(
+      ({ "exp": expiration } : Json),
+      key=test_key,
+      algorithm=HS256,
+    )
+    expect_decode_error(token, expected=error => error is Expired)
+  }
+  for expiration in [1000.25, 1001.0] {
+    let claims : Json = { "exp": expiration }
+    let token = encode(claims, key=test_key, algorithm=HS256)
+    assert_eq(
+      (decode_at(token, key=test_key, algorithm=HS256, now=1000) : Json),
+      claims,
+    )
+  }
+  let token = encode(({ "exp": 1000 } : Json), key=test_key, algorithm=HS256)
+  assert_eq(
+    (decode_at(token, key=test_key, algorithm=HS256, now=1000, leeway=1) : Json),
+    Json::object({ "exp": Json::number(1000) }),
+  )
+  expect_decode_error(token, now=1001, leeway=1, expected=error => {
+    error is Expired
+  })
+}
+
+///|
+test "not-before boundary allows equality and applies positive clock tolerance" {
+  for nbf in [999.5, 1000.0] {
+    let claims : Json = { "exp": 1010, "nbf": nbf }
+    let token = encode(claims, key=test_key, algorithm=HS256)
+    assert_eq(
+      (decode_at(token, key=test_key, algorithm=HS256, now=1000) : Json),
+      claims,
+    )
+  }
+  for nbf in [1000.25, 1001.0] {
+    let claims : Json = { "exp": 1010, "nbf": nbf }
+    let token = encode(claims, key=test_key, algorithm=HS256)
+    expect_decode_error(token, expected=error => {
+      error is NotYetValid(not_before=actual) && actual == nbf
+    })
+    assert_eq(
+      (
+        decode_at(token, key=test_key, algorithm=HS256, now=1000, leeway=1) :
+        Json),
+      claims,
+    )
+  }
+  let future_iat : Json = { "exp": 1010, "iat": 2000.5 }
+  let token = encode(future_iat, key=test_key, algorithm=HS256)
+  assert_eq(
+    (decode_at(token, key=test_key, algorithm=HS256, now=1000) : Json),
+    future_iat,
+  )
+}
+
+///|
+test "fractional current time observes expiration without truncating to whole seconds" {
+  let claims : Json = { "exp": 1000.5 }
+  let token = encode(claims, key=test_key, algorithm=HS256)
+  assert_eq(
+    (decode_at(token, key=test_key, algorithm=HS256, now=1000.499) : Json),
+    claims,
+  )
+  for now in [1000.5, 1000.75] {
+    expect_decode_error(token, now~, expected=error => error is Expired)
+  }
+  assert_eq(
+    (
+      decode_at(token, key=test_key, algorithm=HS256, now=1001.499, leeway=1) :
+      Json),
+    claims,
+  )
+  for now in [1001.5, 1001.75] {
+    expect_decode_error(token, now~, leeway=1, expected=error => {
+      error is Expired
+    })
+  }
+}
+
+///|
+test "fractional current time and leeway preserve the original not-before date" {
+  let claims : Json = { "exp": 1010, "nbf": 1000.5 }
+  let token = encode(claims, key=test_key, algorithm=HS256)
+  expect_decode_error(token, now=1000.25, expected=error => {
+    error is NotYetValid(not_before=actual) && actual == 1000.5
+  })
+  assert_eq(
+    (decode_at(token, key=test_key, algorithm=HS256, now=1000.5) : Json),
+    claims,
+  )
+  expect_decode_error(token, now=999.25, leeway=1, expected=error => {
+    error is NotYetValid(not_before=actual) && actual == 1000.5
+  })
+  assert_eq(
+    (decode_at(token, key=test_key, algorithm=HS256, now=999.5, leeway=1) : Json),
+    claims,
+  )
+}
+
+///|
+test "fractional negative Unix times retain expiration and not-before ordering" {
+  let claims : Json = { "exp": -0.25, "nbf": -1.5 }
+  let token = encode(claims, key=test_key, algorithm=HS256)
+  for now in [-1.5, -1.0, -0.5] {
+    assert_eq(
+      (decode_at(token, key=test_key, algorithm=HS256, now~) : Json),
+      claims,
+    )
+  }
+  expect_decode_error(token, now=-0.25, expected=error => error is Expired)
+  expect_decode_error(token, now=-1.75, expected=error => {
+    error is NotYetValid(not_before=actual) && actual == -1.5
+  })
+}
+
+///|
+test "NumericDates reject coercions and nonfinite values on encode and decode" {
+  for name in ["exp", "nbf", "iat"] {
+    for
+      invalid in [
+        "null", "true", "false", "\"1001\"", "[]", "{}", "1e999", "-1e999",
+      ] {
+      let payload = "{\"exp\":1001,\"\{name}\":\{invalid}}"
+      expect_encode_error(@json.parse(payload))
+      expect_decode_error(raw_token("{\"alg\":\"HS256\"}", payload))
+    }
+    for number in [@double.infinity, @double.neg_infinity, @double.not_a_number] {
+      let values : Map[String, Json] = { "exp": Json::number(1001) }
+      values[name] = Json::number(number)
+      expect_encode_error(Json::object(values))
+    }
+  }
+}
+
+///|
+test "finite NumericDates can exceed the exact integer range" {
+  for date in [9007199254740992.0, 1.0e200] {
+    let claims : Json = { "exp": date, "nbf": -date, "iat": date }
+    let token = encode(claims, key=test_key, algorithm=HS256)
+    let decoded : Json = decode_at(
+      token,
+      key=test_key,
+      algorithm=HS256,
+      now=1000,
+    )
+    assert_eq(decoded, claims)
+    let expired = encode(
+      ({ "exp": -date } : Json),
+      key=test_key,
+      algorithm=HS256,
+    )
+    expect_decode_error(expired, expected=error => error is Expired)
+    let future = encode(
+      ({ "exp": date, "nbf": date } : Json),
+      key=test_key,
+      algorithm=HS256,
+    )
+    expect_decode_error(future, expected=error => {
+      error is NotYetValid(not_before=actual) && actual == date
+    })
+  }
+}
+
+///|
+test "invalid verifier arguments take precedence over malformed credentials" {
+  for token in ["", "not-a-jwt", "e30.e30.AA"] {
+    expect_decode_error(token, key=b"short", expected=error => {
+      error is InvalidArgument(message) && !message.is_empty()
+    })
+    expect_decode_error(token, leeway=-1, expected=error => {
+      error is InvalidArgument(message) && !message.is_empty()
+    })
+  }
+}
+
+///|
+test "forged signatures never produce recoverable expiration or not-before errors" {
+  for
+    claims in [
+      Json::object({ "exp": Json::number(999) }),
+      Json::object({ "exp": Json::number(1010), "nbf": Json::number(1001) }),
+      Json::object({ "exp": Json::number(999), "nbf": Json::number(1001) }),
+    ] {
+    let token = encode(claims, key=Bytes::make(32, b'x'), algorithm=HS256)
+    expect_decode_error(token)
+  }
+}
+
+///|
+test "issuer and audience mismatches take precedence over recoverable time errors" {
+  for (expiration, not_before) in [(999.0, 0.0), (1010.0, 1001.25)] {
+    let wrong_issuer = encode(
+      ({ "exp": expiration, "nbf": not_before, "iss": "unexpected" } : Json),
+      key=test_key,
+      algorithm=HS256,
+    )
+    expect_decode_error(wrong_issuer, issuer="expected")
+    let wrong_audience = encode(
+      ({ "exp": expiration, "nbf": not_before, "aud": "unexpected" } : Json),
+      key=test_key,
+      algorithm=HS256,
+    )
+    expect_decode_error(wrong_audience, audience="expected")
+    // An unconfigured verifier cannot accept an audience-specific token,
+    // even when retrying later or renewing the token would address its dates.
+    expect_decode_error(wrong_audience)
+  }
+}
+
+///|
+test "issuer and audience policy requires configured claims and exact matches" {
+  let absent = encode(({ "exp": 1001 } : Json), key=test_key, algorithm=HS256)
+  expect_decode_error(absent, issuer="issuer")
+  expect_decode_error(absent, audience="api")
+  let issued = encode(
+    ({ "exp": 1001, "iss": "Issuer" } : Json),
+    key=test_key,
+    algorithm=HS256,
+  )
+  ignore((decode_at(issued, key=test_key, algorithm=HS256, now=1000) : Json))
+  ignore(
+    (
+      decode_at(
+        issued,
+        key=test_key,
+        algorithm=HS256,
+        now=1000,
+        issuer="Issuer",
+      ) : Json),
+  )
+  expect_decode_error(issued, issuer="issuer")
+  for
+    audiences in [
+      Json::string("api"),
+      Json::array([Json::string("web"), Json::string("api")]),
+    ] {
+    let claims : Json = { "exp": 1001, "aud": audiences }
+    let token = encode(claims, key=test_key, algorithm=HS256)
+    assert_eq(
+      (
+        decode_at(
+          token,
+          key=test_key,
+          algorithm=HS256,
+          now=1000,
+          audience="api",
+        ) : Json),
+      claims,
+    )
+    expect_decode_error(token)
+    expect_decode_error(token, audience="API")
+  }
+  let empty_aud = encode(
+    ({ "exp": 1001, "aud": [] } : Json),
+    key=test_key,
+    algorithm=HS256,
+  )
+  expect_decode_error(empty_aud, audience="api")
+}
+
+///|
+test "reserved textual claims and audience arrays reject incorrect types" {
+  for name in ["iss", "sub", "jti"] {
+    for invalid in ["null", "123", "false", "[]", "{}"] {
+      let payload = "{\"exp\":1001,\"\{name}\":\{invalid}}"
+      expect_encode_error(@json.parse(payload))
+      expect_decode_error(raw_token("{\"alg\":\"HS256\"}", payload))
+    }
+  }
+  for invalid in ["null", "123", "true", "{}", "[\"api\",null]", "[1]"] {
+    let payload = "{\"exp\":1001,\"aud\":\{invalid}}"
+    expect_encode_error(@json.parse(payload))
+    expect_decode_error(
+      raw_token("{\"alg\":\"HS256\"}", payload),
+      audience="api",
+    )
+  }
+  for
+    invalid in [
+      Json::null(),
+      Json::number(1),
+      Json::array([]),
+      Json::string("claims"),
+    ] {
+    expect_encode_error(invalid)
+  }
+}
+
+///|
+test "unrelated application claims are returned without imposing account rules" {
+  let claims : Json = {
+    "exp": 1001,
+    "username": null,
+    "roles": ["maintainer"],
+    "metadata": { "nested": [true, null, 42] },
+    "at_hash": "application-defined",
+  }
+  let token = encode(claims, key=test_key, algorithm=HS256)
+  assert_eq(
+    (decode_at(token, key=test_key, algorithm=HS256, now=1000) : Json),
+    claims,
+  )
+}
+
+///|
+test "compact token length limit includes header payload separators and signature" {
+  // With this fixed 20-character header, 49,103 payload bytes encode to 65,471
+  // characters, making the entire token exactly 65,536 ASCII bytes.
+  let header = base64url(b"{\"alg\":\"HS256\"}")
+  let prefix = "{\"exp\":1001,\"data\":\""
+  let suffix = "\"}"
+  let payload = prefix +
+    "a".repeat(49103 - prefix.length() - suffix.length()) +
+    suffix
+  let token = signed_segments(header, base64url(@utf8.encode(payload)))
+  assert_eq(token.length(), 65536)
+  ignore((decode_at(token, key=test_key, algorithm=HS256, now=1000) : Json))
+  expect_decode_error(token + "A")
+  let oversized : Json = { "exp": 1001, "data": "a".repeat(50000) }
+  expect_encode_error(oversized)
+}
+
+///|
+test "JSON nesting limit applies to signed headers claims and encoding input" {
+  let allowed_payload = "{\"exp\":1001,\"data\":" +
+    "[".repeat(64) +
+    "0" +
+    "]".repeat(64) +
+    "}"
+  let allowed = raw_token("{\"alg\":\"HS256\"}", allowed_payload)
+  ignore((decode_at(allowed, key=test_key, algorithm=HS256, now=1000) : Json))
+  let deep_payload = "{\"exp\":1001,\"data\":" +
+    "[".repeat(1024) +
+    "0" +
+    "]".repeat(1024) +
+    "}"
+  expect_decode_error(raw_token("{\"alg\":\"HS256\"}", deep_payload))
+  let deep_header = "{\"alg\":\"HS256\",\"data\":" +
+    "[".repeat(1024) +
+    "0" +
+    "]".repeat(1024) +
+    "}"
+  expect_decode_error(raw_token(deep_header, "{\"exp\":1001}"))
+  let mut nested = Json::number(0)
+  for _ in 0..<1024 {
+    nested = Json::array([nested])
+  }
+  expect_encode_error({ "exp": 1001, "data": nested })
+}
+
+///|
+test "unpaired UTF-16 code units return errors instead of reaching native UTF-8 encoding" {
+  let malformed = [
+    String::from_array([(0xD800).unsafe_to_char()]),
+    String::from_array([(0xDC00).unsafe_to_char()]),
+    String::from_array([(0xD800).unsafe_to_char(), 'A']),
+    String::from_array(['A', (0xDC00).unsafe_to_char()]),
+  ]
+  for value in malformed {
+    for
+      token in [
+        value,
+        value + ".e30.AA",
+        "e30." + value + ".AA",
+        "e30.e30." + value,
+      ] {
+      expect_decode_error(token)
+    }
+    expect_encode_error({ "exp": 1001, "data": value })
+  }
+}
+
+///|
+test "encode validates the serialized NumericDate representation" {
+  for repr in ["null", "true", "\"1001\"", "1e999"] {
+    let claims : Json = { "exp": Json::number(1001.0, repr~) }
+    expect_encode_error(claims)
+  }
+  let claims : Json = { "exp": Json::number(1001.0, repr="invalid-json") }
+  expect_encode_error(claims)
+  let claims : Json = { "exp": Json::number(@double.infinity, repr="1001") }
+  let token = encode(claims, key=test_key, algorithm=HS256)
+  let decoded : Json = decode_at(token, key=test_key, algorithm=HS256, now=1000)
+  json_inspect(decoded, content={ "exp": 1001 })
+}

--- a/jwt/moon.pkg
+++ b/jwt/moon.pkg
@@ -1,0 +1,16 @@
+import {
+  "moonbitlang/core/env",
+  "moonbitlang/core/encoding/base64",
+  "moonbitlang/core/encoding/utf8",
+  "moonbitlang/core/json",
+  "moonbitlang/x/crypto",
+}
+
+import {
+  "moonbitlang/core/env",
+  "moonbitlang/core/json",
+} for "test"
+
+import {
+  "moonbitlang/core/double",
+} for "wbtest"

--- a/jwt/pkg.generated.mbti
+++ b/jwt/pkg.generated.mbti
@@ -1,0 +1,29 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbitlang/x/jwt"
+
+import {
+  "moonbitlang/core/debug",
+  "moonbitlang/core/json",
+}
+
+// Values
+pub fn[T : @json.FromJson] decode(String, key~ : Bytes, algorithm~ : HmacAlgorithm, leeway? : Int, require_exp? : Bool, issuer? : String, audience? : String) -> T raise JwtError
+
+pub fn[T : ToJson] encode(T, key~ : Bytes, algorithm~ : HmacAlgorithm) -> String raise JwtError
+
+// Errors
+pub suberror JwtError {
+  InvalidArgument(String)
+  InvalidToken(String)
+  Expired
+  NotYetValid(not_before~ : Double)
+} derive(@debug.Debug)
+
+// Types and methods
+pub(all) enum HmacAlgorithm {
+  HS256
+} derive(Eq, @debug.Debug)
+
+// Type aliases
+
+// Traits

--- a/moon.mod
+++ b/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbitlang/x"
 
-version = "0.5.3"
+version = "0.5.4"
 
 readme = "README.md"
 


### PR DESCRIPTION
Add `moonbitlang/x/jwt` so applications can sign and verify HS256 JWTs with typed claims. `encode[T : ToJson]` and `decode[T : FromJson]` require an explicit algorithm and a raw secret key of at least 32 bytes. Bump the module version to `0.5.4`.

Decoding verifies the signature and standard claims before converting to the requested type. It checks expiration by default, supports clock tolerance and expected issuer/audience, and distinguishes expired or not-yet-valid tokens from invalid input. The README explains payload shape and standard claims with a working example.

Validation:
- `moon check --deny-warn` and `moon check --target native --deny-warn`
- `moon test jwt --target all --serial` and the same command with `--release`, each passing 42 tests on wasm, wasm-gc, JS and native
- Fixed Python interoperability snapshots and the RFC 7515 HS256 vector, plus malformed tokens, signature changes, claim validation and conversion ordering
- `moon info`, `moon fmt` and `git diff --check`
