### PR TITLE
feat(encoding): add percent encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Added `moonbitlang/x/encoding/percent` for percent encoding and
+  decoding with customizable ASCII escape characters. (#319)
+
 - Added `moonbitlang/x/jwt` for signing and verifying HS256 JWTs with explicit
   algorithm selection, typed claims, expiration checks, and issuer/audience
   validation. (#318)

--- a/encoding/percent/README.mbt.md
+++ b/encoding/percent/README.mbt.md
@@ -1,0 +1,14 @@
+# Percent encoding
+
+Percent encoding of text. By default, only ASCII letters and digits are left
+unescaped. Pass `escape_chars` to choose a different set.
+
+```mbt check
+///|
+test {
+  let encoded = @percent.encode("hello 世界+")
+  inspect(encoded, content="hello%20%E4%B8%96%E7%95%8C%2B")
+  let decoded = @utf8.decode(@percent.decode(encoded))
+  inspect(decoded, content="hello 世界+")
+}
+```

--- a/encoding/percent/moon.pkg
+++ b/encoding/percent/moon.pkg
@@ -1,0 +1,4 @@
+import {
+  "moonbitlang/core/buffer",
+  "moonbitlang/core/encoding/utf8",
+}

--- a/encoding/percent/percent.mbt
+++ b/encoding/percent/percent.mbt
@@ -1,0 +1,109 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Percent-encodes the UTF-8 bytes of input as uppercase %HH escapes. Non-ASCII
+/// bytes and the ASCII characters in escape_chars are escaped. By default, only
+/// ASCII letters and digits are unescaped.
+/// Include '%' in a custom escape_chars value to escape literal percent signs.
+/// Duplicate and non-ASCII characters in escape_chars are ignored.
+pub fn encode(
+  input : StringView,
+  escape_chars? : StringView = non_alphanumeric,
+) -> String {
+  let mut lower = 0UL
+  let mut upper = 0UL
+  for char in escape_chars {
+    let value = char.to_int()
+    if value < 64 {
+      lower = lower | (1UL << value)
+    } else if value < 128 {
+      upper = upper | (1UL << (value - 64))
+    }
+  }
+  let output = StringBuilder(size_hint=input.length())
+  let hex = b"0123456789ABCDEF"
+  for byte in @utf8.encode(input) {
+    let value = byte.to_int()
+    let selected = if value < 64 {
+      (lower & (1UL << value)) != 0
+    } else if value < 128 {
+      (upper & (1UL << (value - 64))) != 0
+    } else {
+      true
+    }
+    if selected {
+      output.write_char('%')
+      output.write_char(hex[value >> 4].to_int().unsafe_to_char())
+      output.write_char(hex[value & 15].to_int().unsafe_to_char())
+    } else {
+      output.write_char(value.unsafe_to_char())
+    }
+  }
+  output.to_string()
+}
+
+///|
+/// Decodes %HH escapes once, preserving malformed escapes and literal '+'.
+/// Unescaped text is encoded as UTF-8. The result is arbitrary bytes; UTF-8
+/// decoding is a separate operation.
+pub fn decode(input : StringView) -> Bytes {
+  let input = @utf8.encode(input)
+  let output = @buffer.Buffer(size_hint=input.length())
+  for i = 0; i < input.length(); {
+    let byte = input[i]
+    if byte == b'%' && input.length() - i >= 3 {
+      let hi = hex_value(input[i + 1])
+      let lo = hex_value(input[i + 2])
+      if hi >= 0 && lo >= 0 {
+        output.write_byte(((hi << 4) | lo).to_byte())
+        continue i + 3
+      }
+    }
+    output.write_byte(byte)
+    continue i + 1
+  }
+  output.to_bytes()
+}
+
+///|
+fn hex_value(byte : Byte) -> Int {
+  match byte {
+    b'0'..=b'9' => byte.to_int() - b'0'.to_int()
+    b'A'..=b'F' => byte.to_int() - b'A'.to_int() + 10
+    b'a'..=b'f' => byte.to_int() - b'a'.to_int() + 10
+    _ => -1
+  }
+}
+
+///|
+/// ASCII control characters: U+0000 through U+001F, and U+007F.
+pub let controls : String = String::from_array(
+    [
+      for value in 0..<32 => value.unsafe_to_char()
+    ],
+  ) +
+  "\u007F"
+
+///|
+/// All ASCII characters except letters and digits.
+pub let non_alphanumeric : String = {
+  let chars = StringBuilder()
+  for value in 0..<128 {
+    if !(value is ('A'..='Z' | 'a'..='z' | '0'..='9')) {
+      chars.write_char(value.unsafe_to_char())
+    }
+  }
+  chars.to_string()
+}

--- a/encoding/percent/percent_test.mbt
+++ b/encoding/percent/percent_test.mbt
@@ -1,0 +1,109 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "encoding uses the selected ASCII characters" {
+  inspect(
+    @percent.encode("hello world /?+%~"),
+    content="hello%20world%20%2F%3F%2B%25%7E",
+  )
+  let fragment = @percent.controls + " \"<>`"
+  inspect(
+    @percent.encode("hello world/?+%", escape_chars=fragment),
+    content="hello%20world/?+%",
+  )
+  inspect(
+    @percent.encode(
+      "\u0000\u001F \u007F\u0080ÿ",
+      escape_chars=@percent.controls,
+    ),
+    content="%00%1F %7F%C2%80%C3%BF",
+  )
+}
+
+///|
+test "escape characters cover word boundaries and ignore non-ASCII characters" {
+  let boundaries = "\u0000?@\u007F\u0080ÿ"
+  let chars = "\u0000?@\u007F\u0080ÿ工具🙂??"
+  inspect(
+    @percent.encode(boundaries, escape_chars=chars),
+    content="%00%3F%40%7F%C2%80%C3%BF",
+  )
+  assert_eq(
+    @percent.encode(boundaries, escape_chars=""),
+    "\u0000?@\u007F%C2%80%C3%BF",
+  )
+  inspect(
+    @percent.encode("AZaz09-._~ /", escape_chars=" /"),
+    content="AZaz09-._~%20%2F",
+  )
+}
+
+///|
+test "decoding preserves malformed escapes and decodes only once" {
+  assert_eq(@percent.decode("a%2fb%2Fc%20+%2B%25"), b"a/b/c ++%")
+  assert_eq(@percent.decode("%2541%+1%-1%GG%2%"), b"%41%+1%-1%GG%2%")
+  assert_eq(@percent.decode("%%41%4%42%"), b"%A%4B%")
+  assert_eq(@percent.decode(""), b"")
+  assert_eq(@percent.encode(""), "")
+}
+
+///|
+test "UTF-8 text and escaped binary data are preserved" {
+  let text = "工具🙂"
+  let encoded = @percent.encode(text)
+  inspect(encoded, content="%E5%B7%A5%E5%85%B7%F0%9F%99%82")
+  assert_eq(@utf8.decode(@percent.decode(encoded)), text)
+  assert_eq(@percent.decode("工具%F0%9F%99%82"), @utf8.encode(text))
+  let raw = "%FF%C0%AF%ED%A0%80%00"
+  assert_eq(@percent.decode(raw), b"\xFF\xC0\xAF\xED\xA0\x80\x00")
+}
+
+///|
+test "decoding covers all bytes and encoding honors every ASCII member" {
+  let mut value = 0
+  for hi in "0123456789ABCDEF" {
+    for lo in "0123456789abcdef" {
+      assert_eq(
+        @percent.decode("%\{hi}\{lo}"),
+        Bytes::from_array([value.to_byte()]),
+      )
+      value += 1
+    }
+  }
+  for value in 0..<128 {
+    let input = value.unsafe_to_char().to_string()
+    let encoded = @percent.encode(input, escape_chars=input)
+    assert_eq(encoded.length(), 3)
+    assert_eq(@percent.decode(encoded), @utf8.encode(input))
+    assert_eq(@percent.encode(input, escape_chars="").length(), 1)
+    let expected_length = if value is ('A'..='Z' | 'a'..='z' | '0'..='9') {
+      1
+    } else {
+      3
+    }
+    assert_eq(@percent.encode(input).length(), expected_length)
+  }
+}
+
+///|
+test "views do not decode or encode outside their bounds" {
+  let input = "xx%41%42yy"
+  assert_eq(@percent.decode(input[2:8]), b"AB")
+  assert_eq(@percent.decode(input[2:4]), b"%4")
+  assert_eq(@percent.encode(input[2:8]), "%2541%2542")
+  let unicode = "x工具🙂y"
+  assert_eq(@percent.decode(unicode[1:5]), @utf8.encode("工具🙂"))
+  assert_eq(@percent.encode(unicode[1:5]), "%E5%B7%A5%E5%85%B7%F0%9F%99%82")
+}

--- a/encoding/percent/pkg.generated.mbti
+++ b/encoding/percent/pkg.generated.mbti
@@ -1,0 +1,19 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbitlang/x/encoding/percent"
+
+// Values
+pub let controls : String
+
+pub fn decode(StringView) -> Bytes
+
+pub fn encode(StringView, escape_chars? : StringView) -> String
+
+pub let non_alphanumeric : String
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits

--- a/moon.mod
+++ b/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbitlang/x"
 
-version = "0.5.4"
+version = "0.5.5"
 
 readme = "README.md"
 


### PR DESCRIPTION
Add `encoding/percent` with `StringView` inputs and an optional string of ASCII characters to escape. Encoding defaults to escaping non-alphanumeric characters; decoding returns bytes and preserves malformed escapes and literal `+`. Includes one executable README example.

Validation: all 7 percent tests pass on wasm, wasm-gc, JS, and native in debug and release. `moon check encoding/percent --deny-warn`, `moon info`, `moon fmt`, `typos`, and `hawkeye check` pass.
